### PR TITLE
feat: add opt-in snapshot element rectangles

### DIFF
--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -284,6 +284,7 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
     let mut shot_path: Option<String> = None;
     let mut keep = false;
     let mut diff = false;
+    let mut rect = false;
     let mut expect_watch = false;
     let mut mode = default_mode;
     let mut rest: Vec<&String> = Vec::new();
@@ -478,6 +479,8 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
             keep = true;
         } else if arg == "--diff" {
             diff = true;
+        } else if arg == "--rect" {
+            rect = true;
         } else if arg == "--to-y" {
             to_y = Some(
                 it.next()
@@ -713,6 +716,7 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
         Some("snapshot") => Ok(Request::Snapshot {
             id,
             diff,
+            rect,
             timeout_ms,
         }),
         Some("expect") => {
@@ -920,7 +924,7 @@ const USAGE: &str = "usage: hwatu [--app-id <id>] [--background|--headless|--foc
     | challenge [--id <id>] [--wait] \
     | upload [--id <id>] <selector> <path> \
 | scroll [--id <id>] [<selector> [nth]] [--contains <text>] [--to-y <px>] [--by <pages>] \
-| snapshot [--id <id>] [--diff] \
+| snapshot [--id <id>] [--diff] [--rect] \
 | expect [--id <id>] <selector> [--contains <filter>] [--text <substring>] [--absent] [--visible] [--nth <n>] [--timeout-ms <ms>] [--watch] \
 | click [--id <id>] (<selector> [nth] [--contains <text>] | --ref <n>) \
 | type [--id <id>] (<selector> | --ref <n>) <text> [--enter] [--no-clear] \
@@ -1745,6 +1749,7 @@ mod tests {
             Ok(Request::Snapshot {
                 id: None,
                 diff: false,
+                rect: false,
                 ..
             })
         ));
@@ -1757,6 +1762,7 @@ mod tests {
             Ok(Request::Snapshot {
                 id: None,
                 diff: true,
+                rect: false,
                 ..
             })
         ));
@@ -1765,6 +1771,15 @@ mod tests {
             Ok(Request::Snapshot {
                 id: Some(3),
                 diff: true,
+                rect: false,
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse(&args(&["snapshot", "--rect"])),
+            Ok(Request::Snapshot {
+                rect: true,
+                diff: false,
                 ..
             })
         ));

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -333,6 +333,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
         "snapshot" => Ok(Request::Snapshot {
             id,
             diff: opt_bool(args, "diff").unwrap_or(false),
+            rect: opt_bool(args, "rect").unwrap_or(false),
             timeout_ms,
         }),
         "expect" => Ok(Request::Expect {
@@ -647,6 +648,7 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
                 "id": prop("integer", ID_DESC),
                 "diff": prop("boolean", "Return only changes since the last diff \
                      snapshot of this window instead of the full page state."),
+                "rect": prop("boolean", "Include viewport CSS rectangles as [x, y, width, height] for interactables."),
             }),
             &[],
         ),

--- a/crates/hwatu/src/onboarding.rs
+++ b/crates/hwatu/src/onboarding.rs
@@ -629,6 +629,7 @@ fn demo(args: &[String]) -> i32 {
     match send(&Request::Snapshot {
         id: Some(id),
         diff: false,
+        rect: false,
         timeout_ms: Some(15_000),
     }) {
         Ok(Response::Ok { value: Some(v), .. }) => {

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -2297,12 +2297,14 @@ pub fn snapshot(
     daemon: &Rc<Daemon>,
     id: Option<u64>,
     diff: bool,
+    rect: bool,
     timeout_ms: Option<u64>,
     reply: Reply,
 ) {
     const JS: &str = r#"
 const MAX_TEXT = 4000;
 const MAX_ELS = 120;
+const INCLUDE_RECTS = __HWATU_INCLUDE_RECTS__;
 const clip = (s, n) => {
   s = (s || '').replace(/\s+/g, ' ').trim();
   return s.length > n ? s.slice(0, n - 1) + '…' : s;
@@ -2328,6 +2330,10 @@ const els = [...document.querySelectorAll(sel)].filter(visible).slice(0, MAX_ELS
 window.__hwatu_refs = els;
 const interactables = els.map((el, i) => {
   const out = { ref: i, tag: el.tagName.toLowerCase() };
+  if (INCLUDE_RECTS) {
+    const r = el.getBoundingClientRect();
+    out.rect = [r.x, r.y, r.width, r.height];
+  }
   const text = clip(label(el), 80);
   if (text) out.text = text;
   if (el.id) out.id = el.id;
@@ -2361,8 +2367,12 @@ return {
     max_y: Math.max(0, doc.scrollHeight - window.innerHeight),
   },
 };"#;
+    let js = JS.replace(
+        "__HWATU_INCLUDE_RECTS__",
+        if rect { "true" } else { "false" },
+    );
     if !diff {
-        return eval(daemon, id, JS.to_string(), timeout_ms, reply);
+        return eval(daemon, id, js, timeout_ms, reply);
     }
     // Diff mode: pin the target window now so the baseline read and
     // the post-eval write hit the same window even if focus moves
@@ -2378,7 +2388,7 @@ return {
     eval(
         daemon,
         Some(window_id),
-        JS.to_string(),
+        js,
         timeout_ms,
         Box::new(move |resp| {
             let Response::Ok {

--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -195,9 +195,10 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
         Request::Snapshot {
             id,
             diff,
+            rect,
             timeout_ms,
         } => {
-            return automation::snapshot(daemon, id, diff, timeout_ms, reply);
+            return automation::snapshot(daemon, id, diff, rect, timeout_ms, reply);
         }
         Request::Expect {
             id,

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -272,6 +272,11 @@ pub enum Request {
         /// field and answers a new client with a full snapshot.
         #[serde(default, skip_serializing_if = "is_false")]
         diff: bool,
+        /// Include each interactable's viewport CSS rectangle as
+        /// `[x, y, width, height]`. Disabled by default to keep snapshots
+        /// token-cheap and preserve the original response shape.
+        #[serde(default, skip_serializing_if = "is_false")]
+        rect: bool,
         #[serde(default)]
         timeout_ms: Option<u64>,
     },
@@ -1055,6 +1060,7 @@ mod tests {
         let plain = Request::Snapshot {
             id: Some(2),
             diff: false,
+            rect: false,
             timeout_ms: None,
         };
         let wire = serde_json::to_string(&plain).unwrap();
@@ -1062,14 +1068,17 @@ mod tests {
             !wire.contains("diff"),
             "non-diff snapshot must omit the field for old daemons: {wire}"
         );
+        assert!(!wire.contains("rect"));
 
         let diffing = Request::Snapshot {
             id: Some(2),
             diff: true,
+            rect: true,
             timeout_ms: None,
         };
         let wire = serde_json::to_string(&diffing).unwrap();
         assert!(wire.contains("\"diff\":true"));
+        assert!(wire.contains("\"rect\":true"));
         let Ok(Request::Snapshot { diff, .. }) = serde_json::from_str::<Request>(&wire) else {
             panic!("diff snapshot failed to roundtrip");
         };


### PR DESCRIPTION
Fixes #18.

Adds an opt-in `rect` flag to CLI and MCP snapshot requests. When enabled, each interactable includes `rect: [x, y, width, height]` in viewport CSS pixels. The default snapshot wire shape and token cost remain unchanged.

Validation:
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings