### PR TITLE
docs: lead v0.7.0 notes with user QoL; swap README hero to shortform demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **STOP browser windows stealing your focus. Headless by default, you keep typing.**
 - **STOP shipping 170 MB of Chromium. One static binary + your distro's webkitgtk.**
 
-<a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-aiuc.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-aiuc.webp" alt="hwatu real workflow: open headless, verify the rendered page, then hand the live browser to a human" width="800"></a>
+<a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.webp" alt="hwatu daily driving: quarter-width window spawns, buttery Chromium-curve scrolling, and one-keypress-one-reel shortform controls on Instagram Reels" width="800"></a>
 
 ## Documents
 

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -4,17 +4,63 @@ Released 2026-08-01. [Tag](https://github.com/hongnoul/hwatu/releases/tag/v0.7.0
 [Full changelog](https://github.com/hongnoul/hwatu/compare/v0.6.1...v0.7.0)
 
 v0.6.x made hwatu a fast verification browser. v0.7.0 makes it a
-browser someone can actually *watch things in*, and use the same
-media-correct engine for agent verification of video-heavy pages.
-The release also ships `hwatu clone` (one-shot faithful page copy
-with measured verification), a Docker image for MCP distribution,
-and a mainstream-controls UI pass.
+browser you *want* to live in. The theme is user-side quality of
+life: every scroll frame is animated at full refresh rate, every new
+window lands as a tidy quarter-of-the-monitor pane, and shortform
+video (Instagram Reels, YouTube Shorts, TikTok) is a first-class
+citizen with one-keypress-one-reel controls and media that just
+behaves. The same media-correct engine serves agents verifying
+video-heavy pages. The release also ships `hwatu clone` (one-shot
+faithful page copy with measured verification), a Docker image for
+MCP distribution, and a mainstream-controls UI pass.
 
-## Headline features
+## Daily-driver quality of life
 
-### Unified shortform controls (Instagram Reels, YouTube Shorts, TikTok)
+### Every scroll frame, at your monitor's refresh rate
 
-All shortform feeds now share one control scheme:
+Scrolling is the highest-frequency interaction in a browser, and
+v0.7.0 finishes making every frame of it deliberate:
+
+- **Wheel and keys share one animator.** The Chromium-style curve
+  that smoothed wheel scrolling now also drives Arrow, PageUp,
+  PageDown, and Space, replacing WebKitGTK's isolated-pulse keydown
+  scroller. Keys glide with preserved velocity, and holding a key
+  retargets the running animation instead of stacking pulses.
+- **Full refresh rate.** Scroll animation runs uncapped at the
+  monitor's rate (144 Hz on the reference rig) rather than the
+  60 fps ceiling the default dmabuf path imposed (landed in v0.6.1;
+  v0.7.0 builds the key path and snap handling on top of it).
+- **Snap containers cannot teleport.** The engine used to re-snap
+  every programmatic scroll in the same frame, quantizing the
+  animation into a jump; the snap property is suspended while the
+  animation flies and always lands on an exact snap offset.
+- **Fail-open by design.** Every path bails on `defaultPrevented`,
+  modifier chords, and editable targets, so pages that own their
+  scrolling keep owning it.
+
+### Quarter-viewport window spawn
+
+New windows now open at **25% of the monitor's width by default**,
+native to the tiling workflow hwatu lives in: four upright panes fit
+a 16:9 monitor edge to edge, which is exactly the column shape a
+portrait-video feed or a docs page wants. No more full-screen window
+stealing the workspace and immediately needing a resize. The
+launcher completes the pane aesthetic: it deals a hanafuda card per
+window (edge-to-edge, rotating 90° in landscape panes) with a
+caption-style prompt bar.
+
+The quarter-width pane and the shortform work below are one design:
+a 25%-width upright pane is the natural home for a vertical video
+feed, and hwatu treats that pairing as a first-class layout rather
+than a mobile site squeezed into a desktop window.
+
+### Shortform video as a first-class citizen (Reels, Shorts, TikTok)
+
+All shortform feeds share one control scheme, served in the layout
+they were designed for: hwatu hands touch-first sites an iPhone
+Safari UA (`HWATU_MOBILE_UA_SITES`, default instagram.com), so Reels
+arrives as the mobile vertical feed that actually fits a
+quarter-width pane.
 
 | key | action |
 |---|---|
@@ -49,9 +95,9 @@ ArrowRight seek) cannot shadow the scheme, and every shortcut only
 consumes the key when its target was actually found, so unknown pages
 fail open to native behavior.
 
-### Media correctness
+### Media that behaves
 
-Four fixes that together make video pages behave:
+Four fixes that together make video pages work the way you expect:
 
 - **Unmuted autoplay by default.** WebKit's default policy rejects
   unmuted `play()`, so sites fell back to muted players. Verified:
@@ -75,21 +121,16 @@ Four fixes that together make video pages behave:
   rAF 34-43 fps → ~95 fps, decode steady at native 25-30 fps with 0
   dropped frames. Gate: `HWATU_BLUR_SHIELD=0`.
 
-Supporting this, `hwatud` serves an iPhone Safari UA to touch-first
-sites (`HWATU_MOBILE_UA_SITES`, default instagram.com), switched at
-the response policy decision so a cross-host iframe can never flip
-the top-level page's UA. `HWATU_DISABLE_MEDIA=1` is the escape hatch
-for GStreamer wedges.
+Supporting this, `HWATU_DISABLE_MEDIA=1` is the escape hatch for
+GStreamer wedges.
 
-### Smoothwheel: Chromium-curve scrolling everywhere
+### Mainstream controls
 
-Wheel scrolling gained a Chromium-style animation curve in v0.6.x;
-v0.7.0 routes Arrow/PageUp/PageDown/Space through the same animator,
-so key scrolling glides with preserved velocity instead of WebKitGTK's
-isolated-pulse scroller, and auto-repeat retargets the running
-animation. On snap feeds, keys page exactly like a wheel tick. All
-paths bail on `defaultPrevented`, modifier chords, and editable
-targets, and fail open to native scrolling.
+The Vim-style UI is gone. URL editing is the default text entry,
+`ctrl+y` yanks the current page URL, and a test locks the Vim
+defaults out.
+
+## Agent-side features
 
 ### `hwatu clone`: one-shot faithful page copy, measured
 
@@ -110,13 +151,6 @@ python/imagemagick dependencies:
 Verified end-to-end on an isolated daemon: example.com 100.0% avg,
 webkit.org 95.2% avg across 5 positions (every miss named in the
 report: 404'd cross-origin font CSS).
-
-### Mainstream controls
-
-The Vim-style UI is gone. URL editing is the default text entry,
-`ctrl+y` yanks the current page URL, new windows default to quarter
-monitor width, and the launcher deals a hanafuda card per window.
-A test locks the Vim defaults out.
 
 ### Distribution
 


### PR DESCRIPTION
Follow-up to #25 (this commit was pushed to the branch just after the merge, so it never landed).

- Release notes restructured to open with the daily-driver QoL story: full-refresh-rate scroll frames (wheel + keys on one Chromium-curve animator), quarter-viewport window spawn as a first-class tiling layout, and shortform video as a first-class citizen, before the agent-side features.
- README hero video replaced with the new shortform demo recorded this morning on the v0.7.0 build (readme-assets: demo-shortform.mp4 / .webp, 91 s).

Note: v0.7.0 shipped quarter-width spawn; the later change to a third (865df74) is post-tag and belongs to the next release's notes.