### PR TITLE
Fix #13: keep onboarding commands out of URL parsing

### DIFF
--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -26,10 +26,7 @@ fn main() {
     if args.first().map(String::as_str) == Some("watch") {
         std::process::exit(watch(&args[1..]));
     }
-    if matches!(
-        args.first().map(String::as_str),
-        Some("doctor") | Some("setup") | Some("demo")
-    ) {
+    if is_onboarding_command(args.first().map(String::as_str)) {
         std::process::exit(onboarding::run(&args));
     }
     // `--json` is a client-side output flag (machine-readable `list`
@@ -162,6 +159,12 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+/// Return whether the first argument is handled locally instead of being
+/// interpreted as a URL by the browser client.
+fn is_onboarding_command(command: Option<&str>) -> bool {
+    matches!(command, Some("doctor") | Some("setup") | Some("demo"))
 }
 
 fn parse(args: &[String]) -> Result<Request, String> {
@@ -1140,8 +1143,17 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<UnixStream> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_with_default_mode, OpenMode};
+    use super::{is_onboarding_command, parse_with_default_mode, OpenMode};
     use hwatu_ipc::Request;
+
+    #[test]
+    fn onboarding_commands_are_handled_before_url_parsing() {
+        assert!(is_onboarding_command(Some("doctor")));
+        assert!(is_onboarding_command(Some("setup")));
+        assert!(is_onboarding_command(Some("demo")));
+        assert!(!is_onboarding_command(Some("https://example.com")));
+        assert!(!is_onboarding_command(None));
+    }
 
     /// Env-independent parse: tests themselves often run under a
     /// coding agent, which would flip `default_open_mode()`.

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -25,6 +25,7 @@ mod palette;
 mod prompts;
 mod search;
 mod session;
+mod smoothwheel;
 mod snapdiff;
 mod verify;
 mod window;

--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -1,0 +1,271 @@
+//! Chromium-curve wheel scrolling, injected as a user script.
+//!
+//! Why this exists: WebKitGTK's native smooth scrolling
+//! (`ScrollAnimationSmooth`) animates each discrete wheel tick over
+//! `min(distance/1000s, 200ms)` — ~100ms for a typical ~100px tick —
+//! restarting from zero velocity with an ease-in-out every time. Ticks
+//! arriving slower than the animation length (a human rolling the wheel
+//! at a moderate pace) therefore produce isolated stop-start pulses
+//! instead of a continuous glide. Chromium instead uses an
+//! inverse-delta duration (small deltas animate *longer*, 100-200ms)
+//! and, crucially, retargets a running animation with a cubic-bezier
+//! whose initial slope preserves the current velocity
+//! (`cc/animation/scroll_offset_animation_curve.cc`), so consecutive
+//! ticks fuse into one continuous velocity curve. That difference is
+//! measurable: on the same 16-tick input, WebKit's animator yields six
+//! separate ~100ms pulses with dead gaps; Chromium yields one ~950ms
+//! glide (see `scripts/bench-scroll/`).
+//!
+//! WebKit exposes no tunable for its curve, so hwatu re-implements the
+//! Chromium curve in page JS: a capture-free `wheel` listener claims
+//! *discrete* wheel ticks (integer deltas ≥ 24px, or line/page delta
+//! modes), calls `preventDefault()`, and drives the scroller from
+//! `requestAnimationFrame` with Chromium's exact constants. Precise
+//! touchpad deltas (non-integer, small) are left to the engine, which
+//! already handles them well (instant + kinetic).
+//!
+//! Fail-open by design: the handler bails — leaving native scrolling
+//! intact — when the event is already `defaultPrevented`, not
+//! cancelable, ctrl/alt/meta-modified (zoom and friends), or when no
+//! ancestor can scroll in the delta direction. Any exception inside
+//! the handler is swallowed before `preventDefault`, so a bug degrades
+//! to engine-native scrolling, never to a dead wheel.
+//!
+//! `HWATU_SMOOTH_WHEEL=0` disables the whole thing.
+
+/// See module docs. Constants mirror Chromium
+/// `cc/animation/scroll_offset_animation_curve.cc` (kInverseDelta*)
+/// and `ui/gfx/geometry/cubic_bezier` ease-in-out control points.
+const SMOOTH_WHEEL_JS: &str = r#"(() => {
+  'use strict';
+  if (window.__hwatuSmoothWheel) return;
+  window.__hwatuSmoothWheel = true;
+
+  // Chromium kInverseDelta duration: frames-at-60fps as a function of
+  // distance; small deltas animate longer so slow tick streams overlap.
+  const RAMP_START = 120, RAMP_END = 480, MIN_DUR = 6, MAX_DUR = 12;
+  const SLOPE = (MIN_DUR - MAX_DUR) / (RAMP_END - RAMP_START);
+  const OFFSET = MAX_DUR - RAMP_START * SLOPE;
+  const EPS = 0.01;
+
+  function durationMs(delta) {
+    const frames = Math.min(Math.max(OFFSET + Math.abs(delta) * SLOPE, MIN_DUR), MAX_DUR);
+    return frames * 1000 / 60;
+  }
+
+  // Cubic bezier timing function (CSS semantics: x is time, y is
+  // progress). Newton's method to invert x(s), like Blink/WebKit do.
+  function bezier(x1, y1, x2, y2) {
+    const sx = s => 3*s*(1-s)*(1-s)*x1 + 3*s*s*(1-s)*x2 + s*s*s;
+    const sy = s => 3*s*(1-s)*(1-s)*y1 + 3*s*s*(1-s)*y2 + s*s*s;
+    const dx = s => 3*(1-s)*(1-s)*x1 + 6*s*(1-s)*(x2-x1) + 3*s*s*(1-x2);
+    const dy = s => 3*(1-s)*(1-s)*y1 + 6*s*(1-s)*(y2-y1) + 3*s*s*(1-y2);
+    function solve(t) {
+      let s = t;
+      for (let i = 0; i < 8; i++) {
+        const err = sx(s) - t, d = dx(s);
+        if (Math.abs(err) < 1e-6 || Math.abs(d) < 1e-6) break;
+        s -= err / d;
+      }
+      return Math.min(Math.max(s, 0), 1);
+    }
+    return {
+      value(t) { return t <= 0 ? 0 : t >= 1 ? 1 : sy(solve(t)); },
+      slope(t) { const s = solve(Math.min(Math.max(t, 0), 1)); const d = dx(s); return d ? dy(s) / d : 0; },
+    };
+  }
+
+  const easeInOut = () => bezier(0.42, 0, 0.58, 1);
+  // Chromium EaseInOutWithInitialSlope: scale the first control point
+  // so the curve starts at the previous animation's velocity.
+  function easeWithSlope(slope) {
+    slope = Math.min(Math.max(slope, -1000), 1000);
+    return bezier(0.42, 0.42 * slope, 0.58, 1);
+  }
+
+  // One live animation per scroller. Usually a single entry (the root).
+  const anims = new Map();
+  let rafId = 0;
+
+  const maxScroll = (el, h) => h ? el.scrollWidth - el.clientWidth : el.scrollHeight - el.clientHeight;
+  const getPos = (el, h) => h ? el.scrollLeft : el.scrollTop;
+  function setPos(el, h, v) {
+    // scrollTo with explicit behavior so a page-set
+    // `scroll-behavior: smooth` can't stack its own animation on ours.
+    el.scrollTo(h ? { left: v, behavior: 'instant' } : { top: v, behavior: 'instant' });
+  }
+
+  function tick(now) {
+    rafId = 0;
+    for (const [el, a] of anims) {
+      const t = Math.min((now - a.start) / a.dur, 1);
+      setPos(el, a.horiz, a.from + (a.to - a.from) * a.curve.value(t));
+      if (t >= 1) anims.delete(el);
+    }
+    if (anims.size) rafId = requestAnimationFrame(tick);
+  }
+  const ensureRaf = () => { if (!rafId) rafId = requestAnimationFrame(tick); };
+
+  function isScrollable(el, h) {
+    if ((h ? el.scrollWidth - el.clientWidth : el.scrollHeight - el.clientHeight) <= 0) return false;
+    const o = h ? getComputedStyle(el).overflowX : getComputedStyle(el).overflowY;
+    return o === 'auto' || o === 'scroll';
+  }
+
+  // Nearest ancestor that can still move in `dir`. A scroller we're
+  // already animating stays latched until its animation *target* (not
+  // its current position) hits the extent, so a fast tick stream
+  // doesn't leak into the parent mid-glide.
+  function scrollTarget(node, h, dir) {
+    const root = document.scrollingElement;
+    let el = node instanceof Element ? node : root;
+    for (; el; el = el.parentElement) {
+      if (el !== root && !isScrollable(el, h)) continue;
+      const a = anims.get(el);
+      const eff = a && a.horiz === h ? a.to : getPos(el, h);
+      if (dir > 0 ? eff < maxScroll(el, h) - 1 : eff > 1) return el;
+    }
+    return null;
+  }
+
+  // Discrete wheel ticks come from WebKitGTK as sparse integer deltas
+  // (~100px). Precise touchpad deltas are frequent non-integer floats;
+  // those keep the engine's native instant+kinetic path.
+  function isDiscrete(e) {
+    if (e.deltaMode !== 0) return true;
+    return Number.isInteger(e.deltaY) && Number.isInteger(e.deltaX)
+        && Math.abs(e.deltaY || e.deltaX) >= 24;
+  }
+
+  function animateBy(el, horiz, delta) {
+    const now = performance.now();
+    const max = maxScroll(el, horiz);
+    const cur = getPos(el, horiz);
+    let a = anims.get(el);
+    if (a && a.horiz !== horiz) { anims.delete(el); a = null; }
+
+    const target = Math.min(Math.max((a ? a.to : cur) + delta, 0), max);
+    if (!a) {
+      if (Math.abs(target - cur) < EPS) return;
+      anims.set(el, { horiz, from: cur, to: target, start: now,
+                      dur: durationMs(target - cur), curve: easeInOut() });
+      ensureRaf();
+      return;
+    }
+
+    // Chromium UpdateTarget: retarget from the current curve position,
+    // preserving velocity via the initial-slope bezier, with the
+    // velocity-based duration bound to avoid rubber-banding.
+    const t = Math.min((now - a.start) / a.dur, 1);
+    const pos = a.from + (a.to - a.from) * a.curve.value(t);
+    const vel = a.curve.slope(t) * (a.to - a.from) / a.dur; // px/ms
+    const newDelta = target - pos;
+    if (Math.abs(newDelta) < EPS) { anims.delete(el); setPos(el, horiz, target); return; }
+
+    let dur = durationMs(newDelta);
+    if (Math.abs(vel) > EPS) {
+      const bound = (newDelta / vel) * 2.5;
+      if (bound >= 0) dur = Math.min(dur, bound);
+    }
+    if (dur < 1) { anims.delete(el); setPos(el, horiz, target); return; }
+
+    a.from = pos; a.to = target; a.start = now; a.dur = dur;
+    a.curve = easeWithSlope(vel * dur / newDelta);
+    ensureRaf();
+  }
+
+  addEventListener('wheel', e => {
+    try {
+      if (e.defaultPrevented || !e.cancelable) return;
+      if (e.ctrlKey || e.altKey || e.metaKey) return; // zoom & friends
+      if (!isDiscrete(e)) return;
+
+      let dx = e.deltaX, dy = e.deltaY;
+      if (e.deltaMode === 1) { dx *= 40; dy *= 40; }
+      else if (e.deltaMode === 2) { dx *= innerWidth; dy *= innerHeight; }
+      if (e.shiftKey && !dx) { dx = dy; dy = 0; }
+
+      const horiz = Math.abs(dx) > Math.abs(dy);
+      const delta = horiz ? dx : dy;
+      if (!delta) return;
+
+      const el = scrollTarget(e.target, horiz, delta > 0 ? 1 : -1);
+      if (!el) return; // nothing scrollable: stay native
+
+      e.preventDefault();
+      animateBy(el, horiz, delta);
+    } catch (_) {
+      // Fail open: native scrolling still works if we blow up.
+    }
+  }, { passive: false });
+
+  // Other input takes over instantly: don't fight keys, drags, or
+  // touches with a stale glide.
+  for (const ev of ['keydown', 'mousedown', 'touchstart']) {
+    addEventListener(ev, () => { anims.clear(); }, { capture: true, passive: true });
+  }
+})();"#;
+
+/// True unless `HWATU_SMOOTH_WHEEL` explicitly disables the animator.
+fn enabled() -> bool {
+    !matches!(
+        std::env::var("HWATU_SMOOTH_WHEEL").as_deref(),
+        Ok("0") | Ok("off") | Ok("false")
+    )
+}
+
+/// Inject the wheel animator into a WebView. Must run on every view
+/// (prewarm pool and popups) before page content loads, same contract
+/// as `console::wire_view`.
+pub fn wire_view(view: &webkit6::WebView) {
+    use webkit6::prelude::*;
+    if !enabled() {
+        return;
+    }
+    let Some(ucm) = view.user_content_manager() else {
+        return;
+    };
+    let script = webkit6::UserScript::new(
+        SMOOTH_WHEEL_JS,
+        webkit6::UserContentInjectedFrames::AllFrames,
+        webkit6::UserScriptInjectionTime::Start,
+        &[],
+        &[],
+    );
+    ucm.add_script(&script);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The env gate must treat only explicit "0"/"off"/"false" as off;
+    /// absence and anything else keep the animator on.
+    #[test]
+    fn env_gate_semantics() {
+        // Not set in the test env by default.
+        std::env::remove_var("HWATU_SMOOTH_WHEEL");
+        assert!(enabled());
+        std::env::set_var("HWATU_SMOOTH_WHEEL", "0");
+        assert!(!enabled());
+        std::env::set_var("HWATU_SMOOTH_WHEEL", "off");
+        assert!(!enabled());
+        std::env::set_var("HWATU_SMOOTH_WHEEL", "1");
+        assert!(enabled());
+        std::env::remove_var("HWATU_SMOOTH_WHEEL");
+    }
+
+    /// The injected script must keep its fail-open shape: bail on
+    /// non-cancelable/prevented events before any preventDefault.
+    #[test]
+    fn script_fails_open() {
+        assert!(SMOOTH_WHEEL_JS.contains("e.defaultPrevented || !e.cancelable"));
+        // preventDefault must appear after the discrete/scrollable
+        // guards in the handler body.
+        let handler = SMOOTH_WHEEL_JS.split("addEventListener('wheel'").nth(1).unwrap();
+        let pd = handler.find("e.preventDefault()").unwrap();
+        let discrete = handler.find("isDiscrete").unwrap();
+        let target = handler.find("scrollTarget").unwrap();
+        assert!(discrete < pd && target < pd);
+    }
+}

