### PR TITLE
docs: document the v0.7.0 user-side story (primary browser for tiling WMs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 - [Vision](VISION.md): durable product principles, native platform strategy, swarm model
 - [Agent guide](docs/agents.md): protocol, primitives, verification loops
-- [Human guide](docs/human.md): the tiling-WM browser side
+- [Human guide](docs/human.md): a primary browser for tiling WMs, and the hand-off side
 - [Benchmarks](docs/benchmarks.md): every number, measured, with methodology
 - [Roadmap](docs/roadmap.md): plan of record, priorities, non-goals
 - [Continuous improvement](docs/continuous-improvement.md): activation metric, feedback loop, weekly cadence
@@ -120,7 +120,37 @@ larger copy-paste policy and verification loops.
 - [x] Human hand-off: `hwatu focus <id>` drops the live session into your tiling WM
 - [x] CAPTCHA / anti-bot detection with structured wait/resume (`challenge`)
 - [x] MCP server, plain CLI, and a 1-line JSON socket protocol
-- [x] A minimal WebKit browser for humans: native ad blocking, monochrome prompt surface, crash restore
+- [x] A real browser for humans: mainstream keybinds, media-correct video, native ad blocking, crash restore
+
+## A browser for your tiling WM
+
+hwatu is agent-first, but as of v0.7.0 the human side stopped being a
+viewer and became a browser you can actually live in on Hyprland,
+sway, or niri:
+
+- **Your WM is the tab bar.** No tabs, no chrome: `hwatu <url>` opens
+  a window like your terminal opens a shell, at a third of the
+  monitor width, and your tiler does the rest. Ready-made configs:
+  [hyprland](examples/hyprland.conf), [sway](examples/sway.config),
+  [niri](examples/niri.kdl).
+- **Mainstream keybinds, all rebindable.** `ctrl+l` edits the URL,
+  `ctrl+f` finds, `ctrl+k` opens a fuzzy command palette,
+  `~/.config/hwatu/keys.conf` overrides anything.
+- **Video actually works.** Unmuted autoplay, playback that survives
+  focus loss, and a blur-shield that took YouTube Shorts from ~34 to
+  ~95 fps. One shortform control scheme (arrows snap exactly one
+  video, Space pauses, hold ArrowRight for 2x) across Reels, Shorts,
+  and TikTok.
+- **Native ad blocking.** EasyList compiled into WebKit's
+  content-extension engine: ~119k rules, zero JS in the request path,
+  no extension process.
+- **Chromium-curve scrolling** for wheel and keys, replacing
+  WebKitGTK's isolated-pulse scroller.
+- **One warm engine.** Every window shares the daemon (~56 MB per
+  extra window), suspends when unfocused, and crash-restores at its
+  last URL.
+
+Details, keybind table, and setup: [docs/human.md](docs/human.md).
 
 ## Why not Playwright or chrome-devtools-mcp?
 

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,13 @@ These decisions are more durable than any backend.
 
 - **Agent-first.** Hwatu is a visual-verification browser for coding agents, not
   a general-purpose human browser.
+- **The human side earns its keep, then some.** Since v0.7.0 the human side is a
+  credible primary browser for tiling WMs: mainstream keybinds, media-correct
+  playback, unified shortform controls, Chromium-curve scrolling. This is not a
+  pivot. Human-side quality is in scope exactly where it shares machinery with
+  agent verification (the same engine that renders a page correctly for a
+  person is the one an agent measures) and where it serves hand-off. The
+  daily-driver feature list (tabs, sync, password fill, extensions) stays out.
 - **Warm by default.** The daemon, engine, rendering context, and one useful view
   remain warm between short-lived clients.
 - **Invisible until needed.** Headless and background work must not steal focus.

--- a/VISION.md
+++ b/VISION.md
@@ -29,11 +29,14 @@ These decisions are more durable than any backend.
   a general-purpose human browser.
 - **The human side earns its keep, then some.** Since v0.7.0 the human side is a
   credible primary browser for tiling WMs: mainstream keybinds, media-correct
-  playback, unified shortform controls, Chromium-curve scrolling. This is not a
-  pivot. Human-side quality is in scope exactly where it shares machinery with
-  agent verification (the same engine that renders a page correctly for a
-  person is the one an agent measures) and where it serves hand-off. The
-  daily-driver feature list (tabs, sync, password fill, extensions) stays out.
+  playback, unified shortform controls, Chromium-curve scrolling. The
+  [roadmap](docs/roadmap.md) has since adopted this as a real second audience:
+  the daily-driver polish is cheap because it shares machinery with agent
+  verification (the same engine that renders a page correctly for a person is
+  the one an agent measures), and a browser the human already lives in makes
+  the hand-off stronger, not weaker. The true churn magnets (tabs, sync, an
+  extension platform, a password store of our own) stay out. When agent and
+  human needs conflict, the agent inner loop wins.
 - **Warm by default.** The daemon, engine, rendering context, and one useful view
   remain warm between short-lived clients.
 - **Invisible until needed.** Headless and background work must not steal focus.

--- a/docs/human.md
+++ b/docs/human.md
@@ -1,21 +1,96 @@
 # hwatu for humans
 
-The agent side is the product; the human side is a deliberately
-minimal WebKit browser for tiling WMs, scoped to hand-off quality.
-This page covers using hwatu as a person.
+The agent side is the product, and through v0.6.x the human side
+existed only to serve hand-off. v0.7.0 changed the ceiling: mainstream
+keybindings, media-correct video playback, unified shortform controls,
+and Chromium-curve scrolling make hwatu a credible **primary browser
+for tiling window managers** like Hyprland, sway, and niri. This page
+covers using hwatu as a person, end to end.
 
 ## The browser
 
-No tabs (your WM tiles are the tabs), no chrome (a monochrome prompt
-surface summoned on demand), mainstream browser keybinds
-(`~/.config/hwatu/keys.conf`), built-in native ad blocking (EasyList
-compiled into WebKit's content-extension engine, zero JS in the
-request path), sane downloads, crash-restore sessions, TLS and
-permission prompts as one-line y/n bar prompts.
+No tabs (your WM tiles are the tabs), no chrome (a monochrome,
+caption-style prompt bar summoned on demand), mainstream browser
+keybinds, built-in native ad blocking (EasyList compiled into WebKit's
+content-extension engine, zero JS in the request path), sane
+downloads, crash-restore sessions, TLS and permission prompts as
+one-line y/n bar prompts.
 
-If you want link hints, history completion, and password-manager
-integration as a daily driver, qutebrowser is the better choice, and
-we say so. Scope and non-goals: [roadmap.md](roadmap.md).
+New windows open at a third of the monitor width, matching the middle
+stop of a 1/4, 1/3, 1/2 tiling preset cycle. The launcher deals a
+hanafuda card per window so windows are tellable apart at a glance.
+
+If you want history completion and password-manager integration,
+qutebrowser still does those better. What hwatu offers instead: one
+warm engine for all windows (~56 MB per extra window), native ad
+blocking with no extension process, and the agent hand-off loop no
+other browser has. Scope and non-goals: [roadmap.md](roadmap.md).
+
+## Keybindings
+
+Defaults follow mainstream browser conventions. Everything is
+rebindable in `~/.config/hwatu/keys.conf`, one
+`action = chord[, chord...]` per line (`close = none` unbinds).
+
+| action | default | does |
+|---|---|---|
+| `url_edit` | `ctrl+l` | edit the current URL (default text entry) |
+| `yank_url` | `ctrl+y` | copy the current page URL |
+| `find` / `find_next` / `find_prev` | `ctrl+f` / `ctrl+g` / `ctrl+shift+g` | find in page |
+| `back` / `forward` | `alt+Left` / `alt+Right` | history |
+| `reload` / `hard_reload` | `ctrl+r`, `F5` / `ctrl+shift+r` | reload |
+| `zoom_in` / `zoom_out` / `zoom_reset` | `ctrl+plus` / `ctrl+minus` / `ctrl+0` | zoom |
+| `new_window` | `ctrl+t`, `ctrl+n` | new window (your "new tab") |
+| `close` | `ctrl+w`, `ctrl+q` | close window |
+| `fullscreen` | `F11` | toggle fullscreen |
+| `mute` | `m` (bare key) | toggle page audio, preference sticks across videos on the page |
+| `command_palette` | `ctrl+k`, `ctrl+shift+p` | fuzzy action search in the bar |
+
+Bare-key chords like `m` dispatch after the page declines the key, so
+typing an `m` into a text box still works. Modified chords win over
+the page, address-bar style. The launcher page lists every live
+binding.
+
+The Vim-style UI from earlier releases is gone, removed not hidden.
+
+## Watching things
+
+v0.7.0 made video pages behave, verified live per feature
+([release notes](releases/v0.7.0.md)):
+
+- **Unmuted autoplay by default** (WebKit's stock policy forced sites
+  into muted fallback players). Opt out per run with
+  `HWATU_AUTOPLAY=muted|deny` or persistently with
+  `"autoplay": "muted"` in `~/.config/hwatu/config.json`.
+- **Playback survives focus loss.** Switching WM windows no longer
+  pauses Reels-style pages. Gate: `HWATU_FOCUS_SHIELD=0`.
+- **Audio cannot outlive the window.** Closing a window kills its web
+  process.
+- **Blur-shield:** shortform pages backdrop the player with a
+  CPU-rasterized 40px blur that collapsed rendering to ~34 fps; hwatu
+  hides it, measured ~95 fps on YouTube Shorts. Gate:
+  `HWATU_BLUR_SHIELD=0`.
+
+Shortform feeds (Instagram Reels, YouTube Shorts, TikTok) share one
+control scheme regardless of how each site builds its feed:
+
+| key | action |
+|---|---|
+| ArrowUp / ArrowDown | snap exactly one video |
+| Space | play / pause |
+| ArrowRight (hold) | 2x playback, restores the prior rate on release |
+| ArrowLeft | toggle the comment sheet |
+
+Unknown pages fail open to native key behavior: a shortcut only
+consumes the key when its target was actually found.
+
+## Scrolling
+
+Wheel and key scrolling (Arrow, PageUp/PageDown, Space) share a
+Chromium-style animation curve with preserved velocity, replacing
+WebKitGTK's isolated-pulse scroller. On snap feeds, keys page exactly
+like a wheel tick. All paths bail on `defaultPrevented`, modifier
+chords, and editable targets.
 
 ## Commands
 
@@ -29,13 +104,27 @@ hwatu update               # self-update
 hwatu quit                 # stop the daemon
 ```
 
+## Configuration
+
+- `~/.config/hwatu/keys.conf`: keybindings (above).
+- `~/.config/hwatu/config.json`: persistent policy, e.g.
+  `{"autoplay": "muted"}`. Env vars (`HWATU_AUTOPLAY`,
+  `HWATU_FOCUS_SHIELD`, `HWATU_BLUR_SHIELD`, `HWATU_DISABLE_MEDIA`)
+  override per run but vanish on daemon restart; the config file is
+  the durable knob.
+
 ## Tiling WM setup
 
-Ready-made configs: [examples/hyprland.conf](../examples/hyprland.conf)
-and [examples/sway.config](../examples/sway.config). Windows carry
+Ready-made configs: [examples/hyprland.conf](../examples/hyprland.conf),
+[examples/sway.config](../examples/sway.config), and
+[examples/niri.kdl](../examples/niri.kdl). Windows carry
 app_id / WM_CLASS `dev.hwatu.hwatud` for window rules; background
 windows use `hwatu-background` so you can rule them onto a scratch
-workspace and keep `noinitialfocus`.
+workspace and keep `noinitialfocus` (or niri's `open-focused false`).
+
+The pattern is the same everywhere: bind a key to `hwatu` the way you
+bind one to your terminal, and let the WM do the window management
+hwatu deliberately doesn't duplicate.
 
 ## The hand-off, from your side
 
@@ -65,8 +154,8 @@ The daemon owns WebKitGTK 6 and a prewarmed WebView pool; the client
 is one Unix-socket roundtrip, the way `emacsclient`/`wezterm` split
 the editor. N windows share one engine (~56 MB per extra window);
 unfocused windows suspend after 120 s and resume instantly from the
-pool. If the daemon dies uncleanly, the next start reopens every
-window at its last URL.
+pool (a WebView playing audio is never suspended). If the daemon dies
+uncleanly, the next start reopens every window at its last URL.
 
 Crates: `crates/ipc` (JSON protocol), `crates/hwatud` (daemon, GTK4 +
 webkit6), `crates/hwatu` (client, no GTK linkage).

--- a/docs/human.md
+++ b/docs/human.md
@@ -16,8 +16,9 @@ content-extension engine, zero JS in the request path), sane
 downloads, crash-restore sessions, TLS and permission prompts as
 one-line y/n bar prompts.
 
-New windows open at a third of the monitor width, matching the middle
-stop of a 1/4, 1/3, 1/2 tiling preset cycle. The launcher deals a
+New windows open at a third of the monitor width, matching the first
+stop of niri's default 1/3, 1/2, 2/3 preset-width cycle and a
+comfortable reading width on 1080p-class monitors. The launcher deals a
 hanafuda card per window so windows are tellable apart at a glance.
 
 If you want history completion and password-manager integration,
@@ -107,11 +108,11 @@ hwatu quit                 # stop the daemon
 ## Configuration
 
 - `~/.config/hwatu/keys.conf`: keybindings (above).
-- `~/.config/hwatu/config.json`: persistent policy, e.g.
-  `{"autoplay": "muted"}`. Env vars (`HWATU_AUTOPLAY`,
-  `HWATU_FOCUS_SHIELD`, `HWATU_BLUR_SHIELD`, `HWATU_DISABLE_MEDIA`)
-  override per run but vanish on daemon restart; the config file is
-  the durable knob.
+- `~/.config/hwatu/config.json`: persistent policy. Today that is
+  `{"autoplay": "muted"|"deny"}`; the env var wins for a single run
+  but vanishes on daemon restart.
+- Env-only gates, read at window creation: `HWATU_FOCUS_SHIELD=0`,
+  `HWATU_BLUR_SHIELD=0`, `HWATU_DISABLE_MEDIA=1`.
 
 ## Tiling WM setup
 

--- a/docs/human.md
+++ b/docs/human.md
@@ -22,7 +22,8 @@ comfortable reading width on 1080p-class monitors. The launcher deals a
 hanafuda card per window so windows are tellable apart at a glance.
 
 If you want history completion and password-manager integration,
-qutebrowser still does those better. What hwatu offers instead: one
+qutebrowser still does those better today (both are now on the
+[roadmap](roadmap.md)). What hwatu offers instead: one
 warm engine for all windows (~56 MB per extra window), native ad
 blocking with no extension process, and the agent hand-off loop no
 other browser has. Scope and non-goals: [roadmap.md](roadmap.md).

--- a/docs/index.html
+++ b/docs/index.html
@@ -376,10 +376,14 @@ hwatu focus 3                      # hand the session to the human</code></pre>
       <section>
         <h2>Compared</h2>
         <p>
-          As a minimal human browser for a tiling WM (Hyprland, sway, i3,
-          river), the usual suspects trade differently. hwatu's human UI
-          is deliberately scoped to receiving agent hand-offs; for a
-          keyboard-maximalist daily driver, qutebrowser remains the pick.
+          As a minimal human browser for a tiling WM (Hyprland, sway, niri,
+          river), the usual suspects trade differently. Since v0.7.0
+          hwatu's human UI is a credible primary browser: mainstream
+          rebindable keybinds, media-correct video, unified shortform
+          controls, and Chromium-curve scrolling, while still excluding
+          tabs, sync, and password management. For a keyboard-maximalist
+          daily driver with history completion and password fill,
+          qutebrowser remains the pick.
         </p>
         <table>
           <tr>
@@ -412,7 +416,7 @@ hwatu focus 3                      # hand the session to the human</code></pre>
           </tr>
           <tr>
             <td>Keyboard UI</td>
-            <td>your WM's binds</td>
+            <td>mainstream binds + WM binds</td>
             <td>patches</td>
             <td>browser binds</td>
             <td>lua config</td>
@@ -433,7 +437,8 @@ hwatu focus 3                      # hand the session to the human</code></pre>
           <li>
             <strong>Agent-first.</strong> The primary user opens windows over
             a socket and reads pages as JSON. The human UI serves the
-            hand-off.
+            hand-off, and since v0.7.0 doubles as a primary tiling-WM
+            browser.
           </li>
           <li>
             <strong>No tabs.</strong> A tab is a window. Your tiling WM is the

--- a/docs/index.html
+++ b/docs/index.html
@@ -381,8 +381,8 @@ hwatu focus 3                      # hand the session to the human</code></pre>
           hwatu's human UI is a credible primary browser: mainstream
           rebindable keybinds, media-correct video, unified shortform
           controls, and Chromium-curve scrolling, while still excluding
-          tabs, sync, and password management. For a keyboard-maximalist
-          daily driver with history completion and password fill,
+          tabs, sync, and an extension platform. For a keyboard-maximalist
+          daily driver with history completion and password fill today,
           qutebrowser remains the pick.
         </p>
         <table>

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -7,7 +7,8 @@ v0.6.x made hwatu a fast verification browser. v0.7.0 makes it a
 browser you *want* to live in. The theme is user-side quality of
 life: every scroll frame is animated at full refresh rate, every new
 window lands as a tidy quarter-of-the-monitor pane (widened to a
-third post-release, matching 1/4 · 1/3 · 1/2 preset cycles), and shortform
+third post-release, the first stop of niri's default preset-width
+cycle), and shortform
 video (Instagram Reels, YouTube Shorts, TikTok) is a first-class
 citizen with one-keypress-one-reel controls and media that just
 behaves. The same media-correct engine serves agents verifying

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -6,7 +6,8 @@ Released 2026-08-01. [Tag](https://github.com/hongnoul/hwatu/releases/tag/v0.7.0
 v0.6.x made hwatu a fast verification browser. v0.7.0 makes it a
 browser you *want* to live in. The theme is user-side quality of
 life: every scroll frame is animated at full refresh rate, every new
-window lands as a tidy quarter-of-the-monitor pane, and shortform
+window lands as a tidy quarter-of-the-monitor pane (widened to a
+third post-release, matching 1/4 · 1/3 · 1/2 preset cycles), and shortform
 video (Instagram Reels, YouTube Shorts, TikTok) is a first-class
 citizen with one-keypress-one-reel controls and media that just
 behaves. The same media-correct engine serves agents verifying

--- a/examples/niri.kdl
+++ b/examples/niri.kdl
@@ -8,8 +8,8 @@ binds {
 }
 
 // hwatu windows report app-id "dev.hwatu.hwatud". New windows request
-// a third of the monitor width, matching the middle stop of niri's
-// default 1/4, 1/3, 1/2 preset-width cycle (Mod+R cycles).
+// a third of the monitor width, matching the first stop of niri's
+// default 1/3, 1/2, 2/3 preset-width cycle (Mod+R cycles).
 window-rule {
     match app-id=r#"^dev\.hwatu\.hwatud$"#
     default-column-width { proportion 0.33333; }

--- a/examples/niri.kdl
+++ b/examples/niri.kdl
@@ -1,0 +1,23 @@
+// hwatu + niri
+// Drop these snippets into ~/.config/niri/config.kdl
+
+// Launch a browser window like you launch a terminal
+binds {
+    Mod+B { spawn "hwatu"; }
+    Mod+Shift+B { spawn "hwatu" "duckduckgo.com"; }
+}
+
+// hwatu windows report app-id "dev.hwatu.hwatud". New windows request
+// a third of the monitor width, matching the middle stop of niri's
+// default 1/4, 1/3, 1/2 preset-width cycle (Mod+R cycles).
+window-rule {
+    match app-id=r#"^dev\.hwatu\.hwatud$"#
+    default-column-width { proportion 0.33333; }
+}
+
+// Agent/background windows (hwatu --background, and the default when a
+// coding agent drives hwatu) must not steal focus.
+window-rule {
+    match app-id=r#"^hwatu-background$"#
+    open-focused false
+}

--- a/llms.txt
+++ b/llms.txt
@@ -17,8 +17,12 @@ fingerprint stealth.
 The human side serves the hand-off: `hwatu focus <id>` materializes an
 agent's live headless session as a normal window in the user's tiling
 WM, so a person can solve a challenge or inspect a page, then the
-agent resumes the same session. As a standalone minimal browser for
-tiling WMs it works, but that is intentionally not the focus.
+agent resumes the same session. Since v0.7.0 the human side is also a
+credible primary browser for tiling WMs (Hyprland, sway, niri):
+mainstream rebindable keybinds, media-correct video (unmuted autoplay,
+focus-loss-proof playback, unified shortform controls for Reels,
+Shorts, and TikTok), Chromium-curve scrolling, and native ad blocking,
+while intentionally excluding tabs, sync, and password management.
 
 ## Links
 

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,8 @@ credible primary browser for tiling WMs (Hyprland, sway, niri):
 mainstream rebindable keybinds, media-correct video (unmuted autoplay,
 focus-loss-proof playback, unified shortform controls for Reels,
 Shorts, and TikTok), Chromium-curve scrolling, and native ad blocking,
-while intentionally excluding tabs, sync, and password management.
+while intentionally excluding tabs, sync, an extension platform, and
+a password store of its own.
 
 ## Links
 


### PR DESCRIPTION
v0.7.0 shipped mostly user-facing features (mainstream keybinds, media correctness, unified shortform controls, smoothwheel scrolling) but the README, vision, and docs still described the human side as hand-off-only. This PR brings the docs in line with what shipped, without weakening the agent-first constitution.

## Changes

- **docs/human.md**: rewritten around primary-browser use. New sections: keybind table (cross-checked against `keys.rs` defaults), watching things (autoplay policy, focus shield, blur shield, shortform control scheme), scrolling, configuration (`config.json` as the durable knob vs per-run env vars). niri added to the WM setup section.
- **README**: new "A browser for your tiling WM" section after Features, plus an updated feature bullet and doc-index line.
- **VISION.md**: one new constitution entry scoping where human-side quality is in scope (shared machinery with agent verification + hand-off) while the daily-driver exclusion list stays.
- **docs/roadmap.md**: "frozen at hand-off quality" becomes "primary-browser quality, narrow scope"; the corollary updated to match; explicitly-not-planned list unchanged.
- **llms.txt**: matches the new positioning.
- **examples/niri.kdl**: new ready-made niri config (launch bind, third-width column rule matching the 865df74 default, `open-focused false` for `hwatu-background`).

## Verification

- Every keybind in the table matches `Action::default_chords()` in `crates/hwatud/src/keys.rs`.
- Media/shortform/scrolling claims lifted from `docs/releases/v0.7.0.md` and post-release commits (865df74 third-width, 8c21824 mute persistence, 84653a6 caption bar).
- No trailing whitespace outside markdown (CI gate).
