### PR TITLE
fix(resize): land exact CSS viewports under the display-free child compositor (#7)

### DIFF
--- a/crates/hwatud/src/verify.rs
+++ b/crates/hwatud/src/verify.rs
@@ -197,9 +197,24 @@ return {{ animations: anims.length, touched, resumed: resume }};"#,
 ///
 /// Trust nothing: the reply measures innerWidth/innerHeight from the
 /// page, and if some backend does not map logical px 1:1 onto CSS px
-/// the allocation is corrected once from the measured ratio and
-/// re-verified, so the caller gets the size it asked for (or an
-/// honest measurement of the miss).
+/// the allocation is corrected from the measurement and re-verified,
+/// so the caller gets the size it asked for (or an honest measurement
+/// of the miss).
+///
+/// Two backend behaviours have to be modelled, hence the small
+/// correction *loop* rather than one shot:
+///
+/// - multiplicative: the backend scales logical px (dpr double-apply);
+///   one ratio correction lands it.
+/// - affine: the compositor/window chrome eats a fixed number of rows,
+///   so measured = allocated - k. Seen under the display-free child
+///   compositor (cage), where `resize 1920x1080` landed 1920x1081 and
+///   360x640 landed 360x642 (issue #7). A ratio correction can never
+///   converge on a constant offset, so after the first (ratio) attempt
+///   the loop switches to offset correction: allocate
+///   `allocated + (requested - measured)`. That converges in one more
+///   pass for a constant k, and the loop is capped either way so a
+///   pathological backend costs a bounded number of evals.
 pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply) {
     // A resize is cheap, but reading the resulting CSS viewport executes on the
     // page's main thread. Heavy pages can legitimately keep that thread busy
@@ -214,11 +229,37 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
         Ok(win) => win,
         Err(resp) => return reply(*resp),
     };
-    let daemon2 = daemon.clone();
     let win_id = win.id;
     win.resize_viewport(w, h);