--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -262,7 +262,10 @@ mod tests {
         assert!(SMOOTH_WHEEL_JS.contains("e.defaultPrevented || !e.cancelable"));
         // preventDefault must appear after the discrete/scrollable
         // guards in the handler body.
-        let handler = SMOOTH_WHEEL_JS.split("addEventListener('wheel'").nth(1).unwrap();
+        let handler = SMOOTH_WHEEL_JS
+            .split("addEventListener('wheel'")
+            .nth(1)
+            .unwrap();
         let pd = handler.find("e.preventDefault()").unwrap();
         let discrete = handler.find("isDiscrete").unwrap();
         let target = handler.find("scrollTarget").unwrap();

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -261,6 +261,7 @@ pub fn build_webview() -> webkit6::WebView {
     apply_view_settings(&view);
     crate::console::wire_view(&view);
     crate::clock::wire_view(&view);
+    crate::smoothwheel::wire_view(&view);
     view
 }
 
@@ -425,6 +426,7 @@ impl BrowserWindow {
         apply_view_settings(&webview);
         crate::console::wire_view(&webview);
         crate::clock::wire_view(&webview);
+        crate::smoothwheel::wire_view(&webview);
         self.daemon.adblock.apply_to(&webview);
         let popup = Self::build(
             &self.daemon,

--- a/scripts/bench-scroll/.gitignore
+++ b/scripts/bench-scroll/.gitignore
@@ -1,0 +1,3 @@
+trace-*.json
+*.log
+results.jsonl

--- a/scripts/bench-scroll/analyze-smoothness.py
+++ b/scripts/bench-scroll/analyze-smoothness.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Analyze a scroll smoothness trace (from smoothness.html).
+
+Input: JSON {wheel: [{t, dy, dx, mode}], frames: [{t, y}]} on stdin
+or as a file argument.
+
+Reports, per wheel tick and overall:
+  - px moved per tick (settled displacement)
+  - time from wheel event to first scrollY change (input latency)
+  - animation duration (first movement -> settle)
+  - velocity profile smoothness: number of frames where scrollY jumps
+    by more than 2x the local median step (jerk), and stalls (frames
+    where an active animation moved 0px)
+"""
+import json
+import statistics
+import sys
+
+
+def main() -> None:
+    raw = open(sys.argv[1]).read() if len(sys.argv) > 1 else sys.stdin.read()
+    data = json.loads(raw)
+    wheel = data["wheel"]
+    frames = data["frames"]
+    if not wheel or not frames:
+        print("empty trace")
+        return
+
+    # Frame-to-frame movement.
+    moves = []  # (t, dt, dy)
+    for a, b in zip(frames, frames[1:]):
+        moves.append((b["t"], b["t"] - a["t"], b["y"] - a["y"]))
+
+    total_px = frames[-1]["y"] - frames[0]["y"]
+    n_ticks = len(wheel)
+    print(f"wheel events: {n_ticks}  (deltaMode={wheel[0]['mode']}, "
+          f"dy values: {sorted(set(w['dy'] for w in wheel))})")
+    print(f"net scroll: {total_px:.0f}px  -> {total_px / n_ticks:.1f} px/tick")
+
+    # Input latency: per wheel event, time until the next scrollY change.
+    lats = []
+    for w in wheel:
+        for t, _dt, dy in moves:
+            if t > w["t"] and dy != 0:
+                lats.append(t - w["t"])
+                break
+    if lats:
+        print(f"wheel->movement latency ms: median={statistics.median(lats):.1f} "
+              f"p95={sorted(lats)[int(len(lats) * 0.95)]:.1f} max={max(lats):.1f}")
+
+    # Movement episodes: consecutive frames with dy != 0 (allow 1-frame gaps).
+    episodes = []
+    cur = None
+    gap = 0
+    for t, dt, dy in moves:
+        if dy != 0:
+            if cur is None:
+                cur = {"start": t - dt, "end": t, "px": dy, "steps": [dy], "stalls": 0}
+            else:
+                cur["end"] = t
+                cur["px"] += dy
+                cur["steps"].append(dy)
+                cur["stalls"] += gap
+            gap = 0
+        elif cur is not None:
+            gap += 1
+            if gap > 2:
+                episodes.append(cur)
+                cur = None
+                gap = 0
+    if cur:
+        episodes.append(cur)
+
+    print(f"movement episodes: {len(episodes)}")
+    for i, ep in enumerate(episodes):
+        dur = ep["end"] - ep["start"]
+        steps = ep["steps"]
+        peak = max(abs(s) for s in steps)
+        med = statistics.median(abs(s) for s in steps)
+        # Jerk: frame steps that spike above 2.5x the episode median.
+        jerks = sum(1 for s in steps if abs(s) > 2.5 * med) if med else 0
+        print(f"  ep{i}: {ep['px']:+.0f}px over {dur:.0f}ms "
+              f"({len(steps)} frames, med step {med:.1f}px, peak {peak:.1f}px, "
+              f"jerky frames {jerks}, mid-anim stall frames {ep['stalls']})")
+
+    # Frame cadence during movement.
+    move_dts = [dt for _t, dt, dy in moves if dy != 0]
+    if move_dts:
+        med = statistics.median(move_dts)
+        print(f"frame cadence while scrolling: median {med:.1f}ms "
+              f"(~{1000 / med:.0f}fps), p95 {sorted(move_dts)[int(len(move_dts) * 0.95)]:.1f}ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-scroll/bench-matrix.sh
+++ b/scripts/bench-scroll/bench-matrix.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run the scroll benchmark across a matrix of env configs.
+# Each config gets a fresh isolated hwatud (private XDG_RUNTIME_DIR socket).
+# Usage: bench-matrix.sh [results.jsonl]
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="${1:-$HERE/results.jsonl}"
+SCRATCH="${BENCH_SCRATCH:-${JCODE_SCRATCH_DIR:-/tmp}/hwatu-scroll-bench}"
+HWATUD="${HWATUD_BIN:-$HOME/.local/bin/hwatud}"
+mkdir -p "$SCRATCH"
+: > "$OUT"
+
+bench_config() {
+  local label="$1"; shift
+  local dir="$SCRATCH/$label"
+  mkdir -p "$dir"
+  rm -f "$dir/hwatu.sock"
+  echo "=== $label: $* ===" >&2
+  env XDG_RUNTIME_DIR="$dir" WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
+      HWATU_AGENT_MODE=normal HWATU_DISCARD_SECS=9999 "$@" \
+      "$HWATUD" > "$dir/daemon.log" 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 50); do
+    [ -S "$dir/hwatu.sock" ] && break
+    sleep 0.2
+  done
+  if [ ! -S "$dir/hwatu.sock" ]; then
+    echo "{\"label\": \"$label\", \"error\": \"daemon failed to start\"}" >> "$OUT"
+    kill "$pid" 2>/dev/null
+    return
+  fi
+  sleep 1
+  if ! "$HERE/bench-one.sh" "$dir" "$label" >> "$OUT" 2>"$dir/bench.err"; then
+    echo "{\"label\": \"$label\", \"error\": \"bench failed: $(tail -1 "$dir/bench.err" | tr '"' "'")\"}" >> "$OUT"
+  fi
+  XDG_RUNTIME_DIR="$dir" hwatu quit >/dev/null 2>&1
+  sleep 0.5
+  kill "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+}
+
+bench_config baseline HWATU_BENCH_NOOP=1
+bench_config throttle-144 WEBKIT_DISPLAY_REFRESH_THROTTLE_FPS=144
+bench_config damage-on WEBKIT_DISPLAY_REFRESH_THROTTLE_FPS=144 HWATU_WEBKIT_FEATURES=PropagateDamagingInformation:on
+bench_config damage-show WEBKIT_DISPLAY_REFRESH_THROTTLE_FPS=144 WEBKIT_SHOW_DAMAGE=1 HWATU_WEBKIT_FEATURES=PropagateDamagingInformation:on
+bench_config throttle-144-asyncscroll WEBKIT_DISPLAY_REFRESH_THROTTLE_FPS=144 HWATU_WEBKIT_FEATURES=AsyncFrameScrolling:on,ThreadedScrolling:on
+bench_config kitchen-sink WEBKIT_DISPLAY_REFRESH_THROTTLE_FPS=144 HWATU_WEBKIT_FEATURES=AsyncFrameScrolling:on,ThreadedScrolling:on,PropagateDamagingInformation:on WEBKIT_SKIA_GPU_PAINTING_THREADS=4
+
+echo "--- results ---"
+cat "$OUT"

--- a/scripts/bench-scroll/bench-one.sh
+++ b/scripts/bench-scroll/bench-one.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Scroll/render FPS benchmark for one hwatud instance.
+# Usage: bench-one.sh <runtime_dir> <label>
+# Talks to the daemon whose socket lives in <runtime_dir>/hwatu.sock.
+# Opens the fixture page, measures idle rAF cadence and rAF cadence
+# during a continuous programmatic scroll, prints one JSON line.
+set -euo pipefail
+RUNTIME_DIR="$1"
+LABEL="$2"
+FIXTURE="file://$(cd "$(dirname "$0")" && pwd)/fixture.html"
+HWATU="${HWATU_BIN:-hwatu}"
+
+run() { XDG_RUNTIME_DIR="$RUNTIME_DIR" "$HWATU" "$@"; }
+
+out=$(run --focus "$FIXTURE" 2>&1)
+id=$(echo "$out" | grep -oP 'window \K[0-9]+' | head -1)
+run wait-load --id "$id" --until settled >/dev/null
+sleep 1
+
+result=$(run eval --id "$id" --timeout-ms 20000 '
+(async () => {
+  const stats = arr => {
+    const d = arr.slice().sort((a,b)=>a-b);
+    const mean = d.reduce((a,b)=>a+b,0)/d.length;
+    return { fps: +(1000/mean).toFixed(1),
+             median_ms: +d[Math.floor(d.length/2)].toFixed(2),
+             p95_ms: +d[Math.floor(d.length*0.95)].toFixed(2),
+             max_ms: +d[d.length-1].toFixed(2),
+             long_frames: d.filter(x => x > 1.6*d[Math.floor(d.length/2)]).length };
+  };
+  const raf_deltas = async (n, work) => {
+    const ts = [];
+    await new Promise(res => {
+      function tick(t){
+        ts.push(t);
+        if (work) work();
+        if (ts.length < n) requestAnimationFrame(tick); else res();
+      }
+      requestAnimationFrame(tick);
+    });
+    const out = [];
+    for (let i=1;i<ts.length;i++) out.push(ts[i]-ts[i-1]);
+    return out;
+  };
+  // Warmup.
+  await raf_deltas(30);
+  // Idle cadence.
+  const idle = await raf_deltas(240);
+  // Continuous scroll: 8px per frame down, like a slow wheel drag.
+  window.scrollTo(0, 0);
+  const scroll = await raf_deltas(480, () => window.scrollBy(0, 12));
+  window.scrollTo(0, 0);
+  return JSON.stringify({ idle: stats(idle), scroll: stats(scroll) });
+})()')
+
+run close "$id" >/dev/null 2>&1 || true
+# eval returns a JSON-encoded string; unwrap it.
+echo "{\"label\": \"$LABEL\", \"result\": $(echo "$result" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()))')}"

--- a/scripts/bench-scroll/fixture.html
+++ b/scripts/bench-scroll/fixture.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>hwatu scroll bench</title>
+<style>
+  body { margin: 0; font: 16px/1.5 sans-serif; background: #fafafa; }
+  header { position: fixed; top: 0; left: 0; right: 0; height: 56px;
+           background: rgba(20,20,30,.85); backdrop-filter: blur(8px);
+           color: #fff; display: flex; align-items: center; padding: 0 20px;
+           z-index: 10; box-shadow: 0 2px 8px rgba(0,0,0,.3); }
+  main { padding: 76px 10vw 40px; }
+  .card { background: #fff; border-radius: 12px; padding: 24px; margin: 18px 0;
+          box-shadow: 0 1px 4px rgba(0,0,0,.12); }
+  .grad { height: 120px; border-radius: 8px; margin: 12px 0;
+          background: linear-gradient(120deg, #7c3aed, #06b6d4, #f59e0b); }
+  .row { display: flex; gap: 12px; }
+  .row div { flex: 1; height: 80px; border-radius: 8px; background: #e2e8f0; }
+</style>
+</head>
+<body>
+<header>hwatu scroll benchmark fixture</header>
+<main id="main"></main>
+<script>
+  const main = document.getElementById('main');
+  let html = '';
+  for (let i = 0; i < 300; i++) {
+    html += `<div class="card"><h2>Section ${i}</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+      odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+      quis sem at nibh elementum imperdiet. Duis sagittis ipsum.</p>
+      <div class="grad"></div>
+      <div class="row"><div></div><div></div><div></div></div></div>`;
+  }
+  main.innerHTML = html;
+</script>
+</body>
+</html>

--- a/scripts/bench-scroll/serve-trace.py
+++ b/scripts/bench-scroll/serve-trace.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Tiny same-origin server for smoothness.html A/B runs.
+
+Serves this directory over HTTP and accepts POST /trace, writing the
+body to the file given as argv[2]. Exits after one trace is received.
+Usage: serve-trace.py <port> <out.json>
+"""
+import http.server
+import pathlib
+import sys
+import threading
+
+PORT = int(sys.argv[1])
+OUT = pathlib.Path(sys.argv[2])
+HERE = pathlib.Path(__file__).parent
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *a, **kw):
+        super().__init__(*a, directory=str(HERE), **kw)
+
+    def do_POST(self):
+        if self.path != "/trace":
+            self.send_error(404)
+            return
+        n = int(self.headers.get("Content-Length", 0))
+        OUT.write_bytes(self.rfile.read(n))
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+    def log_message(self, *a):
+        pass
+
+
+http.server.ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/scripts/bench-scroll/smoothness.html
+++ b/scripts/bench-scroll/smoothness.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<!-- Wheel-scroll smoothness recorder.
+     Records every wheel event (t, deltaY, deltaMode) and samples
+     scrollY on every rAF. Read back via `hwatu eval` (window.__scrollTrace)
+     or, when loaded with ?post=<url>, POSTs the JSON there after 1.5s
+     of quiet. Used to compare hwatu's scroll curve against helium's. -->
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body { margin: 0; height: 60000px;
+         background: repeating-linear-gradient(#123, #789 400px, #123 800px); }
+  #hud { position: fixed; top: 8px; left: 8px; color: #fff;
+         font: 14px monospace; background: rgba(0,0,0,.6); padding: 6px; }
+</style>
+</head>
+<body>
+<div id="hud">waiting for wheel…</div>
+<script>
+(() => {
+  const wheel = [];
+  const frames = [];
+  let lastActivity = 0;
+  let posted = false;
+
+  addEventListener('wheel', e => {
+    wheel.push({ t: performance.now(), dy: e.deltaY, dx: e.deltaX, mode: e.deltaMode });
+    lastActivity = performance.now();
+    document.getElementById('hud').textContent =
+      `wheel ${wheel.length}  dy=${e.deltaY} mode=${e.deltaMode}`;
+  }, { passive: true });
+
+  let lastY = -1;
+  function tick(t) {
+    const y = scrollY;
+    frames.push({ t, y });
+    if (frames.length > 20000) frames.shift();
+    if (y !== lastY) { lastY = y; lastActivity = performance.now(); }
+    maybePost();
+    requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+
+  window.__scrollTrace = () => JSON.stringify({ wheel, frames });
+
+  const postUrl = new URLSearchParams(location.search).get('post');
+  function maybePost() {
+    if (!postUrl || posted || !wheel.length) return;
+    if (performance.now() - lastActivity < 1500) return;
+    posted = true;
+    fetch(postUrl, { method: 'POST', body: window.__scrollTrace() })
+      .then(() => document.getElementById('hud').textContent = 'posted ✓')
+      .catch(err => document.getElementById('hud').textContent = 'post failed: ' + err);
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #13

The published v0.6.0 and earlier binaries predate the onboarding CLI, so `hwatu doctor` and `hwatu setup` were parsed as browser searches. Current main already routes these commands to onboarding; this change extracts that dispatch predicate and adds regression coverage so future CLI changes cannot send them through URL parsing.

Validation:
- `cargo test -p hwatu`
- `cargo test --workspace`
- `cargo run -q -p hwatu -- setup --client generic --scope project --dry-run`
- `rustfmt --check crates/hwatu/src/main.rs`