### PR TITLE
docs: v0.7.0 release notes (features + remeasured benchmarks)

### DIFF
--- a/crates/hwatud/src/keys.rs
+++ b/crates/hwatud/src/keys.rs
@@ -52,6 +52,8 @@ pub enum Action {
     ZoomOut,
     ZoomReset,
     Fullscreen,
+    /// Toggle page audio mute.
+    Mute,
     /// Open the command palette (fuzzy action search in the bar).
     CommandPalette,
 }
@@ -77,6 +79,7 @@ impl Action {
         Action::ZoomOut,
         Action::ZoomReset,
         Action::Fullscreen,
+        Action::Mute,
         Action::CommandPalette,
     ];
 
@@ -101,6 +104,7 @@ impl Action {
             Action::ZoomOut => "zoom_out",
             Action::ZoomReset => "zoom_reset",
             Action::Fullscreen => "fullscreen",
+            Action::Mute => "mute",
             Action::CommandPalette => "command_palette",
         }
     }
@@ -127,6 +131,7 @@ impl Action {
             Action::ZoomOut => "zoom out",
             Action::ZoomReset => "reset zoom",
             Action::Fullscreen => "toggle fullscreen",
+            Action::Mute => "toggle mute",
             Action::CommandPalette => "command palette",
         }
     }
@@ -162,6 +167,9 @@ impl Action {
             Action::ZoomOut => "ctrl+minus",
             Action::ZoomReset => "ctrl+0",
             Action::Fullscreen => "F11",
+            // Bare key, so it dispatches in the bubble phase: an `m`
+            // typed into a page text box still reaches the page.
+            Action::Mute => "m",
             // ctrl+shift+p mirrors VS Code; ctrl+k is unclaimed in
             // browsers and one chord shorter for daily use.
             Action::CommandPalette => "ctrl+k, ctrl+shift+p",
@@ -555,6 +563,9 @@ mod tests {
             map.lookup(Phase::Bubble, Key::F11, NONE),
             Some(Action::Fullscreen)
         );
+        // Bare m toggles mute; it must bubble so page inputs keep it.
+        assert_eq!(map.lookup(Phase::Bubble, Key::m, NONE), Some(Action::Mute));
+        assert_eq!(map.lookup(Phase::Capture, Key::m, NONE), None);
     }
 
     #[test]

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -1488,9 +1488,21 @@ impl BrowserWindow {
                     self.window.fullscreen();
                 }
             }
+            Action::Mute => self.toggle_mute(),
             Action::CommandPalette => self.open_palette(),
         }
         glib::Propagation::Stop
+    }
+
+    /// Toggle the WebView's audio mute state and flash the result in
+    /// the bar. A discarded window has no page audio; this is a no-op.
+    fn toggle_mute(self: &Rc<Self>) {
+        let Some(webview) = self.live_webview() else {
+            return;
+        };
+        let muted = !webview.is_muted();
+        webview.set_is_muted(muted);
+        self.flash_bar(if muted { "muted" } else { "unmuted" }, 2);
     }
 
     /// Copy the current page URL to the desktop clipboard.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,184 @@
