### PR TITLE
eval: pick expression-vs-body daemon-side, killing the masked "Script error." on resize

### DIFF
--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -258,69 +258,131 @@ pub fn eval_with(
         }
     };
 
-    // Trailing semicolons are meaningless on an expression but would
-    // break the `return ( ... )` wrapping; strip them for both the
-    // probe and the expression run.
-    let trimmed = js.trim().trim_end_matches(';').trim_end().to_string();
-    // Compile-only probe: defines an arrow wrapping the expression and
-    // returns it without calling it. Parses iff `js` is an expression;
-    // never executes user code, so a probe failure carries no side
-    // effects and a runtime SyntaxError cannot be mistaken for one.
-    let probe = format!("return typeof (async () => (\n{trimmed}\n));");
-    let expr = format!("return (\n{trimmed}\n);");
-    // Multi-statement scripts without an explicit `return` used to
-    // resolve to null, which agents read as "the script broke". Real
-    // REPLs answer with the completion value of the last statement;
-    // indirect eval gives exactly those semantics, so route return-less
-    // bodies through it. Bodies using `return` or `await` keep the
-    // plain async-function-body path: `return` because the author
-    // already chose the value, `await` because eval code is not an
-    // async context and would turn it into a SyntaxError.
-    let body = if js.contains("return") || js.contains("await") {
-        js
-    } else {
-        format!(
-            "return (0, eval)({});",
-            serde_json::to_string(&js).expect("string serializes")
-        )
+    let source = match plan_eval_source(&js) {
+        Ok(source) => source,
+        Err(message) => {
+            unwire();
+            return reply.send(Response::err(format!(
+                "eval failed: SyntaxError: {message}"
+            )));
+        }
     };
-    let view2 = view.clone();
-    let cancellable2 = cancellable.clone();
     view.call_async_javascript_function(
-        &probe,
+        &source,
         None,
         None,
         None,
         Some(&cancellable),
-        move |probed| {
-            let source = if probed.is_ok() { expr } else { body };
-            view2.call_async_javascript_function(
-                &source,
-                None,
-                None,
-                None,
-                Some(&cancellable2),
-                move |result| {
-                    match result {
-                        Ok(value) => {
-                            unwire();
-                            reply.send(Response::value(jsc_to_json(&value)));
-                        }
-                        Err(e) => {
-                            // A cancelled eval means the timeout or the
-                            // nav watcher already owns the reply; do not
-                            // unwire, a Success-policy load may still be
-                            // waiting to resolve it.
-                            if !reply.is_spent() && nav_watch_untriggered(&e) {
-                                unwire();
-                                reply.send(Response::err(format!("eval failed: {e}")));
-                            }
-                        }
+        move |result| {
+            match result {
+                Ok(value) => {
+                    unwire();
+                    reply.send(Response::value(jsc_to_json(&value)));
+                }
+                Err(e) => {
+                    // A cancelled eval means the timeout or the
+                    // nav watcher already owns the reply; do not
+                    // unwire, a Success-policy load may still be
+                    // waiting to resolve it.
+                    if !reply.is_spent() && nav_watch_untriggered(&e) {
+                        unwire();
+                        reply.send(Response::err(format!("eval failed: {e}")));
                     }
-                },
-            );
+                }
+            }
         },
     );
+}
+
+/// Decide the one source string an eval runs in the page, or reject
+/// bad syntax with the parser's message.
+///
+/// An earlier design probed the expression form by *compiling in the
+/// page* (an API-world script that parse-fails for every function
+/// body). WebKit reports that parse failure to the page as a
+/// cross-origin-masked `window` error event, so each probe miss
+/// buffered a spurious `{kind: "exception", text: "Script error."}`
+/// console entry: the resize path's `return {...}` viewport
+/// measurement emitted one per measure eval, polluting every resize
+/// and multi-viewport sweep reply (issue #6). Parsing daemon-side
+/// (same JSC engine, so exact dialect parity with the page) keeps
+/// failed candidates out of the page entirely, so `hwatu console`
+/// only ever reports the page's own errors, and saves the probe's
+/// page round trip.
+///
+/// The form rules are unchanged: an *expression* runs as `return
+/// (expr)` (so `document.title` just works); a function body with an
+/// explicit `return` or `await` runs as-is; a return-less
+/// multi-statement body routes through indirect eval, which answers
+/// with the completion value of the last statement the way a REPL
+/// would (`await` cannot take that route: eval code is not an async
+/// context, so it would turn into a SyntaxError).
+fn plan_eval_source(js: &str) -> Result<String, String> {
+    // Trailing semicolons are meaningless on an expression but would
+    // break the `return ( ... )` wrapping; strip them for the
+    // expression form.
+    let trimmed = js.trim().trim_end_matches(';').trim_end();
+    let expr = format!("return (\n{trimmed}\n);");
+    if js_syntax_check(&wrap_async_body(&expr)).is_ok() {
+        return Ok(expr);
+    }
+    let body = if js.contains("return") || js.contains("await") {
+        js.to_string()
+    } else {
+        format!(
+            "return (0, eval)({});",
+            serde_json::to_string(js).expect("string serializes")
+        )
+    };
+    js_syntax_check(&wrap_async_body(&body))?;
+    Ok(body)
+}
+
+/// The shape `call_async_javascript_function` compiles a body into
+/// (an async function wrapper), so daemon-side parse verdicts match
+/// what the page's compile would say about the same body.
+fn wrap_async_body(body: &str) -> String {
+    format!("async function __hwatu_probe() {{\n{body}\n}}")
+}
+
+/// Parse-only syntax check in a daemon-local JSC context (the same
+/// engine the page uses, so the dialect matches exactly).
+/// `jsc_context_check_syntax` never executes code, so hostile input
+/// that escapes the wrapper braces still cannot run in the daemon;
+/// the context is reused (thread_local) because creating one costs
+/// ~1 ms while a check costs microseconds.
+fn js_syntax_check(code: &str) -> Result<(), String> {
+    use glib::translate::{from_glib_full, ToGlibPtr};
+    use webkit6::javascriptcore as jsc;
+    thread_local! {
+        static CTX: jsc::Context = jsc::Context::new();
+    }
+    CTX.with(|ctx| {
+        let mut exception: *mut jsc::ffi::JSCException = std::ptr::null_mut();
+        // SAFETY: a plain FFI parse call; every pointer is owned by
+        // this frame, and the nullable exception out-pointer is
+        // adopted into a managed Option immediately. The safe binding
+        // is unusable here: it asserts the exception is non-null,
+        // which is exactly the success case.
+        let result = unsafe {
+            jsc::ffi::jsc_context_check_syntax(
+                ctx.to_glib_none().0,
+                code.to_glib_none().0,
+                code.len() as _,
+                jsc::ffi::JSC_CHECK_SYNTAX_MODE_SCRIPT,
+                "hwatu-eval".to_glib_none().0,
+                1,
+                &mut exception,
+            )
+        };
+        let exception: Option<jsc::Exception> = unsafe { from_glib_full(exception) };
+        if result == jsc::ffi::JSC_CHECK_SYNTAX_RESULT_SUCCESS {
+            return Ok(());
+        }
+        Err(exception
+            .and_then(|e| e.message().map(|m| m.to_string()))
+            .unwrap_or_else(|| "invalid syntax".into()))
+    })
 }
 
 /// True when an eval error is a genuine script failure rather than
@@ -2614,8 +2676,8 @@ fn mime_from_extension(path: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        base64, challenge_detect_js, challenge_wait_js, expect_watch_js, ExpectSpec,
-        VISIBILITY_INSPECTOR_JS,
+        base64, challenge_detect_js, challenge_wait_js, expect_watch_js, plan_eval_source,
+        ExpectSpec, VISIBILITY_INSPECTOR_JS,
     };
 
     #[test]
@@ -2734,5 +2796,83 @@ mod tests {
     #[test]
     fn expect_event_kind_is_advertised_for_subscriptions() {
         assert!(hwatu_ipc::EVENT_KINDS.contains(&"expect"));
+    }
+
+    /// The regression these pin (issue #6): the eval form choice must
+    /// never compile a failing candidate in the page. The page-world
+    /// probe surfaced every function-body eval as a cross-origin-masked
+    /// "Script error." console entry (one per `hwatu resize`, one per
+    /// sweep viewport). plan_eval_source decides daemon-side and
+    /// returns exactly one source string.
+    #[test]
+    fn expressions_run_wrapped_in_return() {
+        for js in ["document.title", "1+1", "{a: 1}", "await fetch('/x')"] {
+            let source = plan_eval_source(js).expect("expression accepted");
+            assert_eq!(source, format!("return (\n{js}\n);"), "for {js}");
+        }
+        // Trailing semicolons are stripped from the expression form.
+        assert_eq!(
+            plan_eval_source("document.title;").unwrap(),
+            "return (\ndocument.title\n);"
+        );
+    }
+
+    #[test]
+    fn bodies_with_return_or_await_run_as_is() {
+        for js in [
+            "return document.title",
+            "const n = 6*7; return n",
+            "await hwatuSleep(10); return 1",
+        ] {
+            assert_eq!(plan_eval_source(js).unwrap(), js, "for {js}");
+        }
+    }
+
+    #[test]
+    fn return_less_bodies_route_through_indirect_eval() {
+        let source = plan_eval_source("const n = 6*7; n").unwrap();
+        assert!(
+            source.starts_with("return (0, eval)("),
+            "REPL completion-value semantics: {source}"
+        );
+        assert!(source.contains("const n = 6*7; n"));
+    }
+
+    #[test]
+    fn statements_that_probe_as_neither_form_still_run() {
+        // `throw` parses as a body statement, not an expression.
+        let source = plan_eval_source("throw new Error('boom')").unwrap();
+        assert!(source.starts_with("return (0, eval)("));
+    }
+
+    #[test]
+    fn bad_syntax_is_rejected_daemon_side_with_the_parser_message() {
+        // Bodies that must run as-is (they use return/await) are the
+        // ones whose parse errors used to be compiled in the page;
+        // now they are rejected before touching it. Return-less bad
+        // syntax still routes through indirect eval as string data
+        // and fails at runtime with a normal SyntaxError reply.
+        for js in ["return foo(", "await foo("] {
+            let err = plan_eval_source(js).expect_err("syntax error rejected");
+            assert!(!err.is_empty(), "parser message expected for {js}");
+        }
+        assert!(plan_eval_source("foo(")
+            .expect("routed through indirect eval")
+            .starts_with("return (0, eval)("));
+    }
+
+    #[test]
+    fn wrapper_escape_attempts_do_not_widen_what_runs() {
+        // Escaping the async-wrapper braces makes the candidate fail
+        // to parse as one function body; the check must reject it (or
+        // route it through indirect eval as a string), never let it
+        // parse into extra top-level code.
+        let js = "} globalThis.pwned = 1; async function x() {";
+        match plan_eval_source(js) {
+            // Rejected outright: fine.
+            Err(_) => {}
+            // Accepted only as data inside an indirect eval string.
+            Ok(source) => assert!(source.starts_with("return (0, eval)(")),
+        }
     }
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -172,7 +172,8 @@ controls.
 ### Eval semantics
 
 `js` can be an **expression** or a **function body**; the daemon
-picks the right form with a compile-only probe, so both just work:
+picks the right form with a daemon-side parse (nothing but the code
+that actually runs ever reaches the page), so both just work:
 
 ```sh
 hwatu eval 'document.title'                # expression


### PR DESCRIPTION
Closes #6

## What changed

Every `hwatu resize` (and each sweep viewport after the first) buffered a spurious cross-origin-masked `{kind:"exception", text:"Script error."}` console entry.

**Root cause:** `eval`'s expression-vs-body form choice compiled a probe *in the page* (`call_async_javascript_function` with a compile-only arrow wrapping the script). For any function-body script, that probe is a parse error, and WebKit surfaces API-world parse failures to the page as a masked `window` error event, which the console capture buffers. The resize path measures the viewport with `return { css_width: innerWidth, ... }`, a function body, so every resize emitted one masked entry per measure eval (two per `hwatu resize`: measure + re-verify; one per sweep viewport).

**Fix** (`crates/hwatud/src/automation.rs`): decide the form daemon-side with `jsc_context_check_syntax` in a reused local JSC context. It is the same engine the page uses (exact dialect parity), it never executes code, and failed candidates never reach the page, so `hwatu console` now reports only the page's own errors. The sweep does not need to filter anything, real page exceptions are still captured (verified against a throwing fixture). Side benefits: the probe's page round trip is gone, and a bad `return`/`await` body now gets an immediate structured reply naming the parse error (`eval failed: SyntaxError: Unexpected token '}'`) instead of a masked console entry.

Eval semantics are unchanged and pinned by new unit tests: expression wrapping, `return`/`await` bodies as-is, return-less bodies through indirect eval (REPL completion-value semantics), wrapper-escape input stays inert. Updated the one `docs/agents.md` line describing the probe (roadmap untouched).

## Gates

```
$ cargo fmt --check                                        # exit 0
$ cargo clippy --workspace --all-targets -- -D warnings    # exit 0
$ cargo test --workspace                                   # exit 0
  hwatu:  60 passed; hwatud: 93 passed, 1 ignored; ipc: 8+5 passed; 0 failed

dbus-run-session scripts (release build):
  test-render.sh         13 passed, 0 failed
  test-watch.sh          12 passed, 0 failed
  test-expect-watch.sh    4 passed, 0 failed
  test-snapshot-diff.sh  20 passed, 0 failed
  test-net.sh            11 passed, 0 failed
  test-display-free.sh   13 passed, 0 failed
  test-agent-loop.sh      9 passed, 1 failed *
  test-viewports.sh      13 passed, 2 failed *
  test-expect-visible.sh  1 failed *
```

\* The three failures are pre-existing on this VM and byte-identical on unmodified `main` (verified in a `main` worktree with the same runner): resize height lands 1-3 px off / viewport shots 1-2 px tall under the display-free child compositor, i.e. the issue #7 family, not touched by this change.

## CLI smoke (fresh release build, display-free daemon)

```
$ hwatu --headless --json file:///tmp/smoke.html
{"id":1,"url":"file:///tmp/smoke.html","title":"","focused":false,"suspended":false,"mode":"headless"}
$ hwatu wait-load --id 1
window 1 -> file:///tmp/smoke.html (0 ms)
$ hwatu console --id 1 --clear
[]
$ hwatu resize --id 1 500x600
{"css_height":602,"css_width":500,"dpr":1}
$ hwatu console --id 1       # was: 2x masked 'Script error.', now clean
[]
$ hwatu eval --id 1 'document.title'
"smoke"
$ hwatu eval --id 1 'return 40+2'
42
$ hwatu eval --id 1 'const n = 6*7; n'
42
$ hwatu eval --id 1 'return foo('    # structured error, no console noise
hwatu: eval failed: SyntaxError: Unexpected token '}'
$ hwatu console --id 1
[]
$ hwatu check file:///tmp/smoke.html --viewports 360x640,1920x1080 --eval 'innerWidth'
{"load_ms":36,"title":"smoke","total_ms":39,"url":"file:///tmp/smoke.html","viewports":[{"eval":360,"pass_ms":2,"size":"360x640"},{"eval":1920,"pass_ms":0,"size":"1920x1080"}]}
```

Also verified real page errors still flow: an http-served fixture with an inline `throw` reports `"Error: inline page error"` with url+line, and an unhandled rejection reports its reason+stack. (A `throw` inside a `setTimeout` callback of a file:// page stays masked to `"Script error."`. That is WebKit's own cross-origin masking of file-scheme timer callbacks, unrelated to this path, and identical on main.)

## Caveats

- `js_syntax_check` uses the raw `jsc_context_check_syntax` FFI because the safe binding asserts a non-null exception, which is exactly the success case. One narrow `unsafe` block, commented.
- Syntax-error replies now come from the daemon's parse rather than the page's compile. Message text matches JSC's page-side wording (same engine), but arrives without the page round trip.
- MCP surface untouched (`eval` dispatch path is shared), so no tools/list change.