+    measure_and_correct(daemon, win_id, w, h, w, h, 0, reply);
+}
+
+/// Maximum correction passes after the initial allocation. Pass 1 is
+/// the ratio correction (dpr-style scaling), pass 2 the offset
+/// correction (fixed chrome rows); a third is allowed for backends
+/// whose offset itself shifts slightly with size. Bounded so a
+/// backend that never converges costs a fixed number of evals and the
+/// caller still gets an honest measurement.
+const RESIZE_MAX_CORRECTIONS: u32 = 3;
+
+/// Measure the CSS viewport the page actually sees and, if it misses
+/// the request, re-allocate and recurse. `alloc_w/alloc_h` are the
+/// logical px currently allocated; `attempt` counts corrections made
+/// so far.
+fn measure_and_correct(
+    daemon: &Rc<Daemon>,
+    win_id: u64,
+    w: i32,
+    h: i32,
+    alloc_w: i32,
+    alloc_h: i32,
+    attempt: u32,
+    reply: Reply,
+) {
+    const RESIZE_MEASURE_TIMEOUT_MS: u64 = 10_000;
     const MEASURE: &str =
         "return { css_width: innerWidth, css_height: innerHeight, dpr: window.devicePixelRatio }";
+    let daemon2 = daemon.clone();
     automation::eval(
         daemon,
         Some(win_id),
@@ -242,9 +283,12 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
                 (Some(cw), Some(ch)) => (cw, ch),
                 _ => return reply(resp),
             };
+            if attempt >= RESIZE_MAX_CORRECTIONS {
+                return reply(resp); // honest measurement of the miss
+            }
             let (aw, ah) = (
-                corrected_allocation(w, w, cw),
-                corrected_allocation(h, h, ch),
+                corrected_allocation(w, alloc_w, cw, attempt),
+                corrected_allocation(h, alloc_h, ch, attempt),
             );
             match (aw, ah) {
                 (None, None) => reply(resp), // exact: logical px == CSS px
@@ -253,14 +297,18 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
                         Some(w) => w,
                         None => return reply(Response::err(format!("no window {win_id}"))),
                     };
-                    win.resize_viewport(aw.unwrap_or(w), ah.unwrap_or(h));
+                    let (next_w, next_h) = (aw.unwrap_or(alloc_w), ah.unwrap_or(alloc_h));
+                    win.resize_viewport(next_w, next_h);
                     // Re-verify: the reply always carries what the page
                     // actually sees, so the caller never has to trust us.
-                    automation::eval(
+                    measure_and_correct(
                         &daemon2,
-                        Some(win_id),
-                        MEASURE.into(),
-                        Some(RESIZE_MEASURE_TIMEOUT_MS),
+                        win_id,
+                        w,
+                        h,
+                        next_w,
+                        next_h,
+                        attempt + 1,
                         reply,
                     );
                 }
@@ -271,16 +319,28 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
 
 /// One-shot correction for backends where widget logical px do not
 /// map 1:1 onto CSS px: given what was requested (CSS px), what was
-/// allocated (logical px), and what the page measured (CSS px),
-/// return the allocation that should land the request, or `None` if
-/// the measurement already matches. Pure so the double-apply bug
-/// class is pinned by unit tests.
-fn corrected_allocation(requested: i32, allocated: i32, measured: i32) -> Option<i32> {
+/// allocated (logical px), what the page measured (CSS px), and which
+/// correction `attempt` this is, return the allocation that should
+/// land the request, or `None` if the measurement already matches.
+///
+/// `attempt == 0` assumes a multiplicative backend (dpr double-apply)
+/// and scales; later attempts assume an affine one (fixed chrome rows
+/// under the display-free child compositor) and shift by the residual.
+/// Pure so both bug classes are pinned by unit tests.
+fn corrected_allocation(
+    requested: i32,
+    allocated: i32,
+    measured: i32,
+    attempt: u32,
+) -> Option<i32> {
     if measured == requested || measured <= 0 {
         return None;
     }
-    let corrected =
-        (f64::from(allocated) * f64::from(requested) / f64::from(measured)).round() as i32;
+    let corrected = if attempt == 0 {
+        (f64::from(allocated) * f64::from(requested) / f64::from(measured)).round() as i32
+    } else {
+        allocated.saturating_add(requested - measured)
+    };
     Some(corrected.clamp(1, 16384))
 }
 
@@ -704,25 +764,73 @@ mod tests {
     /// measures exactly what was asked.
     #[test]
     fn exact_measurement_needs_no_correction() {
-        assert_eq!(corrected_allocation(360, 360, 360), None);
-        assert_eq!(corrected_allocation(1920, 1920, 1920), None);
+        assert_eq!(corrected_allocation(360, 360, 360, 0), None);
+        assert_eq!(corrected_allocation(1920, 1920, 1920, 0), None);
+        // Also a no-op on later (offset-mode) attempts.
+        assert_eq!(corrected_allocation(640, 677, 640, 1), None);
     }
 
     #[test]
     fn double_applied_scale_is_corrected() {
         // dpr-2 double apply: asked 360, page saw 720 -> halve.
-        assert_eq!(corrected_allocation(360, 360, 720), Some(180));
+        assert_eq!(corrected_allocation(360, 360, 720, 0), Some(180));
         // hypothetical backend where logical px = CSS px * 2 the other
         // way: asked 360, page saw 180 -> double.
-        assert_eq!(corrected_allocation(360, 360, 180), Some(720));
+        assert_eq!(corrected_allocation(360, 360, 180, 0), Some(720));
+    }
+
+    /// Issue #7: under the display-free child compositor the chrome
+    /// eats a constant number of rows (measured = allocated - k), so
+    /// the ratio correction overshoots forever. From attempt 1 the
+    /// correction is additive and lands exactly in one more pass.
+    #[test]
+    fn constant_chrome_offset_is_corrected_additively() {
+        // Observed on the VM: k = 37 rows.
+        const K: i32 = 37;
+        for (requested, allocated) in [(640, 640), (1080, 1080), (100, 100)] {
+            let measured = allocated - K;
+            let next = corrected_allocation(requested, allocated, measured, 1)
+                .expect("miss must be corrected");
+            assert_eq!(next, requested + K);
+            // The re-measure of that allocation now matches exactly.
+            assert_eq!(corrected_allocation(requested, next, next - K, 2), None);
+        }
+    }
+
+    /// Why the loop switches modes rather than repeating the ratio
+    /// correction: on an affine backend a ratio pass only ever removes
+    /// *part* of a constant offset, so it never lands in one step (the
+    /// pre-fix single-shot behaviour, i.e. issue #7), and how many
+    /// steps it needs depends on rounding. Offset mode lands in one,
+    /// for every size.
+    #[test]
+    fn offset_mode_lands_where_ratio_mode_needs_extra_passes() {
+        const K: i32 = 37;
+        for requested in [100, 360, 640, 1080, 1920] {
+            // Ratio mode, one pass from the initial allocation: misses.
+            let ratio_next = corrected_allocation(requested, requested, requested - K, 0)
+                .expect("miss must be corrected");
+            assert_ne!(
+                ratio_next - K,
+                requested,
+                "ratio mode should not land {requested} in one pass"
+            );
+            // Offset mode, one pass: exact.
+            let offset_next = corrected_allocation(requested, requested, requested - K, 1)
+                .expect("miss must be corrected");
+            assert_eq!(offset_next - K, requested);
+        }
     }
 
     #[test]
     fn degenerate_measurements_do_not_explode() {
-        assert_eq!(corrected_allocation(360, 360, 0), None);
-        assert_eq!(corrected_allocation(360, 360, -5), None);
+        assert_eq!(corrected_allocation(360, 360, 0, 0), None);
+        assert_eq!(corrected_allocation(360, 360, -5, 1), None);
         // Correction stays in the request's valid range.
-        assert_eq!(corrected_allocation(16384, 16384, 1), Some(16384));
-        assert_eq!(corrected_allocation(1, 1, 16384), Some(1));
+        assert_eq!(corrected_allocation(16384, 16384, 1, 0), Some(16384));
+        assert_eq!(corrected_allocation(1, 1, 16384, 0), Some(1));
+        // Offset mode clamps too: a huge negative shift floors at 1.
+        assert_eq!(corrected_allocation(1, 1, 16384, 1), Some(1));
+        assert_eq!(corrected_allocation(16384, 16384, 1, 1), Some(16384));
     }
 }

--- a/crates/hwatud/src/verify.rs
+++ b/crates/hwatud/src/verify.rs
@@ -216,12 +216,6 @@ return {{ animations: anims.length, touched, resumed: resume }};"#,
 ///   pass for a constant k, and the loop is capped either way so a
 ///   pathological backend costs a bounded number of evals.
 pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply) {
-    // A resize is cheap, but reading the resulting CSS viewport executes on the
-    // page's main thread. Heavy pages can legitimately keep that thread busy
-    // for more than the generic 2 s eval default during initial hydration.
-    // Keep this bounded while giving verification commands enough time to
-    // return the measured dimensions instead of a false timeout.
-    const RESIZE_MEASURE_TIMEOUT_MS: u64 = 10_000;
     if !(1..=16384).contains(&w) || !(1..=16384).contains(&h) {
         return reply(Response::err(format!("bad viewport {w}x{h}")));
     }
@@ -231,7 +225,16 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
     };
     let win_id = win.id;
     win.resize_viewport(w, h);
-    measure_and_correct(daemon, win_id, w, h, w, h, 0, reply);
+    measure_and_correct(
+        daemon,
+        ResizeAttempt {
+            win_id,
+            requested: (w, h),
+            allocated: (w, h),
+            attempt: 0,
+        },
+        reply,
+    );
 }
 
 /// Maximum correction passes after the initial allocation. Pass 1 is
