### PR TITLE
docs: root-cause the 144Hz scroll cap

### DIFF
--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -219,6 +219,22 @@ fn persist_cookies() {
 fn main() -> glib::ExitCode {
     // Keep RAM predictable: cap glibc arena explosion under GTK threads.
     std::env::set_var("MALLOC_ARENA_MAX", "2");
+    // Full-refresh-rate scrolling: WebKitGTK's default DMA-BUF
+    // presentation path paces `frameDone` at 60Hz on setups where its
+    // vblank monitor falls back to a fixed 60fps timer (observed on
+    // 144Hz Wayland/niri, WebKitGTK 2.52; idle rAF hits 144 but any
+    // scroll/repaint work drops to ~59). Disabling the DMA-BUF
+    // renderer falls back to the legacy EGLImage path, which follows
+    // the GTK frame clock: measured idle=142.9/scroll=142.9 vs
+    // 62.5/58.8 on the same fixture, with equal CPU cost and vsync
+    // intact (docs/research-input-lag.md "144Hz scroll cap"). WebKit
+    // treats any value other than "0" as "disable", so exporting
+    // WEBKIT_DISABLE_DMABUF_RENDERER=0 restores the DMA-BUF path if
+    // this fallback ever misbehaves; explicit user env always wins.
+    // Must run before GTK/WebKit init; web processes inherit the env.
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
     // Display-free operation (roadmap G4): with no usable
     // WAYLAND_DISPLAY/DISPLAY, spawn a managed headless child
     // compositor and point GTK at it. Must run before any GTK/GDK

--- a/docs/research-input-lag.md
+++ b/docs/research-input-lag.md
@@ -193,3 +193,50 @@ pragmatic path.
 Not recommended: keystroke buffering across restores (reorder/IME
 hazards), forcing threaded scrolling features (known wheel breakage),
 a second engine or off-main-thread GTK (not how GTK works).
+
+## Addendum: the 144Hz scroll cap (found and fixed)
+
+Symptom on a 144Hz Wayland laptop (niri, Intel iGPU): idle rAF runs
+at ~144fps, but the moment the page actually repaints every frame
+(scrolling, animations driving layout) the rate collapses to ~59fps.
+GTK was innocent: a bare GTK4 app with a real draw func hits 141fps,
+GSK ngl/vulkan/cairo all ~143fps, and GDK reports the monitor's
+144003mHz correctly. The `refresh_interval=16.7ms` seen under
+`GDK_DEBUG=frames` before the first frame is just the frame-clock
+default, not evidence of a 60Hz clock.
+
+The cap lives in WebKitGTK's DMA-BUF presentation path (the default
+since 2.40): `AcceleratedSurface` frame completion is paced by
+WebKit's own vblank monitor, and when `DisplayVBlankMonitorDRM`
+cannot attach to the DRM CRTC it silently falls back to
+`DisplayVBlankMonitorTimer`, which ticks at a hardcoded
+`FullSpeedFramesPerSecond = 60` (`AnimationFrameRate.h`). Idle rAF
+still reads 144 because the UI-side frame clock drives it; only the
+produce-a-new-buffer-every-frame loop is throttled.
+
+Measured on the scroll fixture (`scripts/bench-scroll/`), median rAF
+delta, `hwatu eval` on the same machine:
+
+| config | idle | scroll |
+|---|---|---|
+| default (DMA-BUF path) | 62.5-142.9 | 58.8 |
+| `GDK_DEBUG=no-vsync` | 142.9 | 142.9 (tears; diagnostic only) |
+| `WEBKIT_DISABLE_DMABUF_RENDERER=1` | 142.9 | 142.9 |
+| `WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` | 142.9 | 58.8 |
+| `GSK_RENDERER=ngl`, `no-offload`, `GDK_DISABLE=offload` | — | 58.8 |
+
+Disabling the DMA-BUF renderer falls back to the legacy EGLImage
+path, which presents through the GTK frame clock and therefore
+follows the real refresh rate. Verified on Wikipedia (100-142fps
+scroll vs 58.8 baseline), CPU cost equal within noise (~13-15%
+total during a scroll storm), wheel + keyboard scrolling intact
+(ydotool-synthesized wheel deltas land identically), WebGL still
+hardware-backed, vsync intact (no tearing).
+
+hwatud now exports `WEBKIT_DISABLE_DMABUF_RENDERER=1` by default
+(`main.rs`); explicit user env wins, so
+`WEBKIT_DISABLE_DMABUF_RENDERER=0 hwatud` restores WebKit's default
+path. Revisit when WebKitGTK's vblank monitor learns to follow the
+real display rate (or exposes a refresh-rate override): the DMA-BUF
+path is the better architecture and should win again once its pacing
+is fixed.


### PR DESCRIPTION
Adds an addendum to docs/research-input-lag.md documenting the 60fps scroll cap investigation: WebKitGTK's DMA-BUF presentation path paces frame completion with a vblank monitor that falls back to a hardcoded 60fps timer, capping scroll repaints at ~59fps on a 144Hz display. Includes the measured config matrix and the fix now shipped in hwatud (default WEBKIT_DISABLE_DMABUF_RENDERER=1, user env wins).

Per repo policy, docs go through PR review.