### PR TITLE
test: align expect --visible suite with observational visibility semantics

### DIFF
--- a/scripts/test-expect-visible.sh
+++ b/scripts/test-expect-visible.sh
@@ -37,7 +37,7 @@ cat >"$page" <<'HTML'
 <style>
   body { margin: 0; }
   #target { position: absolute; top: 1200px; left: 40px; width: 240px; height: 80px; }
-  #cover { display: none; position: fixed; z-index: 10; background: #111; color: white; }
+  #cover { display: none; position: absolute; z-index: 10; background: #111; color: white; }
 </style>
 <button id="target">Target</button>
 <div id="cover">sticky cover</div>
@@ -46,17 +46,25 @@ HTML
 id="$($bin/hwatu --headless "file://$page" | sed -n 's/^window \([0-9][0-9]*\).*/\1/p')"
 "$bin/hwatu" wait-load --id "$id" --until dom >/dev/null
 
-# Fully off-screen targets are scrolled into view before hit testing.
-"$bin/hwatu" expect --id "$id" '#target' --visible --timeout-ms 250 >/dev/null
+# Fully off-screen targets are scrolled into view for hit testing, but the
+# inspection is observational: the caller's scroll position is restored
+# afterwards, so scrollY must remain 0 while the diagnostics report the
+# internal scroll happened and was undone.
+out="$("$bin/hwatu" expect --id "$id" '#target' --visible --timeout-ms 250)"
 scroll_y="$($bin/hwatu eval --id "$id" 'scrollY')"
-python3 - "$scroll_y" <<'PY'
+python3 - "$out" "$scroll_y" <<'PY'
 import json, sys
-assert json.loads(sys.argv[1]) > 0, sys.argv[1]
+vis = json.loads(sys.argv[1])["visibility"]
+assert vis["scrolled"] is True, vis
+assert vis["scroll_restored"] is True, vis
+assert json.loads(sys.argv[2]) == 0, sys.argv[2]
 PY
 
 # Cover only the target's top edge. A center-only test would pass, while
-# the top-corner samples must identify the partial overlap.
-"$bin/hwatu" eval --id "$id" 'const t=document.querySelector("#target").getBoundingClientRect(); const c=document.querySelector("#cover"); Object.assign(c.style,{display:"block",left:t.left+"px",top:t.top+"px",width:t.width+"px",height:"16px"}); return true;' >/dev/null
+# the top-corner samples must identify the partial overlap. The cover is
+# absolutely positioned in document coordinates so it still overlaps the
+# target during the inspector's internal (restored) scroll-into-view.
+"$bin/hwatu" eval --id "$id" 'const t=document.querySelector("#target").getBoundingClientRect(); const c=document.querySelector("#cover"); Object.assign(c.style,{display:"block",left:(t.left+scrollX)+"px",top:(t.top+scrollY)+"px",width:t.width+"px",height:"16px"}); return true;' >/dev/null
 if "$bin/hwatu" expect --id "$id" '#target' --visible --timeout-ms 0 >"$work/out" 2>&1; then
     echo "FAIL - partially covered element passed --visible" >&2
     cat "$work/out" >&2


### PR DESCRIPTION
Fixes #12.

## Root cause
Not a child-compositor behavioural difference. Since 54fd34d ("fix: make visibility checks observational") the visibility inspector scrolls fully off-screen targets into view internally, hit-tests, then **restores** the caller's scroll position. `test-expect-visible.sh` was written against the pre-54fd34d behaviour and still asserted `scrollY > 0` after `expect --visible`, so its first assertion fails deterministically on every machine (reproduced locally on x86_64), not just the display-free aarch64 VM. The other 8 suites do not touch this path, which is why only this one failed.

## Fix (test-only)
- Assert the new contract instead: diagnostics report `scrolled: true` and `scroll_restored: true`, while `scrollY` stays `0`.
- The occlusion step depended on the old leaked scroll: it placed a `position:fixed` cover at the target's viewport rect measured at `scrollY=0`, which no longer overlaps the target during the inspector's internal scroll. The cover is now absolutely positioned in document coordinates (`t.left+scrollX`, `t.top+scrollY`) so the partial-overlap case is still exercised.

## Validation
- `scripts/test-expect-visible.sh`: 3 passed, 0 failed (was failing at the first assertion on origin/main).
- `scripts/test-expect-watch.sh`: 4 passed.
- `scripts/test-display-free.sh`: 19 passed.