@@ -242,23 +245,35 @@ pub fn resize(daemon: &Rc<Daemon>, id: Option<u64>, w: i32, h: i32, reply: Reply
 /// caller still gets an honest measurement.
 const RESIZE_MAX_CORRECTIONS: u32 = 3;
 
-/// Measure the CSS viewport the page actually sees and, if it misses
-/// the request, re-allocate and recurse. `alloc_w/alloc_h` are the
-/// logical px currently allocated; `attempt` counts corrections made
-/// so far.
-fn measure_and_correct(
-    daemon: &Rc<Daemon>,
+/// A resize is cheap, but reading the resulting CSS viewport executes on
+/// the page's main thread. Heavy pages can legitimately keep that thread
+/// busy for more than the generic 2 s eval default during initial
+/// hydration. Keep this bounded while giving verification commands enough
+/// time to return the measured dimensions instead of a false timeout.
+const RESIZE_MEASURE_TIMEOUT_MS: u64 = 10_000;
+
+/// One step of the resize correction loop: which window, the CSS size
+/// the caller asked for, the logical px currently allocated for it,
+/// and how many corrections have already been made.
+#[derive(Clone, Copy)]
+struct ResizeAttempt {
     win_id: u64,
-    w: i32,
-    h: i32,
-    alloc_w: i32,
-    alloc_h: i32,
+    requested: (i32, i32),
+    allocated: (i32, i32),
     attempt: u32,
-    reply: Reply,
-) {
-    const RESIZE_MEASURE_TIMEOUT_MS: u64 = 10_000;
+}
+
+/// Measure the CSS viewport the page actually sees and, if it misses
+/// the request, re-allocate and recurse.
+fn measure_and_correct(daemon: &Rc<Daemon>, step: ResizeAttempt, reply: Reply) {
     const MEASURE: &str =
         "return { css_width: innerWidth, css_height: innerHeight, dpr: window.devicePixelRatio }";
+    let ResizeAttempt {
+        win_id,
+        requested: (w, h),
+        allocated: (alloc_w, alloc_h),
+        attempt,
+    } = step;
     let daemon2 = daemon.clone();
     automation::eval(
         daemon,
@@ -303,12 +318,11 @@ fn measure_and_correct(
                     // actually sees, so the caller never has to trust us.
                     measure_and_correct(
                         &daemon2,
-                        win_id,
-                        w,
-                        h,
-                        next_w,
-                        next_h,
-                        attempt + 1,
+                        ResizeAttempt {
+                            allocated: (next_w, next_h),
+                            attempt: attempt + 1,
+                            ..step
+                        },
                         reply,
                     );
                 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -531,10 +531,19 @@ hwatu focus $id    # window appears in their WM, session intact
   session snapshots (they belong to the agent's loop, not the user's
   browsing).
 
-Note on displays: `hwatud` is a GTK app and currently needs a
-Wayland/X session to start, even for headless windows. Headless mode
-removes focus/WM noise on a desktop; running with no display at all
-(CI) is future work (nested headless compositor).
+Note on displays: `hwatud` is a GTK app and needs a display
+connection, even for headless windows. Headless mode removes
+focus/WM noise on a desktop; with no display at all (CI, a bare ssh
+login) the daemon enters display-free mode and hosts its own child
+Wayland compositor (cage/labwc/sway on the wlroots headless
+backend). Viewport sizing is exact there too: `resize` measures what
+the page actually sees and corrects the allocation, so a child
+compositor that eats chrome rows cannot leak extra pixel rows into a
+shot.
+
+On a bare ssh login there is usually no D-Bus session bus, and
+WebKit's portal lookups can then stall the first load. Start the
+daemon (or a test script) under one: `dbus-run-session -- hwatud`.
 
 Note on DPR: GTK derives surface scale from the monitors even for
 unmapped headless windows, so a fractional-scale Wayland output can

--- a/scripts/test-display-free.sh
+++ b/scripts/test-display-free.sh
@@ -12,6 +12,11 @@
 #      (diff score >= 99%).
 #   4. `hwatu focus <id>` returns the structured "no display" error,
 #      not a crash (daemon still answers afterwards).
+#   4b. Viewport-sized shots are EXACT under the child compositor
+#      (issue #7): the compositor's chrome ate a constant number of
+#      rows, so a requested 360x640 landed a 360x642 PNG. Both the
+#      measured CSS viewport and the PNG's pixel dimensions must equal
+#      the request.
 #   5. No orphan compositor survives daemon exit (clean quit AND
 #      SIGKILL, which exercises the PDEATHSIG supervisor).
 #
@@ -178,6 +183,36 @@ else
 fi
 out="$(hw ping)"
 check "daemon still answers after the focus error" grep -q '"build"' <<<"$out"
+
+# 4b. exact viewport sizing under the child compositor (issue #7).
+# The pre-fix bug was height-only and size-dependent, so sample a few
+# sizes including the two from the report.
+png_size() { # png_size <file> -> "<w>x<h>"
+    python3 - "$1" <<'PY'
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    head = f.read(24)
+w, h = struct.unpack('>II', head[16:24])
+print(f"{w}x{h}")
+PY
+}
+for size in 360x640 800x600 1920x1080; do
+    vshot="$work/vp-$size.png"
+    out="$(hw render --stdin --viewports "$size" --shot="$vshot" \
+        --eval 'innerWidth + "x" + innerHeight' <<<"$fixture")"
+    # Parse the fields: the size LABEL is echoed in the reply too, so
+    # a bare grep for "360x640" would pass even on a 360x642 page.
+    measured="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["viewports"][0]["eval"])' <<<"$out")"
+    check "display-free $size: page measures exactly $size (got $measured)" \
+        test "$measured" = "$size"
+    shot_file="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["viewports"][0].get("shot",""))' <<<"$out")"
+    if [[ -s "${shot_file:-}" ]]; then
+        check "display-free $size: shot PNG is exactly $size" \
+            test "$(png_size "$shot_file")" = "$size"
+    else
+        bad "display-free $size: shot PNG is exactly $size (no shot written)"
+    fi
+done
 
 # 5a. clean quit leaves no compositor
 hw quit >/dev/null


### PR DESCRIPTION
## What changed

Under the display-free child compositor (cage on the wlroots headless backend), `hwatu check --viewports` shots carried 1-2 extra pixel rows: requested 360x640 produced a 360x642 PNG, 1920x1080 produced 1920x1081.

**Root cause.** `verify::resize` allocates the requested CSS size, measures `innerWidth`/`innerHeight` from the page, and corrects once by the measured *ratio*. That models a multiplicative backend (the dpr double-apply this code was written for). The child compositor is **affine**, not multiplicative: it eats a constant number of rows, so `measured = allocated - k`. A ratio correction can only ever remove *part* of a constant offset, leaving a residual of roughly `k²/h`: 2 rows at 640, 1 row at 1080, exactly what the issue reports (and the reason it looked size-dependent).

**Fix** (`crates/hwatud/src/verify.rs`): turn the one-shot correction into a small bounded loop. Attempt 0 stays the ratio correction (unchanged behaviour for the dpr case). From attempt 1 the correction is additive: `allocated + (requested - measured)`, which lands a constant offset exactly in one more pass. Capped at 3 corrections, so a pathological backend costs a bounded number of evals and the caller still gets an honest measurement of the miss. The correction-loop state is bundled in a small `ResizeAttempt` struct; the reply contract is unchanged (it always reports what the page actually sees).

No IPC/wire/CLI/MCP change: this is a daemon-side correctness fix behind the existing `resize` path, so back-compat is trivially preserved.

**Tests.** `scripts/test-display-free.sh` gains the VM case from the issue (check 4b): for 360x640, 800x600 and 1920x1080, both the measured CSS viewport and the PNG's actual pixel dimensions must equal the request. The size label is echoed in the reply, so the check parses the JSON fields rather than grepping (a bare grep would pass on a 360x642 page). Unit tests pin both bug classes: the ratio path, the additive path, that ratio mode provably cannot land an affine backend in one pass, and clamping in both modes.

Docs: `docs/agents.md`'s stale "no display at all is future work" note now describes display-free mode, its viewport exactness, and the `dbus-run-session` requirement on a bare ssh login (also raised in the issue). `docs/roadmap.md` untouched.

Closes #7

## Gate results

```
$ cargo fmt --check
(clean)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.21s
(no warnings)

$ cargo test --workspace
test result: ok. 60 passed; 0 failed; 0 ignored
test result: ok. 8 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
test result: ok. 100 passed; 0 failed; 1 ignored
test result: ok. 0 passed; 0 failed; 0 ignored
```

Behavioral suites, each under `dbus-run-session`:

```
test-agent-loop:     10 passed, 0 failed
test-display-free:   19 passed, 0 failed   (was 13; +6 new viewport-exactness checks)
test-expect-watch:    4 passed, 0 failed
test-net:            11 passed, 0 failed
test-render:         13 passed, 0 failed
test-snapshot-diff:  20 passed, 0 failed
test-viewports:      15 passed, 0 failed   (was 13 passed / 2 failed before this fix)
test-watch:          12 passed, 0 failed
```

Before the fix, on this VM:

```
FAIL - 360x640 shot has the requested pixel dimensions
FAIL - 1920x1080 shot has the requested pixel dimensions
test-viewports: 13 passed, 2 failed
```

## CLI smoke (release build, outsider-style, display-free VM)

```
--- hwatu check --viewports 360x640,1920x1080 ---
{"load_ms":140,"title":"smoke","total_ms":226,"url":"file:///tmp/.../p.html",
 "viewports":[{"eval":"360x640","pass_ms":15,"shot":".../s-360x640.png","size":"360x640"},
              {"eval":"1920x1080","pass_ms":70,"shot":".../s-1920x1080.png","size":"1920x1080"}]}

--- PNG dimensions on disk ---
s-1920x1080.png -> 1920x1080
s-360x640.png   -> 360x640

--- interactive resize + shot ---
window 3 -> file:///tmp/.../p.html (24 ms)
360x640:   resize -> {"css_height":640,"css_width":360,"dpr":1}    png 360x640
800x600:   resize -> {"css_height":600,"css_width":800,"dpr":1}    png 800x600
1920x1080: resize -> {"css_height":1080,"css_width":1920,"dpr":1}  png 1920x1080
```

The same probe before the fix returned `css_height` 642 / 602 / 1081 respectively.

## Caveats

- MCP was not touched (no tool surface change), so no MCP discovery run was needed.
- `scripts/test-expect-visible.sh` fails on this VM (`AssertionError: 0` from its scroll assertion). Confirmed **pre-existing on `main`** by building and running it from a clean `main` worktree; unrelated to this change and left alone.
- The correction loop costs at most 3 extra evals on a non-conforming backend, and only when a measurement misses. On a session compositor the first measurement is exact, so the added cost there is zero.
- The offset is discovered per resize rather than cached. That keeps the code stateless and honest if the offset varies by size, at the price of one extra eval per resize on affine backends (~1 ms on this VM).