+# hwatu v0.7.0: the shortform release
+
+Released 2026-08-01. [Tag](https://github.com/hongnoul/hwatu/releases/tag/v0.7.0) ·
+[Full changelog](https://github.com/hongnoul/hwatu/compare/v0.6.1...v0.7.0)
+
+v0.6.x made hwatu a fast verification browser. v0.7.0 makes it a
+browser someone can actually *watch things in*, and use the same
+media-correct engine for agent verification of video-heavy pages.
+The release also ships `hwatu clone` (one-shot faithful page copy
+with measured verification), a Docker image for MCP distribution,
+and a mainstream-controls UI pass.
+
+## Headline features
+
+### Unified shortform controls (Instagram Reels, YouTube Shorts, TikTok)
+
+All shortform feeds now share one control scheme:
+
+| key | action |
+|---|---|
+| ArrowUp / ArrowDown | snap exactly one video |
+| Space | play / pause |
+| ArrowRight (hold) | 2x playback, restores prior rate on release |
+| ArrowLeft | toggle the comment sheet |
+
+Getting "one keypress = one reel" right required three different
+paging strategies, because the three sites build their feeds three
+different ways:
+
+- **CSS mandatory-snap feeds** (Shorts, TikTok): discrete wheel ticks
+  and arrow keys page one snap point, mid-flight same-direction ticks
+  are absorbed so a flick moves exactly one page, and the container's
+  `scroll-snap-type` is suspended while the animation runs so the
+  engine cannot quantize it into a teleport.
+- **Snapless uniform-card feeds** (Instagram Reels mobile web): no
+  CSS snap exists, so a card-feed heuristic detects scrollers whose
+  children are ≥80% uniform viewport-sized cards and pages on card
+  boundaries. Verified live: one ArrowDown lands exactly one 991 px
+  card.
+- **Gesture-state feeds** (Instagram Reels): IG tracks the current
+  reel in React pointer-handler state, not scroll position, so paging
+  scrollTop moved pixels without advancing the reel. Paging now
+  dispatches a synthetic touch pointer swipe. Verified live: 12
+  consecutive ArrowDown presses advanced the reel URL every time and
+  resumed GraphQL pagination (feed grew from 7 to 21 children).
+
+The listeners run in capture phase so per-site bindings (YouTube's
+ArrowRight seek) cannot shadow the scheme, and every shortcut only
+consumes the key when its target was actually found, so unknown pages
+fail open to native behavior.
+
+### Media correctness
+
+Four fixes that together make video pages behave:
+
+- **Unmuted autoplay by default.** WebKit's default policy rejects
+  unmuted `play()`, so sites fell back to muted players. Verified:
+  unmuted `<video autoplay>` now resolves with `muted:false`.
+  Opt out with `HWATU_AUTOPLAY=muted` or `=deny`.
+- **Playback survives focus loss.** A focus-shield user script pins
+  `document.hidden`/`visibilityState` and swallows window-level
+  blur/visibility events, so Reels-style pages stop pausing when you
+  switch windows. Element-level focus passes through untouched.
+  Gate: `HWATU_FOCUS_SHIELD=0`.
+- **Audio cannot outlive the window.** Closing a window now kills its
+  web process; WebKit's cached-process reuse previously let an
+  autoplaying video keep playing sound after `hwatu close`.
+  Relatedly, a WebView that is playing audio is never discarded by
+  the idle-suspend path.
+- **Blur-shield: 34 → 95 fps on Shorts.** Shortform pages put a
+  stretched video copy behind the player with `filter: blur(40px)`,
+  which WebKitGTK Skia rasterizes on the CPU every frame, collapsing
+  the page to 7-34 rAF fps. A user script hides blur(≥16px) layers
+  covering ≥200k px² near a video. Measured on YouTube Shorts:
+  rAF 34-43 fps → ~95 fps, decode steady at native 25-30 fps with 0
+  dropped frames. Gate: `HWATU_BLUR_SHIELD=0`.
+
+Supporting this, `hwatud` serves an iPhone Safari UA to touch-first
+sites (`HWATU_MOBILE_UA_SITES`, default instagram.com), switched at
+the response policy decision so a cross-host iframe can never flip
+the top-level page's UA. `HWATU_DISABLE_MEDIA=1` is the escape hatch
+for GStreamer wedges.
+
+### Smoothwheel: Chromium-curve scrolling everywhere
+
+Wheel scrolling gained a Chromium-style animation curve in v0.6.x;
+v0.7.0 routes Arrow/PageUp/PageDown/Space through the same animator,
+so key scrolling glides with preserved velocity instead of WebKitGTK's
+isolated-pulse scroller, and auto-repeat retargets the running
+animation. On snap feeds, keys page exactly like a wheel tick. All
+paths bail on `defaultPrevented`, modifier chords, and editable
+targets, and fail open to native scrolling.
+
+### `hwatu clone`: one-shot faithful page copy, measured
+
+`hwatu clone <url>` productizes the pipeline that hit 100.0% pixel
+match on stripe.com into one built-in command with zero
+python/imagemagick dependencies:
+
+- **capture**: sweeps lazy content, harvests canvas frames, pauses
+  animations, serializes the rendered DOM + CSSOM + asset manifest;
+  blank WebGL canvases fall back to engine screenshot crops (pure
+  Rust).
+- **materialize**: parallel asset fetch, fonts inlined as data URLs,
+  media-scoped pins, scroll restore.
+- **verify** (default on): opens the clone in a second headless
+  window, diffs against the live page at 5 scroll offsets, and writes
+  `report.json` with per-position match scores.
+
+Verified end-to-end on an isolated daemon: example.com 100.0% avg,
+webkit.org 95.2% avg across 5 positions (every miss named in the
+report: 404'd cross-origin font CSS).
+
+### Mainstream controls
+
+The Vim-style UI is gone. URL editing is the default text entry,
+`ctrl+y` yanks the current page URL, new windows default to quarter
+monitor width, and the launcher deals a hanafuda card per window.
+A test locks the Vim defaults out.
+
+### Distribution
+
+- **Docker image** for MCP distribution (`Dockerfile`,
+  `docker-entrypoint.sh`).
+- **Snapshot element rectangles**: `snapshot` can now include layout
+  rects, opt-in, for agents that need geometry without a screenshot.
+- Daemon file paths (shots, clones) resolve from the caller's cwd.
+
+## Benchmarks
+
+Remeasured on the v0.7.0 binaries, 2026-08-01, same rig as
+[benchmarks.md](../benchmarks.md) (i7-12650H, 15 GiB, Wayland,
+WebKitGTK 2.52.5, isolated `XDG_RUNTIME_DIR`, fresh daemon, local
+40-card fixture over loopback HTTP). Medians over 12 runs:
+
+| scenario | v0.6.x documented | v0.7.0 measured |
+|---|---|---|
+| warm verify pass, screenshot included (`check --eval --shot`, one CLI spawn) | 39 ms | **16 ms** |
+| DOM-only verify (`check --eval --until dom`) | 21 ms | **5 ms** |
+| headless window spawn (warm daemon) | 14 ms | **2-3 ms** |
+| memory, 5 headless windows (tree PSS, unique PIDs) | 757 MB* | **375 MB** |
+| ad blocking | 117,431 rules | 119,494 rules, 0 JS in the request path |
+
+\* The v0.6.x figure was measured with mapped windows on a live
+session and a different PSS accounting; the v0.7.0 figure is headless
+windows on a fresh isolated daemon. Treat the memory rows as two
+snapshots, not a strict A/B. The latency rows are the same
+methodology as before (wall clock around the CLI call, including
+process spawn and socket roundtrip) and are directly comparable.
+
+Feature-level measurements from this cycle, verified live at commit
+time:
+
+| what | before | after |
+|---|---|---|
+| YouTube Shorts page fps (blur-shield) | 34-43 rAF fps | ~95 rAF fps, 0 dropped decode frames |
+| Instagram Reels paging (synthetic swipe) | URL frozen, feed starved at ~6 reels | 12/12 keypresses advance, feed 7 → 21 |
+| Reels mobile-web arrow key | 40 px line glide | exactly one 991 px card |
+| `hwatu clone` fidelity | n/a | example.com 100.0%, webkit.org 95.2% |
+
+Rerun any of these: `scripts/bench-spawn.sh`,
+`scripts/bench-vs-playwright.mjs`, `scripts/bench-scroll/` (snap
+fixture + trace recorder, new this release).
+
+## Compatibility notes
+
+- Vim-style keybindings are removed, not hidden. If you scripted
+  around them, migrate to the mainstream scheme.
+- Unmuted autoplay is now the default. Set `HWATU_AUTOPLAY=muted` to
+  restore the old behavior.
+- New env gates, all default-on features: `HWATU_FOCUS_SHIELD=0`,
+  `HWATU_BLUR_SHIELD=0`, `HWATU_AUTOPLAY=muted|deny`,
+  `HWATU_MOBILE_UA_SITES`, `HWATU_DISABLE_MEDIA=1`.
+
+## Assets
+
+| asset | contents |
+|---|---|
+| `hwatu-linux-x86_64.tar.gz` | `hwatu` + `hwatud`, x86_64, ~2.2 MB |
+| `hwatu-linux-aarch64.tar.gz` | same, aarch64 |
+| `hwatu-mcp-linux-x86_64.tar.gz` | MCP registry package (same binaries) |
+
+Install: `curl -fsSL https://raw.githubusercontent.com/hongnoul/hwatu/main/scripts/install.sh | bash`
+or the AUR package / Docker image.


### PR DESCRIPTION
Adds docs/releases/v0.7.0.md: the shortform-release story (unified IG Reels/Shorts/TikTok controls, media correctness, blur-shield, smoothwheel key routing, hwatu clone, mainstream controls, Docker/MCP distribution) plus benchmarks remeasured on the v0.7.0 binaries this morning.

Measured on the usual rig (isolated XDG_RUNTIME_DIR, fresh daemon, loopback fixture, medians over 12):
- warm check --eval --shot: 16 ms (docs previously said 39 ms)
- check --until dom: 5 ms (was 21 ms)
- headless spawn: 2-3 ms (was 14 ms)
- 5 headless windows: 375 MB PSS, unique-PID accounting

Memory row is flagged as not strictly A/B comparable (headless vs mapped windows). Feature-level numbers (blur-shield fps, Reels paging, clone fidelity) are quoted from the verified commit messages.

Per repo policy this is a PR for review, not a direct push. Numbers can be rerun via scripts/bench-spawn.sh and scripts/bench-vs-playwright.mjs.