### PR TITLE
feat: configure preferred browser window width

### DIFF
--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -90,13 +90,19 @@ fn autoplay_policy() -> webkit6::AutoplayPolicy {
     }
 }
 
-/// Read `"autoplay"` from ~/.config/hwatu/config.json (the same file
-/// adblock persists its toggle in). Returns None when absent/invalid.
-fn config_autoplay() -> Option<String> {
+/// Read one key from ~/.config/hwatu/config.json (the same file adblock
+/// persists its toggle in). Returns None when the file or key is
+/// absent/invalid.
+fn config_value(key: &str) -> Option<serde_json::Value> {
     let raw =
         std::fs::read_to_string(glib::user_config_dir().join("hwatu").join("config.json")).ok()?;
     let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
-    Some(v.get("autoplay")?.as_str()?.to_string())
+    Some(v.get(key)?.clone())
+}
+
+/// Read `"autoplay"` from config.json. Returns None when absent/invalid.
+fn config_autoplay() -> Option<String> {
+    Some(config_value("autoplay")?.as_str()?.to_string())
 }
 
 const DEFAULT_WINDOW_WIDTH: i32 = 1024;
@@ -126,15 +132,18 @@ fn default_window_width() -> i32 {
 const DEFAULT_PREFERRED_WIDTH: f64 = 1.0 / 3.0;
 
 fn preferred_width_ratio() -> f64 {
-    let raw =
-        std::fs::read_to_string(glib::user_config_dir().join("hwatu").join("config.json")).ok();
-    let config = raw
-        .as_deref()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-        .and_then(|value| value.get("preferred_width").and_then(|v| v.as_f64()));
-    config
-        .filter(|ratio| ratio.is_finite() && (0.0..=1.0).contains(ratio) && *ratio > 0.0)
+    config_value("preferred_width")
+        .and_then(|v| ratio_from_value(&v))
         .unwrap_or(DEFAULT_PREFERRED_WIDTH)
+}
+
+/// Accept only a finite fraction in (0, 1]; anything else (zero, negatives,
+/// above one, NaN, inf, non-numbers) is rejected so a typo cannot produce
+/// an invisible or absurd window.
+fn ratio_from_value(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0 && *ratio <= 1.0)
 }
 
 fn preferred_width(viewport_width: i32, ratio: f64) -> i32 {
@@ -2023,5 +2032,18 @@ mod tests {
             super::preferred_width(-1, super::DEFAULT_PREFERRED_WIDTH),
             1
         );
+    }
+
+    #[test]
+    fn ratio_from_value_accepts_only_fractions_in_zero_one() {
+        use serde_json::json;
+        assert_eq!(super::ratio_from_value(&json!(0.25)), Some(0.25));
+        assert_eq!(super::ratio_from_value(&json!(1.0)), Some(1.0));
+        assert_eq!(super::ratio_from_value(&json!(0.0)), None);
+        assert_eq!(super::ratio_from_value(&json!(-0.5)), None);
+        assert_eq!(super::ratio_from_value(&json!(1.5)), None);
+        assert_eq!(super::ratio_from_value(&json!("0.25")), None);
+        assert_eq!(super::ratio_from_value(&json!(null)), None);
+        assert_eq!(super::ratio_from_value(&json!({})), None);
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -93,10 +93,8 @@ fn autoplay_policy() -> webkit6::AutoplayPolicy {
 /// Read `"autoplay"` from ~/.config/hwatu/config.json (the same file
 /// adblock persists its toggle in). Returns None when absent/invalid.
 fn config_autoplay() -> Option<String> {
-    let raw = std::fs::read_to_string(
-        glib::user_config_dir().join("hwatu").join("config.json"),
-    )
-    .ok()?;
+    let raw =
+        std::fs::read_to_string(glib::user_config_dir().join("hwatu").join("config.json")).ok()?;
     let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
     Some(v.get("autoplay")?.as_str()?.to_string())
 }
@@ -128,10 +126,8 @@ fn default_window_width() -> i32 {
 const DEFAULT_PREFERRED_WIDTH: f64 = 1.0 / 3.0;
 
 fn preferred_width_ratio() -> f64 {
-    let raw = std::fs::read_to_string(
-        glib::user_config_dir().join("hwatu").join("config.json"),
-    )
-    .ok();
+    let raw =
+        std::fs::read_to_string(glib::user_config_dir().join("hwatu").join("config.json")).ok();
     let config = raw
         .as_deref()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -104,10 +104,12 @@ fn config_autoplay() -> Option<String> {
 const DEFAULT_WINDOW_WIDTH: i32 = 1024;
 const DEFAULT_WINDOW_HEIGHT: i32 = 768;
 
-/// Request a third of the current monitor's width for a newly mapped
-/// window. Tiling WMs use this as the initial size hint when deciding how to
-/// place a new toplevel, while floating WMs still get a useful desktop-sized
-/// window instead of an arbitrary fixed width.
+/// Request the preferred fraction of the current monitor's width for a newly
+/// mapped window. Tiling WMs use this as the initial size hint when deciding
+/// how to place a new toplevel, while floating WMs still get a useful
+/// desktop-sized window instead of an arbitrary fixed width. The built-in
+/// default is one third; users can override it with `"preferred_width"` in
+/// `~/.config/hwatu/config.json`.
 fn default_window_width() -> i32 {
     let Some(display) = gtk::gdk::Display::default() else {
         return DEFAULT_WINDOW_WIDTH;
@@ -120,11 +122,27 @@ fn default_window_width() -> i32 {
         return DEFAULT_WINDOW_WIDTH;
     };
 
-    third_width(monitor.geometry().width())
+    preferred_width(monitor.geometry().width(), preferred_width_ratio())
 }
 
-fn third_width(viewport_width: i32) -> i32 {
-    (viewport_width / 3).max(1)
+const DEFAULT_PREFERRED_WIDTH: f64 = 1.0 / 3.0;
+
+fn preferred_width_ratio() -> f64 {
+    let raw = std::fs::read_to_string(
+        glib::user_config_dir().join("hwatu").join("config.json"),
+    )
+    .ok();
+    let config = raw
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.get("preferred_width").and_then(|v| v.as_f64()));
+    config
+        .filter(|ratio| ratio.is_finite() && (0.0..=1.0).contains(ratio) && *ratio > 0.0)
+        .unwrap_or(DEFAULT_PREFERRED_WIDTH)
+}
+
+fn preferred_width(viewport_width: i32, ratio: f64) -> i32 {
+    ((viewport_width as f64) * ratio).floor().max(1.0) as i32
 }
 
 /// State saved across a discard. The session blob itself lives on disk
@@ -1954,14 +1972,18 @@ mod tests {
     }
 
     #[test]
-    fn third_width_uses_one_third_of_the_viewport() {
-        assert_eq!(super::third_width(1920), 640);
-        assert_eq!(super::third_width(1366), 455);
+    fn preferred_width_uses_the_configured_fraction_of_the_viewport() {
+        assert_eq!(super::preferred_width(1920, 1.0 / 3.0), 640);
+        assert_eq!(super::preferred_width(1366, 1.0 / 3.0), 455);
+        assert_eq!(super::preferred_width(1920, 0.25), 480);
     }
 
     #[test]
-    fn third_width_never_returns_zero() {
-        assert_eq!(super::third_width(0), 1);
-        assert_eq!(super::third_width(-1), 1);
+    fn preferred_width_never_returns_zero() {
+        assert_eq!(super::preferred_width(0, super::DEFAULT_PREFERRED_WIDTH), 1);
+        assert_eq!(
+            super::preferred_width(-1, super::DEFAULT_PREFERRED_WIDTH),
+            1
+        );
     }
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -520,6 +520,15 @@ hwatu focus $id    # window appears in their WM, session intact
 
 ## Window modes
 
+New visible windows request one third of the first monitor's width by
+default. A personal installation can override that initial size without
+changing the upstream default by adding a fractional value between 0 and 1
+to `~/.config/hwatu/config.json`:
+
+```json
+{"preferred_width": 0.25}
+```
+
 - **normal**: map + request focus. What a human asked for.
 - **background**: mapped, rendered, present in the WM layout, but
   no activation request: focus stays where the user has it. Pair

--- a/docs/human.md
+++ b/docs/human.md
@@ -18,7 +18,9 @@ one-line y/n bar prompts.
 
 New windows open at a third of the monitor width, matching the first
 stop of niri's default 1/3, 1/2, 2/3 preset-width cycle and a
-comfortable reading width on 1080p-class monitors. The launcher deals a
+comfortable reading width on 1080p-class monitors. Prefer a different
+fraction? Set `"preferred_width"` in `~/.config/hwatu/config.json`
+(see [Configuration](#configuration)). The launcher deals a
 hanafuda card per window so windows are tellable apart at a glance.
 
 If you want history completion and password-manager integration,
@@ -109,9 +111,11 @@ hwatu quit                 # stop the daemon
 ## Configuration
 
 - `~/.config/hwatu/keys.conf`: keybindings (above).
-- `~/.config/hwatu/config.json`: persistent policy. Today that is
-  `{"autoplay": "muted"|"deny"}`; the env var wins for a single run
-  but vanishes on daemon restart.
+- `~/.config/hwatu/config.json`: persistent policy.
+  - `"autoplay": "muted"|"deny"`: the env var wins for a single run
+    but vanishes on daemon restart.
+  - `"preferred_width": 0.25`: initial window width as a fraction of
+    the monitor width, between 0 and 1. Default is one third.
 - Env-only gates, read at window creation: `HWATU_FOCUS_SHIELD=0`,
   `HWATU_BLUR_SHIELD=0`, `HWATU_DISABLE_MEDIA=1`.
 


### PR DESCRIPTION
## Summary
- keep the upstream default at one third of the first monitor width
- allow a personal `preferred_width` fraction in `~/.config/hwatu/config.json`
- document the 25% personal override without committing personal config

## Validation
- `cargo test --workspace`
- `cargo test -p hwatud window::tests`
- `git diff --check