### PR TITLE
G4 CI fix: software-rendering fallback on GPU-less boxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq libwebkitgtk-6.0-dev libgtk-4-dev cage
 
+      - name: Allow unprivileged user namespaces
+        # Ubuntu 24.04 runners restrict userns via AppArmor, which breaks
+        # WebKit's bubblewrap sandbox (bwrap: loopback: Failed RTM_NEWADDR).
+        run: sudo sysctl -q -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2

--- a/crates/hwatud/src/compositor.rs
+++ b/crates/hwatud/src/compositor.rs
@@ -135,6 +135,7 @@ pub fn ensure_display() -> Result<Option<Compositor>, String> {
     match detect_mode() {
         DisplayMode::Session => Ok(None),
         DisplayMode::DisplayFree => {
+            export_software_rendering_fallback();
             let comp = Compositor::spawn()?;
             std::env::set_var("WAYLAND_DISPLAY", &comp.socket);
             std::env::set_var("GDK_BACKEND", "wayland");
@@ -148,6 +149,52 @@ pub fn ensure_display() -> Result<Option<Compositor>, String> {
             Ok(Some(comp))
         }
     }
+}
+
+/// GPU-less boxes (CI runners, minimal VMs) are the main audience of
+/// display-free mode, and WebKitGTK's default DMA-BUF renderer aborts
+/// there (`g_error` -> SIGTRAP) because buffer sharing needs a DRM
+/// render node. When no usable node exists, fall back to software
+/// rendering before GTK/WebKit initialize (web processes inherit the
+/// env). Explicit user env always wins; boxes WITH a GPU are
+/// untouched.
+fn export_software_rendering_fallback() {
+    if has_drm_render_node() {
+        return;
+    }
+    for (key, value) in [
+        // WebKit: render in shared memory instead of DMA-BUF.
+        ("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
+        // Mesa: llvmpipe instead of probing for hardware.
+        ("LIBGL_ALWAYS_SOFTWARE", "1"),
+        // wlroots: pure-CPU pixman compositing. GLES-on-llvmpipe is
+        // the alternative and has aborted cage on GPU-less CI; pixman
+        // (wlroots >= 0.15, everything packaged today) is the honest
+        // renderer for a display nothing is shown on. Inherited by
+        // the child compositor via spawn_candidate.
+        ("WLR_RENDERER", "pixman"),
+    ] {
+        if std::env::var_os(key).is_none() {
+            std::env::set_var(key, value);
+        }
+    }
+    println!("hwatud: no DRM render node; falling back to software rendering");
+}
+
+/// Is there an openable DRM render node? Openable matters: the node
+/// can exist while the daemon's user lacks the `render` group.
+fn has_drm_render_node() -> bool {
+    let Ok(entries) = std::fs::read_dir("/dev/dri") else {
+        return false;
+    };
+    entries.flatten().any(|e| {
+        e.file_name().to_string_lossy().starts_with("renderD")
+            && std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(e.path())
+                .is_ok()
+    })
 }
 
 /// A supervised child compositor. Dropping it terminates the child

--- a/scripts/dev/no-gpu.sh
+++ b/scripts/dev/no-gpu.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Local repro of a GPU-less CI runner: run a command inside a bubblewrap
+# sandbox where /dev/dri is masked with an empty tmpfs, so no DRM render
+# node is visible. Everything else binds through read-write.
+# Usage: scripts/dev/no-gpu.sh <command...>
+set -euo pipefail
+exec bwrap \
+    --dev-bind / / \
+    --tmpfs /dev/dri \
+    --die-with-parent \
+    -- "$@"

--- a/scripts/test-display-free.sh
+++ b/scripts/test-display-free.sh
@@ -29,6 +29,22 @@ fi
 # Keep the workdir path SHORT: it becomes XDG_RUNTIME_DIR, and Unix
 # socket paths (compositor + daemon) cap at ~108 bytes.
 work="$(mktemp -d /tmp/hwatu-df.XXXXXX)"
+
+# GPU-less boxes (CI runners): WebKit's DMA-BUF renderer SIGTRAPs and
+# GLES-on-llvmpipe has aborted cage without a DRM render node. The
+# daemon applies this fallback itself in display-free mode; the
+# REFERENCE half of this suite runs in session mode (script-spawned
+# compositor + WAYLAND_DISPLAY), which by design changes nothing, so
+# the script must set the same env there. Exported globally so both
+# halves render identically for the pixel-parity assertion.
+gpu=no
+for node in /dev/dri/renderD*; do
+    [[ -r "$node" && -w "$node" ]] && gpu=yes && break
+done
+if [[ "$gpu" == no ]]; then
+    echo "test-display-free: no DRM render node; using software rendering" >&2
+    export WEBKIT_DISABLE_DMABUF_RENDERER=1 LIBGL_ALWAYS_SOFTWARE=1 WLR_RENDERER=pixman
+fi
 comp_pid=""
 cleanup() {
     [[ -n "$comp_pid" ]] && kill "$comp_pid" 2>/dev/null || true

--- a/scripts/test-display-free.sh
+++ b/scripts/test-display-free.sh
@@ -47,11 +47,21 @@ if [[ "$gpu" == no ]]; then
 fi
 comp_pid=""
 cleanup() {
+    local rc=$?
     [[ -n "$comp_pid" ]] && kill "$comp_pid" 2>/dev/null || true
     # Any daemon still running on either isolated socket.
     XDG_RUNTIME_DIR="$work/hosted" "$bin/hwatu" quit >/dev/null 2>&1 || true
     XDG_RUNTIME_DIR="$work/free" "$bin/hwatu" quit >/dev/null 2>&1 || true
     sleep 0.5
+    # On failure, the logs are the only evidence (especially on CI);
+    # dump them before removing the workdir.
+    if [[ "$rc" -ne 0 || "${fail:-0}" -ne 0 ]]; then
+        for log in "$work"/*.log; do
+            [[ -s "$log" ]] || continue
+            echo "===== $log =====" >&2
+            cat "$log" >&2
+        done
+    fi
     rm -rf "$work"
 }
 trap cleanup EXIT


### PR DESCRIPTION
Draft PR to validate the display-free CI job fix (run 30538572490 failed).

Root cause: WebKitGTK DMA-BUF renderer SIGTRAPs without a DRM render node, and cage aborts under GLES-on-llvmpipe on GPU-less runners.

Fix: in display-free mode, when no openable render node exists, the daemon exports WEBKIT_DISABLE_DMABUF_RENDERER=1, LIBGL_ALWAYS_SOFTWARE=1, WLR_RENDERER=pixman before GTK init. The test script mirrors the env for its session-mode reference half.

Do not merge until the display-free job is green.
