### PR TITLE
clone: one-shot faithful page copy with measured verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ name = "hwatu"
 version = "0.6.0"
 dependencies = [
  "hwatu-ipc",
+ "png",
  "serde_json",
 ]
 

--- a/crates/hwatu/Cargo.toml
+++ b/crates/hwatu/Cargo.toml
@@ -13,3 +13,5 @@ readme = "../../README.md"
 [dependencies]
 hwatu-ipc = { path = "../ipc", version = "0.6.0" }
 serde_json = "1"
+# `hwatu clone` crops engine screenshots for blank WebGL canvases.
+png = "0.17"

--- a/crates/hwatu/assets/extract.js
+++ b/crates/hwatu/assets/extract.js
@@ -102,18 +102,28 @@ document.querySelectorAll('video[poster]').forEach(el => { const u = abs(el.getA
 // Inner scroll positions (carousels, code panes). Restored by a tiny
 // inline script the materializer appends, since scroll-snap can land
 // the clone's scrollers on a different snap point.
+// Two phases — read everything, then write the data attributes —
+// because a dataset write invalidates style and turns the next
+// element's layout read into a full recalc: interleaved, this loop is
+// O(n²) on JS-heavy DOMs (scale.com-sized pages blow the eval budget).
 const scrolls = [];
 {
-  let i = 0;
-  for (const el of document.querySelectorAll('*')) {
+  const MAX_SCAN = 60000; // huge DOMs: cap the walk, report the truth below
+  const all = document.querySelectorAll('*');
+  const n = Math.min(all.length, MAX_SCAN);
+  const found = [];
+  for (let k = 0; k < n; k++) {
+    const el = all[k];
     // Record every scrollable box, including ones at 0: scroll-snap in
     // the clone can otherwise pick a different initial snap point.
     const scrollable = el.scrollWidth > el.clientWidth + 4 || el.scrollHeight > el.clientHeight + 4;
     if (!scrollable || el === document.documentElement || el === document.body) continue;
-    el.dataset.hwatuScroll = i;
-    scrolls.push({ i, left: el.scrollLeft, top: el.scrollTop });
-    i++;
+    found.push([el, el.scrollLeft, el.scrollTop]);
   }
+  found.forEach(([el, left, top], i) => {
+    el.dataset.hwatuScroll = i;
+    scrolls.push({ i, left, top });
+  });
 }
 
 // 3.5 Pin transition state. Rules like `max-height: var(--max-height)`
@@ -134,8 +144,15 @@ const covers = (declared, pin) => declared === 'all' || pin === declared || pin.
 // responsive CSS instead of wearing this width's measurements.
 const pins = [];
 {
-  let pinId = 0;
-  for (const el of document.querySelectorAll('*')) {
+  // Same two-phase discipline as the scroll walk above: all
+  // getComputedStyle reads first, all dataset writes after, or the
+  // style invalidation makes this O(n²) on large DOMs.
+  const MAX_SCAN = 60000;
+  const all = document.querySelectorAll('*');
+  const n = Math.min(all.length, MAX_SCAN);
+  const found = [];
+  for (let k = 0; k < n; k++) {
+    const el = all[k];
     const st = getComputedStyle(el);
     const hasTransition = st.transitionProperty && !st.transitionDuration.split(',').every(d => parseFloat(d) === 0);
     // CSS animation state does not survive serialization: the clone
@@ -157,12 +174,12 @@ const pins = [];
       const v = st.getPropertyValue(p);
       if (v) decls.push(`${p}: ${v} !important`);
     }
-    if (decls.length) {
-      el.dataset.hwatuPin = pinId;
-      pins.push({ i: pinId, css: decls.join('; ') });
-      pinId++;
-    }
+    if (decls.length) found.push([el, decls.join('; ')]);
   }
+  found.forEach(([el, css], i) => {
+    el.dataset.hwatuPin = i;
+    pins.push({ i, css });
+  });
 }
 
 // 4. Serialized DOM. Strip scripts (the clone is a static still) and

--- a/crates/hwatu/assets/extract.js
+++ b/crates/hwatu/assets/extract.js
@@ -1,0 +1,193 @@
+// extract.js — runs inside the target page via `hwatu eval`.
+// Async: sweeps the page (priming lazy content + scroll reveals and
+// harvesting canvas frames while they are painted), settles animations
+// (entrance reveals to their END state, infinite loops paused at 0 —
+// pausing everything at 0 freezes reveals at opacity:0 and produces a
+// faithful copy of a broken page), then serializes the rendered DOM.
+return (async () => {
+const canvasFrames = new Map(); // canvas element -> dataURL
+{
+  // Tag canvases up front so frames can be matched later.
+  document.querySelectorAll('canvas').forEach((c, i) => { c.dataset.hwatuCanvas = i; });
+  const harvest = () => {
+    for (const c of document.querySelectorAll('canvas')) {
+      const r = c.getBoundingClientRect();
+      const visible = r.bottom > 0 && r.top < innerHeight && r.width > 0;
+      if (!visible) continue;
+      try {
+        const data = c.toDataURL('image/png');
+        // Keep the largest capture (later frames of a lazy canvas
+        // usually have more drawn on them than the first).
+        const prev = canvasFrames.get(c);
+        if (!prev || data.length > prev.length) canvasFrames.set(c, data);
+      } catch (e) { /* tainted */ }
+    }
+  };
+  const H = document.documentElement.scrollHeight;
+  for (let y = 0; y <= H; y += 400) {
+    scrollTo(0, y);
+    await new Promise(r => setTimeout(r, 60));
+    harvest();
+  }
+  scrollTo(0, 0);
+  await new Promise(r => setTimeout(r, 800));
+  harvest();
+}
+// Freeze animation state for a still capture. Just pause, at the
+// current frame: the sweep above already ran entrance reveals to
+// completion naturally, and force-finish()ing is wrong for exclusive
+// states (rotating headlines render every variant at once).
+for (const a of document.getAnimations()) {
+  try { a.pause(); } catch (e) { /* infinite timeline etc. */ }
+}
+await new Promise(r => setTimeout(r, 200));
+
+// Returns { html, css, assets, canvases, base } as JSON.
+// Serializes the *rendered* DOM so JS-built content survives without
+// re-running the site's scripts locally.
+
+// 1. Collect every rule the page actually loaded, via CSSOM.
+//    Cross-origin sheets throw on .cssRules; record their href so the
+//    materializer can fetch them server-side instead.
+const sheets = [];
+for (const sheet of document.styleSheets) {
+  try {
+    const rules = [...sheet.cssRules].map(r => r.cssText).join('\n');
+    sheets.push({ base: sheet.href || location.href, text: rules });
+  } catch (e) {
+    if (sheet.href) sheets.push({ href: sheet.href });
+  }
+}
+
+// 2. Freeze canvases and lazy media into data URLs / concrete attrs.
+const canvases = [];
+document.querySelectorAll('canvas').forEach((c) => {
+  const i = Number(c.dataset.hwatuCanvas);
+  const r = c.getBoundingClientRect();
+  let data = canvasFrames.get(c);
+  if (!data) {
+    try { data = c.toDataURL('image/png'); } catch (e) { data = null; }
+  }
+  // WebGL without preserveDrawingBuffer yields blank data URLs (a few
+  // hundred bytes). Record geometry either way: the driver falls back
+  // to an engine-side screenshot crop for blank ones.
+  canvases.push({
+    i, data, w: Math.round(r.width), h: Math.round(r.height),
+    doc_x: Math.round(r.left + scrollX), doc_y: Math.round(r.top + scrollY),
+    blank: !data || data.length < 2000,
+  });
+});
+// Lazy images: promote data-src/srcset and currentSrc to src.
+document.querySelectorAll('img').forEach(img => {
+  const cur = img.currentSrc || img.src;
+  if (cur) img.setAttribute('src', cur);
+  img.removeAttribute('srcset');
+  img.removeAttribute('data-src');
+  img.setAttribute('loading', 'eager');
+});
+// Videos: pin the poster (frame capture is out of scope for stills).
+document.querySelectorAll('video').forEach(v => {
+  v.removeAttribute('autoplay');
+});
+
+// 3. Asset manifest: everything referenced by the rendered page.
+const assets = new Set();
+const abs = (u) => { try { return new URL(u, location.href).href; } catch (e) { return null; } };
+document.querySelectorAll('img[src]').forEach(el => { const u = abs(el.getAttribute('src')); if (u && !u.startsWith('data:')) assets.add(u); });
+document.querySelectorAll('source[src]').forEach(el => { const u = abs(el.getAttribute('src')); if (u && !u.startsWith('data:')) assets.add(u); });
+document.querySelectorAll('video[poster]').forEach(el => { const u = abs(el.getAttribute('poster')); if (u) assets.add(u); });
+// url(...) references inside the collected CSS (images + fonts).
+
+
+// Inner scroll positions (carousels, code panes). Restored by a tiny
+// inline script the materializer appends, since scroll-snap can land
+// the clone's scrollers on a different snap point.
+const scrolls = [];
+{
+  let i = 0;
+  for (const el of document.querySelectorAll('*')) {
+    // Record every scrollable box, including ones at 0: scroll-snap in
+    // the clone can otherwise pick a different initial snap point.
+    const scrollable = el.scrollWidth > el.clientWidth + 4 || el.scrollHeight > el.clientHeight + 4;
+    if (!scrollable || el === document.documentElement || el === document.body) continue;
+    el.dataset.hwatuScroll = i;
+    scrolls.push({ i, left: el.scrollLeft, top: el.scrollTop });
+    i++;
+  }
+}
+
+// 3.5 Pin transition state. Rules like `max-height: var(--max-height)`
+// gated on JS-managed classes can resolve differently in the clone
+// (hydration state, hover, mid-cycle carousels). For every element
+// that declares a transition, bake the *rendered* values of the
+// transitioned properties into inline style, so the clone shows the
+// exact captured frame of every accordion/reveal/fade.
+const PINNABLE = ['max-height', 'height', 'width', 'max-width', 'opacity', 'transform', 'visibility',
+  'grid-template-rows', 'background-color', 'border-top-color', 'border-right-color',
+  'border-bottom-color', 'border-left-color', 'color', 'box-shadow'];
+// A transition on the shorthand ('background', 'border') covers its
+// longhands, so match by prefix in both directions.
+const covers = (declared, pin) => declared === 'all' || pin === declared || pin.startsWith(declared + '-');
+// Pins are emitted as CSS rules keyed by data attribute, NOT inline
+// styles: the materializer scopes them in a @media block matching the
+// capture width, so other widths fall back to the site's own
+// responsive CSS instead of wearing this width's measurements.
+const pins = [];
+{
+  let pinId = 0;
+  for (const el of document.querySelectorAll('*')) {
+    const st = getComputedStyle(el);
+    const hasTransition = st.transitionProperty && !st.transitionDuration.split(',').every(d => parseFloat(d) === 0);
+    // CSS animation state does not survive serialization: the clone
+    // restarts every cycle at load, so a rotating headline renders all
+    // of its phrases overlapped. Pin the rendered values and kill the
+    // animation instead — the still shows the captured instant.
+    const hasAnimation = st.animationName && st.animationName !== 'none';
+    if (!hasTransition && !hasAnimation) continue;
+    const decls = [];
+    let wanted;
+    if (hasAnimation) {
+      wanted = PINNABLE;
+      decls.push('animation: none !important');
+    } else {
+      const props = st.transitionProperty.split(',').map(p => p.trim());
+      wanted = PINNABLE.filter(p => props.some(d => covers(d, p)));
+    }
+    for (const p of wanted) {
+      const v = st.getPropertyValue(p);
+      if (v) decls.push(`${p}: ${v} !important`);
+    }
+    if (decls.length) {
+      el.dataset.hwatuPin = pinId;
+      pins.push({ i: pinId, css: decls.join('; ') });
+      pinId++;
+    }
+  }
+}
+
+// 4. Serialized DOM. Strip scripts (the clone is a static still) and
+//    live stylesheet links (we inline the CSSOM text instead).
+const doc = document.documentElement.cloneNode(true);
+// Static still: drop scripts (React re-hydration against a serialized
+// post-render DOM tears the layout apart) and stylesheet links (CSSOM
+// text is inlined instead).
+doc.querySelectorAll('script, link[rel=stylesheet], link[rel=preload], link[rel=modulepreload]').forEach(el => el.remove());
+doc.querySelectorAll('noscript').forEach(el => {
+  // Render noscript content: our clone runs without JS.
+  const span = document.createElement('div');
+  span.innerHTML = el.textContent;
+  el.replaceWith(span);
+});
+
+return {
+  base: location.href,
+  title: document.title,
+  html: '<!doctype html>\n' + doc.outerHTML,
+  sheets,
+  assets: [...assets].slice(0, 500),
+  canvases,
+  scrolls,
+  pins,
+  viewport: { w: innerWidth, h: innerHeight, dpr: devicePixelRatio },
+};
+})();

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -1,0 +1,1056 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Justin Hong
+//! `hwatu clone`: one-shot faithful copy of a live page.
+//!
+//! Phase 0 (stills): productizes the `examples/clone/` pipeline that
+//! reached a 100.0% average pixel match across 20 viewport positions
+//! against stripe.com. The flow:
+//!
+//! 1. Open the URL in a headless window, wait for settle, resize to
+//!    the capture viewport.
+//! 2. Run the embedded `extract.js` in the page: sweep-prime lazy
+//!    content and scroll reveals, harvest canvas frames, pause
+//!    animations, then serialize the *rendered* DOM plus CSSOM text,
+//!    an asset manifest, transition-state pins, and inner scroll
+//!    positions.
+//! 3. Blank canvases (WebGL without preserveDrawingBuffer) fall back
+//!    to an engine-side screenshot crop.
+//! 4. Materialize: download assets (curl, parallel), inline fonts as
+//!    data URLs, rewrite URLs to local copies, re-inject canvas
+//!    frames, media-scope the pins to the capture width, restore
+//!    scroll positions, and write a self-contained `index.html`.
+//! 5. Verify (default): open the clone in a second headless window
+//!    and run `Diff` at several scroll offsets against the live
+//!    window; write `report.json` with per-position scores so
+//!    "faithful" is a measured claim.
+//!
+//! Known Phase 0 limits, stated honestly: animations are frozen at
+//! the captured frame (a *still* clone), scripts do not survive (no
+//! interactivity), and cross-origin iframes keep their live URLs.
+
+use hwatu_ipc::{LoadStage, OpenMode, Request, Response};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// The in-page capture script (see module docs). Embedded so `clone`
+/// works from any directory with no sidecar files.
+const EXTRACT_JS: &str = include_str!("../assets/extract.js");
+
+const UA: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 \
+                  (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+const USAGE: &str = "usage: hwatu clone <url> [--out <dir>] [--viewport <WxH>] \
+     [--tolerance <0-255>] [--no-verify] [--keep] [--timeout-ms <ms>]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match Opts::parse(args) {
+        Ok(o) => o,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return 2;
+        }
+    };
+    match clone(&opts) {
+        Ok(summary) => {
+            println!("{summary}");
+            0
+        }
+        Err(msg) => {
+            eprintln!("hwatu: clone: {msg}");
+            1
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Opts {
+    url: String,
+    out: PathBuf,
+    viewport: (i32, i32),
+    tolerance: Option<u8>,
+    verify: bool,
+    keep: bool,
+    timeout_ms: u64,
+}
+
+impl Opts {
+    fn parse(args: &[String]) -> Result<Self, String> {
+        let mut url = None;
+        let mut out = None;
+        let mut viewport = (1920, 1080);
+        let mut tolerance = None;
+        let mut verify = true;
+        let mut keep = false;
+        let mut timeout_ms = 180_000u64;
+        let mut it = args.iter();
+        while let Some(a) = it.next() {
+            match a.as_str() {
+                "--out" => out = Some(PathBuf::from(it.next().ok_or(USAGE)?)),
+                "--viewport" => {
+                    let v = it.next().ok_or(USAGE)?;
+                    let (w, h) = v.split_once(['x', 'X']).ok_or(USAGE)?;
+                    viewport = (
+                        w.trim().parse().map_err(|_| USAGE)?,
+                        h.trim().parse().map_err(|_| USAGE)?,
+                    );
+                }
+                "--tolerance" => {
+                    tolerance = Some(it.next().and_then(|s| s.parse().ok()).ok_or(USAGE)?)
+                }
+                "--no-verify" => verify = false,
+                "--keep" => keep = true,
+                "--timeout-ms" => {
+                    timeout_ms = it.next().and_then(|s| s.parse().ok()).ok_or(USAGE)?
+                }
+                other if url.is_none() && !other.starts_with('-') => url = Some(other.to_string()),
+                other => return Err(format!("unknown argument {other:?}\n{USAGE}")),
+            }
+        }
+        let url = url.ok_or(USAGE)?;
+        // Bare domains navigate like the rest of the CLI.
+        let url = if url.contains("://") {
+            url
+        } else {
+            format!("https://{url}")
+        };
+        let out = out.unwrap_or_else(|| {
+            let host = url
+                .split("://")
+                .nth(1)
+                .unwrap_or(&url)
+                .split(['/', '?'])
+                .next()
+                .unwrap_or("clone");
+            PathBuf::from(format!("{host}-clone"))
+        });
+        Ok(Opts {
+            url,
+            out,
+            viewport,
+            tolerance,
+            verify,
+            keep,
+            timeout_ms,
+        })
+    }
+}
+
+// ---- daemon roundtrips ------------------------------------------------
+
+/// One request, one reply, one connection (the daemon protocol is
+/// one-shot per connection for everything except Subscribe).
+fn call(req: &Request) -> Result<Response, String> {
+    let mut stream = crate::connect_or_spawn().map_err(|e| format!("cannot reach daemon: {e}"))?;
+    let mut payload = serde_json::to_vec(req).expect("serialize request");
+    payload.push(b'\n');
+    stream
+        .write_all(&payload)
+        .map_err(|e| format!("write: {e}"))?;
+    let mut line = String::new();
+    BufReader::new(stream)
+        .read_line(&mut line)
+        .map_err(|e| format!("read: {e}"))?;
+    serde_json::from_str::<Response>(line.trim()).map_err(|e| format!("bad response: {e}"))
+}
+
+/// Like [`call`], but unwraps `Response::Err` into this Err.
+fn call_ok(req: &Request) -> Result<Response, String> {
+    match call(req)? {
+        r @ Response::Ok { .. } => Ok(r),
+        Response::Err { message } => Err(message),
+    }
+}
+
+fn eval(id: u64, js: &str, timeout_ms: u64) -> Result<serde_json::Value, String> {
+    match call_ok(&Request::Eval {
+        id: Some(id),
+        js: js.to_string(),
+        timeout_ms: Some(timeout_ms),
+    })? {
+        Response::Ok { value, .. } => Ok(value.unwrap_or(serde_json::Value::Null)),
+        Response::Err { message } => Err(message),
+    }
+}
+
+fn open_headless(url: &str, timeout_ms: u64) -> Result<u64, String> {
+    let Response::Ok { window, .. } = call_ok(&Request::Open {
+        url: Some(url.to_string()),
+        app_id: None,
+        mode: OpenMode::Headless,
+    })?
+    else {
+        unreachable!("call_ok filters Err")
+    };
+    let id = window.ok_or("open returned no window")?.id;
+    call_ok(&Request::WaitLoad {
+        id: Some(id),
+        until: LoadStage::Settled,
+        timeout_ms: Some(timeout_ms),
+    })?;
+    Ok(id)
+}
+
+fn close(id: u64) {
+    let _ = call(&Request::Close { id });
+}
+
+// ---- the pipeline -----------------------------------------------------
+
+fn clone(opts: &Opts) -> Result<String, String> {
+    std::fs::create_dir_all(opts.out.join("assets"))
+        .map_err(|e| format!("cannot create {}: {e}", opts.out.display()))?;
+
+    eprintln!("clone: opening {} headless...", opts.url);
+    let live = open_headless(&opts.url, opts.timeout_ms)?;
+    // Close on any failure: a leaked headless window is invisible and
+    // therefore never manually cleaned up.
+    let result = clone_with_window(opts, live);
+    if result.is_err() || !opts.keep {
+        close(live);
+    }
+    result
+}
+
+fn clone_with_window(opts: &Opts, live: u64) -> Result<String, String> {
+    call_ok(&Request::Resize {
+        id: Some(live),
+        width: opts.viewport.0,
+        height: opts.viewport.1,
+    })?;
+
+    eprintln!("clone: capturing rendered DOM (sweep + freeze)...");
+    let cap = eval(live, EXTRACT_JS, opts.timeout_ms)?;
+    if cap.get("html").and_then(|v| v.as_str()).is_none() {
+        return Err(format!("capture returned no html: {cap}"));
+    }
+    std::fs::write(
+        opts.out.join("capture.json"),
+        serde_json::to_vec_pretty(&cap).expect("serialize capture"),
+    )
+    .map_err(|e| format!("write capture.json: {e}"))?;
+
+    crop_blank_canvases(&cap, live, &opts.out)?;
+
+    eprintln!("clone: materializing...");
+    let stats = materialize(&cap, &opts.out)?;
+    eprintln!(
+        "clone: fetched {}/{} assets, index.html {} bytes",
+        stats.fetched, stats.wanted, stats.html_bytes
+    );
+
+    let mut summary = format!(
+        "clone written to {} ({}/{} assets)",
+        opts.out.display(),
+        stats.fetched,
+        stats.wanted
+    );
+
+    if opts.verify {
+        eprintln!("clone: verifying against the live page...");
+        let report = verify(opts, live)?;
+        std::fs::write(
+            opts.out.join("report.json"),
+            serde_json::to_vec_pretty(&report).expect("serialize report"),
+        )
+        .map_err(|e| format!("write report.json: {e}"))?;
+        let avg = report
+            .get("average_match_percent")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        summary.push_str(&format!(
+            "\nverify: {avg:.1}% average pixel match ({} positions), report.json written",
+            report
+                .get("positions")
+                .and_then(|v| v.as_array())
+                .map(Vec::len)
+                .unwrap_or(0)
+        ));
+    }
+    Ok(summary)
+}
+
+// ---- blank-canvas fallback (engine screenshot crop) -------------------
+
+/// WebGL canvases without `preserveDrawingBuffer` serialize to blank
+/// data URLs; capture those from the engine instead: scroll the canvas
+/// into view, isolate its paint, screenshot, and crop its rect.
+fn crop_blank_canvases(cap: &serde_json::Value, live: u64, out: &Path) -> Result<(), String> {
+    let canvases = cap.get("canvases").and_then(|v| v.as_array());
+    let blanks: Vec<&serde_json::Value> = canvases
+        .map(|cs| {
+            cs.iter()
+                .filter(|c| c.get("blank").and_then(|b| b.as_bool()) == Some(true))
+                .collect()
+        })
+        .unwrap_or_default();
+    if blanks.is_empty() {
+        return Ok(());
+    }
+    let dpr = cap
+        .pointer("/viewport/dpr")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0);
+    for c in blanks {
+        let (i, w, h) = (
+            c.get("i").and_then(|v| v.as_u64()).unwrap_or(0),
+            c.get("w").and_then(|v| v.as_f64()).unwrap_or(0.0),
+            c.get("h").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        );
+        let doc_x = c.get("doc_x").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let doc_y = c.get("doc_y").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        if w < 1.0 || h < 1.0 {
+            continue;
+        }
+        let scroll_y = (doc_y - 80.0).max(0.0);
+        eval(live, &format!("scrollTo(0,{scroll_y}); return 0"), 10_000)?;
+        // Give rAF draw loops a beat to paint now that it is visible.
+        std::thread::sleep(Duration::from_millis(1200));
+        // Isolate the canvas paint: visibility on ancestors is
+        // overridable by descendants, so the canvas stays visible while
+        // overlaying DOM text does not get baked into the crop.
+        let iso = format!(
+            "const st=document.createElement('style'); st.id='hwatu-iso';\
+             st.textContent='body * {{ visibility: hidden !important }} \
+             [data-hwatu-canvas=\"{i}\"] {{ visibility: visible !important }}';\
+             document.head.appendChild(st); return 1"
+        );
+        eval(live, &iso, 10_000)?;
+        std::thread::sleep(Duration::from_millis(300));
+        let shot = out.join(format!("canvas-shot-{i}.png"));
+        let Response::Ok { path, .. } = call_ok(&Request::Screenshot {
+            id: Some(live),
+            path: Some(shot.to_string_lossy().into_owned()),
+            full: false,
+        })?
+        else {
+            unreachable!()
+        };
+        eval(
+            live,
+            "document.getElementById('hwatu-iso')?.remove(); return 1",
+            10_000,
+        )?;
+        let shot_path = path.map(PathBuf::from).unwrap_or(shot);
+        let dest = out.join("assets").join(format!("canvas-{i}.png"));
+        let vx = (doc_x * dpr).round() as u32;
+        let vy = ((doc_y - scroll_y) * dpr).round() as u32;
+        let cw = (w * dpr).round() as u32;
+        let ch = (h * dpr).round() as u32;
+        match crop_png(&shot_path, vx, vy, cw, ch, &dest) {
+            Ok(()) => eprintln!("clone: canvas {i}: engine crop {cw}x{ch}+{vx}+{vy}"),
+            Err(e) => eprintln!("clone: canvas {i}: crop failed ({e}); left blank"),
+        }
+        let _ = std::fs::remove_file(&shot_path);
+    }
+    eval(live, "scrollTo(0,0); return 0", 10_000)?;
+    Ok(())
+}
+
+/// Crop `src` to `w x h + x + y` and write `dest`. Pure Rust (png
+/// crate); clamps the rect to the image bounds.
+fn crop_png(src: &Path, x: u32, y: u32, w: u32, h: u32, dest: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(src).map_err(|e| format!("open {}: {e}", src.display()))?;
+    let decoder = png::Decoder::new(BufReader::new(file));
+    let mut reader = decoder.read_info().map_err(|e| e.to_string())?;
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buf).map_err(|e| e.to_string())?;
+    let bpp = match info.color_type {
+        png::ColorType::Rgba => 4,
+        png::ColorType::Rgb => 3,
+        other => return Err(format!("unsupported screenshot color type {other:?}")),
+    };
+    let (iw, ih) = (info.width, info.height);
+    let x = x.min(iw.saturating_sub(1));
+    let y = y.min(ih.saturating_sub(1));
+    let w = w.min(iw - x);
+    let h = h.min(ih - y);
+    if w == 0 || h == 0 {
+        return Err("empty crop rect".into());
+    }
+    let row = (iw as usize) * bpp;
+    let mut out_buf = Vec::with_capacity((w as usize) * (h as usize) * bpp);
+    for r in y..y + h {
+        let start = (r as usize) * row + (x as usize) * bpp;
+        out_buf.extend_from_slice(&buf[start..start + (w as usize) * bpp]);
+    }
+    let file =
+        std::fs::File::create(dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
+    let mut enc = png::Encoder::new(std::io::BufWriter::new(file), w, h);
+    enc.set_color(info.color_type);
+    enc.set_depth(png::BitDepth::Eight);
+    let mut writer = enc.write_header().map_err(|e| e.to_string())?;
+    writer
+        .write_image_data(&out_buf)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ---- materialize ------------------------------------------------------
+
+struct MaterializeStats {
+    fetched: usize,
+    wanted: usize,
+    html_bytes: usize,
+}
+
+fn materialize(cap: &serde_json::Value, out: &Path) -> Result<MaterializeStats, String> {
+    let base = cap
+        .get("base")
+        .and_then(|v| v.as_str())
+        .ok_or("capture has no base url")?
+        .to_string();
+    let mut html = cap
+        .get("html")
+        .and_then(|v| v.as_str())
+        .ok_or("capture has no html")?
+        .to_string();
+
+    // 1. Ordered stylesheet list (cascade order matters). Entries are
+    //    {base, text} (read via CSSOM) or {href} (cross-origin: fetch).
+    let mut all_css: Vec<(String, String)> = Vec::new();
+    if let Some(sheets) = cap.get("sheets").and_then(|v| v.as_array()) {
+        for sh in sheets {
+            if let Some(text) = sh.get("text").and_then(|v| v.as_str()) {
+                let sheet_base = sh
+                    .get("base")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&base)
+                    .to_string();
+                all_css.push((sheet_base, text.to_string()));
+            } else if let Some(href) = sh.get("href").and_then(|v| v.as_str()) {
+                match fetch(href) {
+                    Some(body) => {
+                        all_css.push((href.to_string(), String::from_utf8_lossy(&body).into()))
+                    }
+                    None => eprintln!("clone: miss stylesheet {href}"),
+                }
+            }
+        }
+    }
+
+    // 2. Asset set: page manifest + every url(...) in the CSS,
+    //    absolutized against each sheet's own URL.
+    let mut assets: BTreeSet<String> = cap
+        .get("assets")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    let all_css: Vec<(String, String)> = all_css
+        .into_iter()
+        .map(|(b, t)| {
+            let abs = rewrite_css_urls(&t, |u| {
+                if u.starts_with("data:") {
+                    return u.to_string();
+                }
+                match url_join(&b, u) {
+                    Some(a) => {
+                        assets.insert(a.clone());
+                        a
+                    }
+                    None => u.to_string(),
+                }
+            });
+            (b, abs)
+        })
+        .collect();
+
+    // 3. Download in parallel (curl keeps the client crate free of an
+    //    HTTP stack, matching `hwatu update`). Fonts embed as data URLs
+    //    so the real face exists at first paint: a swapping font
+    //    invalidates text layers late, and WebKit blend-mode layers can
+    //    keep the fallback paint, double-exposing headlines.
+    let wanted = assets.len();
+    let mapping = fetch_all(&assets, out);
+    eprintln!("clone: fetched {}/{} assets", mapping.len(), wanted);
+
+    let css_joined = all_css
+        .iter()
+        .map(|(_, t)| t.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut css = rewrite_to_local(&css_joined, &mapping, &base);
+    html = rewrite_to_local(&html, &mapping, &base);
+
+    // 4. Canvas freeze: swap each canvas for its captured frame (data
+    //    URL, or the engine crop written by crop_blank_canvases).
+    if let Some(canvases) = cap.get("canvases").and_then(|v| v.as_array()) {
+        for c in canvases {
+            let i = c.get("i").and_then(|v| v.as_u64()).unwrap_or(0);
+            let w = c.get("w").and_then(|v| v.as_i64()).unwrap_or(0);
+            let h = c.get("h").and_then(|v| v.as_i64()).unwrap_or(0);
+            let crop_rel = format!("assets/canvas-{i}.png");
+            let src = if c.get("blank").and_then(|v| v.as_bool()) == Some(true)
+                && out.join(&crop_rel).exists()
+            {
+                Some(crop_rel)
+            } else {
+                c.get("data").and_then(|v| v.as_str()).map(String::from)
+            };
+            if let Some(src) = src {
+                html = replace_canvas(&html, i, &src, w, h);
+            }
+        }
+    }
+
+    // 5. Media-scoped transition pins: bake this capture's rendered
+    //    transition state, but only near the capture width so other
+    //    widths stay on the site's own responsive CSS.
+    if let Some(pins) = cap.get("pins").and_then(|v| v.as_array()) {
+        if !pins.is_empty() {
+            let vw = cap
+                .pointer("/viewport/w")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            css.push_str(&pin_media_block(pins, vw));
+        }
+    }
+
+    // 6. Scroll restoration + snap disable: scroll-snap in the clone
+    //    can land scrollers on a different snap point than the
+    //    captured frame.
+    if let Some(scrolls) = cap.get("scrolls").and_then(|v| v.as_array()) {
+        if !scrolls.is_empty() {
+            let js = scroll_restore_script(scrolls);
+            if let Some(pos) = html.find("</body>") {
+                html.insert_str(pos, &js);
+            } else {
+                html.push_str(&js);
+            }
+        }
+    }
+
+    // 7. Fonts are inline data URLs (decode is local and fast), so
+    //    font-display:block is free and prevents any fallback first
+    //    paint (WebKit keeps stale fallback paint inside blend-mode
+    //    layers).
+    css = pin_font_display(&css);
+
+    // 8. Inject the inlined CSS and write.
+    let style_block = format!("<style>\n{css}\n</style>");
+    if let Some(pos) = html.find("</head>") {
+        html.insert_str(pos, &style_block);
+    } else {
+        html = format!("{style_block}{html}");
+    }
+    let html_bytes = html.len();
+    std::fs::write(out.join("index.html"), &html).map_err(|e| format!("write index.html: {e}"))?;
+    Ok(MaterializeStats {
+        fetched: mapping.len(),
+        wanted,
+        html_bytes,
+    })
+}
+
+/// Download every asset; return url -> local reference (relative path
+/// or data URL for fonts).
+fn fetch_all(assets: &BTreeSet<String>, out: &Path) -> BTreeMap<String, String> {
+    let queue: Mutex<Vec<String>> = Mutex::new(assets.iter().cloned().collect());
+    let mapping: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
+    let workers = 8;
+    std::thread::scope(|s| {
+        for _ in 0..workers {
+            s.spawn(|| loop {
+                let url = match queue.lock().expect("queue lock").pop() {
+                    Some(u) => u,
+                    None => break,
+                };
+                let Some(body) = fetch(&url) else {
+                    eprintln!("clone: miss {url}");
+                    continue;
+                };
+                let name = local_name(&url);
+                let ext = name.rsplit_once('.').map(|(_, e)| e).unwrap_or("");
+                let font_mime = match ext {
+                    "woff2" => Some("font/woff2"),
+                    "woff" => Some("font/woff"),
+                    "ttf" => Some("font/ttf"),
+                    "otf" => Some("font/otf"),
+                    _ => None,
+                };
+                let local = if let Some(mime) = font_mime {
+                    format!("data:{mime};base64,{}", base64(&body))
+                } else if std::fs::write(out.join("assets").join(&name), &body).is_ok() {
+                    format!("assets/{name}")
+                } else {
+                    continue;
+                };
+                mapping.lock().expect("mapping lock").insert(url, local);
+            });
+        }
+    });
+    mapping.into_inner().expect("mapping lock")
+}
+
+fn fetch(url: &str) -> Option<Vec<u8>> {
+    let out = Command::new("curl")
+        .args(["-fsSL", "--max-time", "30", "-A", UA, "--", url])
+        .output()
+        .ok()?;
+    if out.status.success() && !out.stdout.is_empty() {
+        Some(out.stdout)
+    } else {
+        None
+    }
+}
+
+// ---- pure text transforms (unit-tested) --------------------------------
+
+/// Stable local filename: content-independent hash of the URL plus a
+/// best-effort extension, so the same URL maps to the same file across
+/// the html/css rewrite passes.
+fn local_name(url: &str) -> String {
+    // FNV-1a, 64-bit: tiny, deterministic across runs and toolchains.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in url.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    let path = url
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(url)
+        .rsplit('/')
+        .next()
+        .unwrap_or("");
+    let ext = path.rsplit_once('.').map(|(_, e)| e).unwrap_or("");
+    let clean = ext.len() <= 7 && !ext.is_empty() && ext.bytes().all(|b| b.is_ascii_alphanumeric());
+    if clean {
+        format!("{h:016x}.{ext}")
+    } else {
+        format!("{h:016x}")
+    }
+}
+
+/// Resolve `rel` against `base` (RFC 3986-lite: absolute URLs pass
+/// through, `//host` keeps the base scheme, `/path` keeps the origin,
+/// anything else joins onto the base directory).
+fn url_join(base: &str, rel: &str) -> Option<String> {
+    if rel.contains("://") {
+        return Some(rel.to_string());
+    }
+    let (scheme, rest) = base.split_once("://")?;
+    if let Some(pp) = rel.strip_prefix("//") {
+        return Some(format!("{scheme}://{pp}"));
+    }
+    let (host, path) = match rest.split_once('/') {
+        Some((h, p)) => (h, format!("/{p}")),
+        None => (rest, "/".to_string()),
+    };
+    if rel.starts_with('/') {
+        return Some(format!("{scheme}://{host}{rel}"));
+    }
+    // Strip query/fragment from the base path, then its last segment.
+    let path = path.split(['?', '#']).next().unwrap_or("/");
+    let dir = &path[..path.rfind('/').map(|i| i + 1).unwrap_or(1)];
+    // Normalize ../ and ./ segments.
+    let mut segs: Vec<&str> = dir.split('/').filter(|s| !s.is_empty()).collect();
+    for seg in rel.split('/') {
+        match seg {
+            "." | "" => {}
+            ".." => {
+                segs.pop();
+            }
+            s => segs.push(s),
+        }
+    }
+    let trailing = if rel.ends_with('/') { "/" } else { "" };
+    Some(format!("{scheme}://{host}/{}{trailing}", segs.join("/")))
+}
+
+/// Rewrite every `url(...)` occurrence in a stylesheet through `f`.
+fn rewrite_css_urls(css: &str, mut f: impl FnMut(&str) -> String) -> String {
+    let mut out = String::with_capacity(css.len());
+    let mut rest = css;
+    while let Some(pos) = rest.find("url(") {
+        out.push_str(&rest[..pos + 4]);
+        rest = &rest[pos + 4..];
+        let Some(end) = rest.find(')') else {
+            break;
+        };
+        let raw = &rest[..end];
+        let trimmed = raw.trim().trim_matches(['\'', '"']);
+        if trimmed.is_empty() {
+            out.push_str(raw);
+        } else {
+            out.push_str(&f(trimmed));
+        }
+        out.push(')');
+        rest = &rest[end + 1..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Point absolute asset URLs (and their root-relative spellings on the
+/// page's own origin) at the local copies. Longest URL first so a
+/// prefix URL never clobbers a longer one.
+fn rewrite_to_local(text: &str, mapping: &BTreeMap<String, String>, base: &str) -> String {
+    let mut entries: Vec<(&String, &String)> = mapping.iter().collect();
+    entries.sort_by_key(|(u, _)| std::cmp::Reverse(u.len()));
+    let base_origin = origin_of(base);
+    let mut text = text.to_string();
+    for (url, local) in entries {
+        text = text.replace(url.as_str(), local);
+        // Root-relative spelling on the page's own origin, as it may
+        // appear in the original document.
+        let Some(origin) = &base_origin else { continue };
+        let Some(rel) = url.strip_prefix(origin.as_str()) else {
+            continue;
+        };
+        if !rel.is_empty() && rel != "/" {
+            text = text
+                .replace(&format!("\"{rel}\""), &format!("\"{local}\""))
+                .replace(&format!("'{rel}'"), &format!("'{local}'"))
+                .replace(&format!("url({rel})"), &format!("url({local})"));
+        }
+    }
+    text
+}
+
+/// `https://host` for an absolute URL.
+fn origin_of(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    let host = rest.split(['/', '?', '#']).next()?;
+    Some(format!("{scheme}://{host}"))
+}
+
+/// Swap `<canvas ... data-hwatu-canvas="i" ...></canvas>` for an
+/// `<img>` with the CSS box pinned: an `<img>` otherwise sizes itself
+/// by the data URL's intrinsic ratio, not the canvas's layout.
+fn replace_canvas(html: &str, i: u64, src: &str, w: i64, h: i64) -> String {
+    let marker = format!("data-hwatu-canvas=\"{i}\"");
+    let Some(mpos) = html.find(&marker) else {
+        return html.to_string();
+    };
+    let Some(start) = html[..mpos].rfind("<canvas") else {
+        return html.to_string();
+    };
+    let Some(gt) = html[mpos..].find('>') else {
+        return html.to_string();
+    };
+    let open_end = mpos + gt;
+    let Some(close) = html[open_end..].find("</canvas>") else {
+        return html.to_string();
+    };
+    let end = open_end + close + "</canvas>".len();
+    let attrs = &html[start + "<canvas".len()..open_end];
+    let style = if w > 0 {
+        format!(" style=\"width:{w}px;height:{h}px\"")
+    } else {
+        String::new()
+    };
+    format!(
+        "{}<img{attrs} src=\"{src}\"{style}>{}",
+        &html[..start],
+        &html[end..]
+    )
+}
+
+/// Pins bake one width's rendered transition state; scope them to a
+/// window around the capture width so every other width falls back to
+/// the site's own responsive CSS.
+fn pin_media_block(pins: &[serde_json::Value], vw: i64) -> String {
+    let lo = (vw - 40).max(1);
+    let hi = vw + 40;
+    let rules = pins
+        .iter()
+        .filter_map(|p| {
+            let i = p.get("i")?.as_u64()?;
+            let css = p.get("css")?.as_str()?;
+            Some(format!("[data-hwatu-pin=\"{i}\"] {{ {css} }}"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "\n@media (min-width: {lo}px) and (max-width: {hi}px) {{\n\
+         /* transition-state pins from capture at {vw}px */\n{rules}\n}}\n"
+    )
+}
+
+/// The only JS in the clone: restore recorded inner scroll positions
+/// with snap disabled.
+fn scroll_restore_script(scrolls: &[serde_json::Value]) -> String {
+    let payload: Vec<serde_json::Value> = scrolls
+        .iter()
+        .filter_map(|s| {
+            Some(serde_json::json!({
+                "i": s.get("i")?.as_u64()?,
+                "l": s.get("left")?.as_f64()?,
+                "t": s.get("top")?.as_f64()?,
+            }))
+        })
+        .collect();
+    format!(
+        "<script>for (const s of {}) {{\
+         const el = document.querySelector('[data-hwatu-scroll=\"' + s.i + '\"]');\
+         if (el) {{ el.style.scrollSnapType = 'none'; el.scrollLeft = s.l; el.scrollTop = s.t; }}\
+         }}</script>",
+        serde_json::Value::Array(payload)
+    )
+}
+
+/// Replace swappable `font-display` values with `block` (fonts are
+/// inline data URLs, so blocking is free and never paints a fallback).
+fn pin_font_display(css: &str) -> String {
+    let mut out = css.to_string();
+    for v in ["swap", "auto", "fallback", "optional"] {
+        for sp in ["", " "] {
+            out = out.replace(&format!("font-display:{sp}{v}"), "font-display:block");
+        }
+    }
+    out
+}
+
+/// Minimal base64 (standard alphabet, padded); avoids a dependency for
+/// one call site.
+fn base64(data: &[u8]) -> String {
+    const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+        out.push(T[(n >> 18) as usize & 63] as char);
+        out.push(T[(n >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            T[(n >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            T[n as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+// ---- verify -----------------------------------------------------------
+
+/// Open the clone next to the live window and diff at several scroll
+/// offsets. The report names exactly what was measured (the envelope):
+/// this viewport, these offsets, nothing else.
+fn verify(opts: &Opts, live: u64) -> Result<serde_json::Value, String> {
+    let index = std::fs::canonicalize(opts.out.join("index.html"))
+        .map_err(|e| format!("canonicalize index.html: {e}"))?;
+    let clone_url = format!("file://{}", index.display());
+    let clone_win = open_headless(&clone_url, opts.timeout_ms)?;
+    let result = verify_with(opts, live, clone_win);
+    if !opts.keep || result.is_err() {
+        close(clone_win);
+    }
+    result
+}
+
+fn verify_with(opts: &Opts, live: u64, clone_win: u64) -> Result<serde_json::Value, String> {
+    for id in [live, clone_win] {
+        call_ok(&Request::Resize {
+            id: Some(id),
+            width: opts.viewport.0,
+            height: opts.viewport.1,
+        })?;
+        // Freeze animations so the diff compares stills, not phases.
+        let _ = call(&Request::Seek {
+            id: Some(id),
+            time_ms: None,
+            progress: Some(0.0),
+            resume: false,
+            timeout_ms: Some(10_000),
+        });
+    }
+    std::thread::sleep(Duration::from_millis(500));
+
+    let max_scroll = eval(
+        live,
+        "return Math.max(0, document.documentElement.scrollHeight - innerHeight)",
+        10_000,
+    )?
+    .as_f64()
+    .unwrap_or(0.0);
+
+    let fractions = [0.0, 0.25, 0.5, 0.75, 1.0];
+    let mut positions = Vec::new();
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    for frac in fractions {
+        let y = (max_scroll * frac).round();
+        for id in [live, clone_win] {
+            eval(id, &format!("scrollTo(0,{y}); return 0"), 10_000)?;
+        }
+        std::thread::sleep(Duration::from_millis(400));
+        let Response::Ok { value, .. } = call_ok(&Request::Diff {
+            id: live,
+            other: Some(clone_win),
+            baseline: None,
+            tolerance: opts.tolerance,
+            heatmap: None,
+            full: false,
+            timeout_ms: Some(30_000),
+        })?
+        else {
+            unreachable!()
+        };
+        let value = value.unwrap_or(serde_json::Value::Null);
+        let pct = value
+            .get("match_percent")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        sum += pct;
+        n += 1;
+        eprintln!("clone: verify y={y}: {pct:.1}% match");
+        positions.push(serde_json::json!({
+            "scroll_y": y,
+            "match_percent": pct,
+            "regions": value.get("regions").cloned().unwrap_or(serde_json::Value::Null),
+        }));
+    }
+    let avg = if n == 0 { 0.0 } else { sum / n as f64 };
+    Ok(serde_json::json!({
+        "url": opts.url,
+        "viewport": { "w": opts.viewport.0, "h": opts.viewport.1 },
+        "tolerance": opts.tolerance.unwrap_or(8),
+        "positions": positions,
+        "average_match_percent": (avg * 100.0).round() / 100.0,
+        "envelope": "still clone; scores cover exactly this viewport and these scroll offsets",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opts_parse_defaults() {
+        let o = Opts::parse(&["stripe.com".to_string()]).unwrap();
+        assert_eq!(o.url, "https://stripe.com");
+        assert_eq!(o.out, PathBuf::from("stripe.com-clone"));
+        assert_eq!(o.viewport, (1920, 1080));
+        assert!(o.verify);
+        assert!(!o.keep);
+    }
+
+    #[test]
+    fn opts_parse_flags() {
+        let args: Vec<String> = [
+            "https://example.com/x",
+            "--out",
+            "/tmp/o",
+            "--viewport",
+            "800x600",
+            "--tolerance",
+            "12",
+            "--no-verify",
+            "--keep",
+            "--timeout-ms",
+            "9000",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let o = Opts::parse(&args).unwrap();
+        assert_eq!(o.out, PathBuf::from("/tmp/o"));
+        assert_eq!(o.viewport, (800, 600));
+        assert_eq!(o.tolerance, Some(12));
+        assert!(!o.verify);
+        assert!(o.keep);
+        assert_eq!(o.timeout_ms, 9000);
+    }
+
+    #[test]
+    fn opts_reject_unknown() {
+        assert!(Opts::parse(&["x.com".into(), "--bogus".into()]).is_err());
+        assert!(Opts::parse(&[]).is_err());
+    }
+
+    #[test]
+    fn url_join_cases() {
+        let b = "https://a.com/css/site.css?v=1";
+        assert_eq!(
+            url_join(b, "img/x.png").unwrap(),
+            "https://a.com/css/img/x.png"
+        );
+        assert_eq!(url_join(b, "../f.woff2").unwrap(), "https://a.com/f.woff2");
+        assert_eq!(url_join(b, "/root.png").unwrap(), "https://a.com/root.png");
+        assert_eq!(
+            url_join(b, "//cdn.com/y.js").unwrap(),
+            "https://cdn.com/y.js"
+        );
+        assert_eq!(url_join(b, "https://z.com/q").unwrap(), "https://z.com/q");
+    }
+
+    #[test]
+    fn css_url_rewrite() {
+        let css = "a{background:url('x.png')}b{src:url( \"y.woff2\" )}c{d:url(data:foo)}";
+        let out = rewrite_css_urls(css, |u| {
+            if u.starts_with("data:") {
+                u.to_string()
+            } else {
+                format!("LOCAL/{u}")
+            }
+        });
+        assert!(out.contains("url(LOCAL/x.png)"));
+        assert!(out.contains("url(LOCAL/y.woff2)"));
+        assert!(out.contains("url(data:foo)"));
+    }
+
+    #[test]
+    fn canvas_swap() {
+        let html = r#"<div><canvas class="c" data-hwatu-canvas="3" width="10"></canvas></div>"#;
+        let out = replace_canvas(html, 3, "assets/canvas-3.png", 100, 50);
+        assert!(out.contains(r#"<img class="c" data-hwatu-canvas="3" width="10" src="assets/canvas-3.png" style="width:100px;height:50px">"#), "{out}");
+        assert!(!out.contains("<canvas"));
+    }
+
+    #[test]
+    fn base64_matches_reference() {
+        assert_eq!(base64(b""), "");
+        assert_eq!(base64(b"f"), "Zg==");
+        assert_eq!(base64(b"fo"), "Zm8=");
+        assert_eq!(base64(b"foo"), "Zm9v");
+        assert_eq!(base64(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn font_display_pinned() {
+        assert_eq!(
+            pin_font_display("x{font-display: swap}y{font-display:auto}"),
+            "x{font-display:block}y{font-display:block}"
+        );
+    }
+
+    #[test]
+    fn rewrite_local_root_relative() {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "https://a.com/img/x.png".to_string(),
+            "assets/1.png".to_string(),
+        );
+        let text = r#"<img src="/img/x.png"> url(/img/x.png) <a href="https://a.com/img/x.png">"#;
+        let out = rewrite_to_local(text, &m, "https://a.com/page");
+        assert!(out.contains(r#"src="assets/1.png""#), "{out}");
+        assert!(out.contains("url(assets/1.png)"), "{out}");
+        assert!(out.contains(r#"href="assets/1.png""#), "{out}");
+    }
+
+    #[test]
+    fn pin_block_scoped_to_width() {
+        let pins = vec![serde_json::json!({"i": 0, "css": "opacity: 1 !important"})];
+        let block = pin_media_block(&pins, 819);
+        assert!(block.contains("min-width: 779px"));
+        assert!(block.contains("max-width: 859px"));
+        assert!(block.contains(r#"[data-hwatu-pin="0"] { opacity: 1 !important }"#));
+    }
+}

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -5,6 +5,7 @@
 //! `hana <url>` opens a window in ~1 IPC roundtrip. If no daemon is
 //! running, it spawns one and waits for the socket.
 
+mod clone;
 mod mcp;
 mod onboarding;
 mod update;
@@ -25,6 +26,9 @@ fn main() {
     }
     if args.first().map(String::as_str) == Some("watch") {
         std::process::exit(watch(&args[1..]));
+    }
+    if args.first().map(String::as_str) == Some("clone") {
+        std::process::exit(clone::run(&args[1..]));
     }
     if is_onboarding_command(args.first().map(String::as_str)) {
         std::process::exit(onboarding::run(&args));
@@ -931,6 +935,7 @@ const USAGE: &str = "usage: hwatu [--app-id <id>] [--background|--headless|--foc
 | seek [--id <id>] (--time-ms <ms> | --progress <0..1> | --resume) \
 | clock [--id <id>] (pause | resume | step <ms> | set <ms> | seed <u64> | status) \
 | diff --id <id> (--other <id> | --baseline <png>) [--tolerance <0-255>] [--heatmap <png>] [--full] \
+| clone <url> [--out <dir>] [--viewport <WxH>] [--tolerance <0-255>] [--no-verify] [--keep] \
 | adblock [on|off|status|update] \
 | doctor | setup [--client claude|cursor|generic|jcode] [--scope project|user] [--dry-run] [--undo] \
 | demo [url] [--focus] \

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -257,7 +257,25 @@ fn set_wayland_app_id(window: &gtk::Window, app_id: &str) {
 /// Build a fully configured WebView. Called for the prewarm pool and as
 /// a fallback; all engine knobs live here, never on the spawn path.
 pub fn build_webview() -> webkit6::WebView {
-    let view = webkit6::WebView::new();
+    // HWATU_BLOCK_AUTOPLAY=1: deny media autoplay engine-wide (muted
+    // videos included — the user-gesture setting exempts those).
+    // Escape hatch for a WebKitGTK+GStreamer wedge observed with gst
+    // 1.28.5: pages with several lazy-initialized autoplay videos
+    // (scale.com) deadlock the web process main thread in a futex
+    // inside the gst pipeline seconds after load, killing every
+    // subsequent eval. Still-capture flows (`hwatu clone`) don't need
+    // playback — poster frames render without it. Must be set at
+    // construction: website-policies is a construct-only property.
+    let view = if std::env::var_os("HWATU_BLOCK_AUTOPLAY").is_some_and(|v| v == "1") {
+        let policies = webkit6::WebsitePolicies::builder()
+            .autoplay(webkit6::AutoplayPolicy::Deny)
+            .build();
+        webkit6::WebView::builder()
+            .website_policies(&policies)
+            .build()
+    } else {
+        webkit6::WebView::new()
+    };
     apply_view_settings(&view);
     crate::console::wire_view(&view);
     crate::clock::wire_view(&view);

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -51,6 +51,7 @@ machine the human is working on.
 |---|---|
 | `snapshot` | what's on this page, what can I click (JSON, ~tokens not pixels) |
 | `diff --other/--baseline` | how close are these two renders, where do they differ, as a score + regions + heatmap |
+| `clone` | a self-contained local copy of a live page (rendered DOM + assets), verified against the original with a measured pixel-match report |
 | `motion` | every animation as numbers: duration, delay, easing, keyframes |
 | `seek` | pin all animations at time t; two shots at the same t are byte-identical |
 | `expect` | assert page state in one call (polls, structured pass/fail) |

--- a/examples/clone/README.md
+++ b/examples/clone/README.md
@@ -60,3 +60,18 @@ hwatu diff --id 1 --other 2 --heatmap heat.png
 Iterate on the clone until `match_percent` converges; the heatmap and
 `regions` name what to fix next. Verify motion parity with
 `hwatu motion` on both windows and diff the JSON.
+
+## The fidelity ladder
+
+`scripts/test-clone-suite.sh` is the canonical regression suite for
+`hwatu clone` — every phase of clone work must climb the same three
+rungs, in order:
+
+1. **webkit.org** — static-ish page; CSSOM + fonts + SVG floor.
+2. **stripe.com** — WebGL canvases, entrance reveals, transition pins.
+3. **scale.com** — heavy JS DOM, lazy loading, autoplay video.
+
+Run it after any change to `extract.js`, `clone.rs`, or engine
+settings that capture depends on. Thresholds in the script are floors
+measured from what the current phase achieves — raise them as later
+phases land; never lower them to pass.

--- a/examples/clone/README.md
+++ b/examples/clone/README.md
@@ -1,5 +1,12 @@
 # Page-clone convergence kit
 
+> **Now built in:** `hwatu clone <url> [--out <dir>] [--viewport <WxH>]
+> [--tolerance <n>] [--no-verify] [--keep]` runs this whole pipeline
+> (capture, materialize, verify with a `report.json`) in one command
+> with no python/imagemagick dependencies. The scripts here remain as
+> the hackable reference implementation and for iterating on the
+> method itself.
+
 Captures a live page from a hwatu window into a self-contained local
 mirror, then verifies fidelity with `hwatu diff`. This is the pipeline
 behind the "pixel-perfect copy of stripe.com" demo: it reached a

--- a/scripts/test-clone-suite.sh
+++ b/scripts/test-clone-suite.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Fidelity ladder for `hwatu clone`: the canonical difficulty
+# progression every clone phase must climb, in order.
+#
+#   1. webkit.org — static-ish marketing page: CSSOM inlining, SVG
+#      assets, web fonts. The floor: if this regresses, everything
+#      else is noise.
+#   2. stripe.com — the original 100%-match demo target: WebGL
+#      canvases, entrance reveals, transition pins, scroll-snap
+#      carousels, cross-origin CSS.
+#   3. scale.com — heavy JS-built DOM, aggressive lazy loading,
+#      script-driven motion. The current frontier.
+#
+# Each rung runs `hwatu clone` on an ISOLATED daemon (the user's
+# session is untouched), records the verify report, and asserts the
+# average pixel match clears the rung's threshold. Thresholds are
+# floors, not goals: raise them as later phases (resource archive,
+# animation re-arm) land, never lower them to pass.
+#
+# Live-site caveat, stated honestly: these are third-party pages that
+# change without notice. A failure here means "look", not necessarily
+# "the code broke" — read the report and heatmap regions before
+# blaming the pipeline. CI should treat this suite as advisory
+# (network + third-party variance); the gate is local pre-merge runs.
+#
+# Usage: scripts/test-clone-suite.sh [outdir]
+#   outdir defaults to a mktemp dir; pass one to keep the clones.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin="$root/target/release"
+
+if [[ ! -x "$bin/hwatu" || ! -x "$bin/hwatud" ]]; then
+    echo "test-clone-suite: building release binaries..." >&2
+    cargo build --release --manifest-path "$root/Cargo.toml" >&2
+fi
+
+keep_out=""
+if [[ $# -ge 1 ]]; then
+    keep_out="$1"
+    mkdir -p "$keep_out"
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-clone-suite.XXXXXX")"
+out="${keep_out:-$work/clones}"
+mkdir -p "$out"
+export XDG_RUNTIME_DIR="$work/run"
+export XDG_STATE_HOME="$work/state"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
+# Deny media autoplay in the capture daemon. WebKitGTK+GStreamer
+# (gst 1.28.5) deadlocks the web process main thread on pages with
+# several lazy-initialized autoplay videos (scale.com); a still
+# clone renders poster frames anyway, so playback buys nothing.
+export HWATU_BLOCK_AUTOPLAY=1
+
+cleanup() {
+    "$bin/hwatu" quit >/dev/null 2>&1 || true
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+# The ladder: url  min_avg_match  viewport
+# Thresholds reflect what Phase 0 (stills) demonstrably achieves
+# today; see the table in the results log for measured values.
+rungs=(
+    "https://webkit.org   90.0  1440x900"
+    "https://stripe.com   85.0  1920x1080"
+    "https://scale.com    75.0  1920x1080"
+)
+
+fails=0
+summary=()
+for rung in "${rungs[@]}"; do
+    read -r url min viewport <<<"$rung"
+    name="$(sed -E 's#https?://##; s#[/.]#-#g' <<<"$url")"
+    dir="$out/$name"
+    echo "=== clone $url (floor ${min}%) ===" >&2
+    if ! "$bin/hwatu" clone "$url" --out "$dir" --viewport "$viewport" \
+        --timeout-ms 240000 >&2; then
+        echo "FAIL $url: clone exited nonzero" >&2
+        summary+=("FAIL  $url  (clone error)")
+        fails=$((fails + 1))
+        continue
+    fi
+    avg="$(python3 -c "
+import json, sys
+r = json.load(open('$dir/report.json'))
+print(r['average_match_percent'])
+")"
+    ok="$(python3 -c "print('yes' if $avg >= $min else 'no')")"
+    if [[ "$ok" == "yes" ]]; then
+        summary+=("PASS  $url  avg=${avg}%  floor=${min}%")
+    else
+        summary+=("FAIL  $url  avg=${avg}%  floor=${min}%")
+        fails=$((fails + 1))
+    fi
+done
+
+echo
+echo "== clone fidelity ladder =="
+printf '%s\n' "${summary[@]}"
+[[ -n "$keep_out" ]] && echo "clones kept in $keep_out"
+exit "$fails"


### PR DESCRIPTION
## What

`hwatu clone <url> [--out <dir>] [--viewport <WxH>] [--tolerance <n>] [--no-verify] [--keep]`

Phase 0 of the one-shot clone feature: productizes the `examples/clone/` pipeline (100.0% pixel match on stripe.com) into a single built-in command with zero python/imagemagick dependencies.

## How

1. **Capture**: opens the URL headless, runs the embedded `extract.js` (sweep-prime lazy content, harvest canvas frames, pause animations, serialize rendered DOM + CSSOM + asset manifest + transition pins + scroll positions).
2. **Blank canvas fallback**: WebGL canvases without `preserveDrawingBuffer` get engine screenshot crops (pure Rust `png` crop replaces `magick`).
3. **Materialize**: parallel curl asset fetch, fonts inlined as data URLs with `font-display:block`, media-scoped transition pins, scroll restore. `materialize.py` ported to unit-tested Rust.
4. **Verify (default)**: opens the clone in a second headless window, diffs at 5 scroll offsets against the live page, writes `report.json` with per-position scores and an explicit envelope.

## Verification

- 70 unit tests pass (10 new for clone parsing/URL join/CSS rewrite/canvas swap/base64/pins), clippy `-D warnings` clean, fmt clean.
- Live E2E on an isolated daemon:
  - `example.com`: **100.0%** average match (5 positions)
  - `webkit.org`: **95.2%** average match; misses are two 404'd cross-origin font stylesheets and two 404'd assets, all named in stderr and reflected in `report.json` regions.

## Roadmap context

Phase 0 of the clone strategy (stills). Later phases: engine-side resource archive for byte-exact assets, live animation re-arm/synthesis, and the interaction state-graph crawler.
