### PR TITLE
docs: apex README, agent verification harness first

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,30 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CI](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml/badge.svg)](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml)
 
-**One warm browser, two users: you in your tiling WM, and your coding agent.**
+**Real eyes for your coding agent: verified page checks it can't fake, in one warm browser you can also live in.**
 
 </div>
 
-hwatu is a WebKit daemon with two front doors. For **humans on
-Hyprland, sway, niri, or i3**, it is a primary browser built for the
-window-per-page model: no tabs (your WM is the tab bar), mainstream
-keybinds, native ad blocking, media that actually plays. For **coding
-agents**, it is real eyes: one-call verified page checks in ~35 ms,
-pixel-diff scores instead of "looks right to me", and headless
-windows that never steal your focus.
+hwatu is a visual verification harness for coding agents, built as a
+WebKit daemon. Instead of "looks right to me", your agent gets
+**one-call verified page checks in ~35 ms**, **pixel-diff scores it
+can climb**, **animations as numbers**, and **headless windows that
+never steal your focus**, at any parallelism.
 
-The seam between the two is the feature no other browser has: an
-agent's invisible session and your daily-driver window are the same
-object. `hwatu focus <id>` materializes a live agent session, cookies
-and half-filled forms intact, into your tiler. You act, it takes
-back over.
-
-<a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.webp" alt="hwatu daily driving: quarter-width window spawns, buttery Chromium-curve scrolling, and one-keypress-one-reel shortform controls on Instagram Reels" width="800"></a>
+The same daemon has a second front door: it is a real browser for
+tiling WMs (Hyprland, sway, niri, i3), so while your agents loop you
+watch some reels. That is not a gimmick, it is the seam no other tool
+has: an agent's invisible session and your window are the same
+object. When the agent hits a CAPTCHA or wants human judgment,
+`hwatu focus <id>` materializes the live session, cookies and
+half-filled forms intact, into your tiler. You act, it takes back
+over.
 
 ## Documents
 
 - [Vision](VISION.md): durable product principles, native platform strategy, swarm model
-- [Human guide](docs/human.md): daily driving hwatu in a tiling WM, keybinds, media, hand-off
 - [Agent guide](docs/agents.md): protocol, primitives, verification loops
+- [Human guide](docs/human.md): daily driving hwatu in a tiling WM, keybinds, media, hand-off
 - [Benchmarks](docs/benchmarks.md): every number, measured, with methodology
 - [Roadmap](docs/roadmap.md): plan of record, priorities, non-goals
 - [Continuous improvement](docs/continuous-improvement.md): activation metric, feedback loop, weekly cadence
@@ -48,47 +47,9 @@ checks). On Arch: `yay -S hwatu`. From source: `cargo build --release`.
 Then pick your door, or take both:
 
 ```sh
-hwatu localhost:3000    # human: open a window like you open a terminal
 hwatu setup             # agent: detect Claude Code, Cursor, Jcode, or MCP
+hwatu localhost:3000    # human: open a window like you open a terminal
 ```
-
-## A primary browser for your tiling WM
-
-You already have a window manager you like. hwatu is the browser that
-stops fighting it:
-
-- **Your WM is the tab bar.** No tabs, no chrome: `hwatu <url>` opens
-  a window like your terminal opens a shell, at a third of the
-  monitor width, and your tiler does the rest. Ready-made configs:
-  [hyprland](examples/hyprland.conf), [sway](examples/sway.config),
-  [niri](examples/niri.kdl).
-- **Mainstream keybinds, all rebindable.** `ctrl+l` edits the URL,
-  `ctrl+f` finds, `ctrl+k` opens a fuzzy command palette,
-  `~/.config/hwatu/keys.conf` overrides anything. Config is a
-  dotfile, not a settings maze.
-- **Video actually works.** Unmuted autoplay, playback that survives
-  focus loss, and a blur-shield that took YouTube Shorts from ~34 to
-  ~95 fps. One shortform control scheme (arrows snap exactly one
-  video, Space pauses, hold ArrowRight for 2x) across Reels, Shorts,
-  and TikTok.
-- **Native ad blocking.** EasyList compiled into WebKit's
-  content-extension engine: ~119k rules, zero JS in the request path,
-  no extension process.
-- **Chromium-curve scrolling** for wheel and keys, replacing
-  WebKitGTK's isolated-pulse scroller.
-- **One warm engine.** Every window shares the daemon (~56 MB per
-  extra window), suspends when unfocused, and crash-restores at its
-  last URL.
-
-People adopt browsers in this category (qutebrowser, vimb, luakit)
-for keyboard-first UX and the window-per-page model, and abandon them
-over ad quality, broken sites, and video. hwatu attacks the
-abandonment list head-on; the [roadmap](docs/roadmap.md) tracks what
-is landed and what is next (global history and URL completion, link
-hints, password-manager integration). Honest gaps today: qutebrowser
-still wins on history completion and password fill, and WebKitGTK has
-no Widevine or passkeys, so keep a fallback browser bound for
-Netflix. Full keybind table and setup: [docs/human.md](docs/human.md).
 
 ## Real eyes for your coding agent
 
@@ -160,10 +121,10 @@ hwatu diff --id 2 --other 1
 
 We ran this loop against a clone of stripe.com's landing page: an
 agent took it from **85.1% to 98.8% pixel match**. Reproduce it:
-[scripts/demo/](scripts/demo/). The README hero uses a second,
-real-agent scenario against AIUC: four responsive viewport diffs
-followed by live human hand-off, reproducible with evidence manifests
-from [scripts/demo-aiuc/](scripts/demo-aiuc/).
+[scripts/demo/](scripts/demo/). A second, real-agent scenario against
+AIUC (four responsive viewport diffs followed by live human hand-off)
+is reproducible with evidence manifests from
+[scripts/demo-aiuc/](scripts/demo-aiuc/).
 
 A full verification pass (open, load, eval, screenshot, close) is
 **one command, one tool call, ~35 ms median**
@@ -213,9 +174,32 @@ for emergencies.
 `challenge` is detection and hand-off only, by design: no solver
 APIs, no token injection, no fingerprint games.
 
+## Agents loop, you watch some reels
+
+The hand-off works because hwatu is also a real browser, one built
+for tiling WMs. `hwatu <url>` opens a window like your terminal opens
+a shell (your WM is the tab bar, there is none in the window), with
+mainstream keybinds (`ctrl+l`, `ctrl+f`, `ctrl+k` palette, all
+rebindable via a dotfile), native ad blocking (~119k EasyList rules
+compiled into WebKit's content-extension engine, zero JS in the
+request path), Chromium-curve scrolling, and video that actually
+works: unmuted autoplay, a blur-shield that took Shorts from ~34 to
+~95 fps, and one shortform control scheme (arrows snap exactly one
+video, Space pauses, hold ArrowRight for 2x) across Reels, Shorts,
+and TikTok.
+
+<a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.webp" alt="hwatu daily driving: quarter-width window spawns, buttery Chromium-curve scrolling, and one-keypress-one-reel shortform controls on Instagram Reels" width="800"></a>
+
+Every window shares the one warm daemon (~56 MB per extra window),
+suspends when unfocused, and crash-restores at its last URL. Honest
+gaps: no Widevine or passkeys in WebKitGTK, so keep a fallback bound
+for Netflix. Ready-made WM configs
+([hyprland](examples/hyprland.conf), [sway](examples/sway.config),
+[niri](examples/niri.kdl)), the full keybind table, and setup:
+[docs/human.md](docs/human.md).
+
 ## Features
 
-- [x] A real browser for humans: mainstream keybinds, media-correct video, native ad blocking, crash restore
 - [x] Headless / background / focused as a *per-window* property, switchable live
 - [x] Human hand-off: `hwatu focus <id>` drops the live session into your tiling WM
 - [x] Pixel-diff scoring: match percent + diff regions + heatmap (`diff`)
@@ -228,6 +212,7 @@ APIs, no token injection, no fingerprint games.
 - [x] One-call page assertions with polling (`expect`)
 - [x] CAPTCHA / anti-bot detection with structured wait/resume (`challenge`)
 - [x] MCP server, plain CLI, and a 1-line JSON socket protocol
+- [x] A real browser for humans: mainstream keybinds, media-correct video, native ad blocking, crash restore
 
 ## Why not Playwright or chrome-devtools-mcp?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CI](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml/badge.svg)](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml)
 
-**Real eyes for your coding agent: verified page checks it can't fake, in one warm browser you can also live in.**
+**Your agents loop with real eyes. You watch some reels. One warm browser, native on Linux.**
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -6,42 +6,100 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CI](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml/badge.svg)](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml)
 
-**Make your agent harness loop instantly faster by giving it real eyes**
+**One warm browser, two users: you in your tiling WM, and your coding agent.**
 
 </div>
 
-- **STOP your agent claiming "pixel-perfect." Make it prove 97.49%.**
-- **STOP paying 5 tool calls per page check. `hwatu check` is one call, ~35 ms (beats warm-server Playwright ~9x).**
-- **STOP browser windows stealing your focus. Headless by default, you keep typing.**
-- **STOP shipping 170 MB of Chromium. One static binary + your distro's webkitgtk.**
+hwatu is a WebKit daemon with two front doors. For **humans on
+Hyprland, sway, niri, or i3**, it is a primary browser built for the
+window-per-page model: no tabs (your WM is the tab bar), mainstream
+keybinds, native ad blocking, media that actually plays. For **coding
+agents**, it is real eyes: one-call verified page checks in ~35 ms,
+pixel-diff scores instead of "looks right to me", and headless
+windows that never steal your focus.
+
+The seam between the two is the feature no other browser has: an
+agent's invisible session and your daily-driver window are the same
+object. `hwatu focus <id>` materializes a live agent session, cookies
+and half-filled forms intact, into your tiler. You act, it takes
+back over.
 
 <a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-shortform.webp" alt="hwatu daily driving: quarter-width window spawns, buttery Chromium-curve scrolling, and one-keypress-one-reel shortform controls on Instagram Reels" width="800"></a>
 
 ## Documents
 
 - [Vision](VISION.md): durable product principles, native platform strategy, swarm model
+- [Human guide](docs/human.md): daily driving hwatu in a tiling WM, keybinds, media, hand-off
 - [Agent guide](docs/agents.md): protocol, primitives, verification loops
-- [Human guide](docs/human.md): a primary browser for tiling WMs, and the hand-off side
 - [Benchmarks](docs/benchmarks.md): every number, measured, with methodology
 - [Roadmap](docs/roadmap.md): plan of record, priorities, non-goals
 - [Continuous improvement](docs/continuous-improvement.md): activation metric, feedback loop, weekly cadence
 - [Launch kit](docs/launch-kit.md): reusable copy, channels, and measurement plan
 
-## Quick Start
-
-**Install → Detect workflow → Connect agent → Verify page → Hand off to human**
+## Install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/hongnoul/hwatu/main/scripts/install.sh | bash
-hwatu setup
 ```
 
 One static binary plus your distro's `webkitgtk-6.0` (the installer
 checks). On Arch: `yay -S hwatu`. From source: `cargo build --release`.
 
-The installer installs binaries only. `hwatu setup` detects supported coding
-agents and prints the available connections without changing their config.
-Choose a client explicitly when you are ready:
+Then pick your door, or take both:
+
+```sh
+hwatu localhost:3000    # human: open a window like you open a terminal
+hwatu setup             # agent: detect Claude Code, Cursor, Jcode, or MCP
+```
+
+## A primary browser for your tiling WM
+
+You already have a window manager you like. hwatu is the browser that
+stops fighting it:
+
+- **Your WM is the tab bar.** No tabs, no chrome: `hwatu <url>` opens
+  a window like your terminal opens a shell, at a third of the
+  monitor width, and your tiler does the rest. Ready-made configs:
+  [hyprland](examples/hyprland.conf), [sway](examples/sway.config),
+  [niri](examples/niri.kdl).
+- **Mainstream keybinds, all rebindable.** `ctrl+l` edits the URL,
+  `ctrl+f` finds, `ctrl+k` opens a fuzzy command palette,
+  `~/.config/hwatu/keys.conf` overrides anything. Config is a
+  dotfile, not a settings maze.
+- **Video actually works.** Unmuted autoplay, playback that survives
+  focus loss, and a blur-shield that took YouTube Shorts from ~34 to
+  ~95 fps. One shortform control scheme (arrows snap exactly one
+  video, Space pauses, hold ArrowRight for 2x) across Reels, Shorts,
+  and TikTok.
+- **Native ad blocking.** EasyList compiled into WebKit's
+  content-extension engine: ~119k rules, zero JS in the request path,
+  no extension process.
+- **Chromium-curve scrolling** for wheel and keys, replacing
+  WebKitGTK's isolated-pulse scroller.
+- **One warm engine.** Every window shares the daemon (~56 MB per
+  extra window), suspends when unfocused, and crash-restores at its
+  last URL.
+
+People adopt browsers in this category (qutebrowser, vimb, luakit)
+for keyboard-first UX and the window-per-page model, and abandon them
+over ad quality, broken sites, and video. hwatu attacks the
+abandonment list head-on; the [roadmap](docs/roadmap.md) tracks what
+is landed and what is next (global history and URL completion, link
+hints, password-manager integration). Honest gaps today: qutebrowser
+still wins on history completion and password fill, and WebKitGTK has
+no Widevine or passkeys, so keep a fallback browser bound for
+Netflix. Full keybind table and setup: [docs/human.md](docs/human.md).
+
+## Real eyes for your coding agent
+
+- **STOP your agent claiming "pixel-perfect." Make it prove 97.49%.**
+- **STOP paying 5 tool calls per page check. `hwatu check` is one call, ~35 ms (beats warm-server Playwright ~9x).**
+- **STOP browser windows stealing your focus. Headless by default, you keep typing.**
+- **STOP shipping 170 MB of Chromium. One static binary + your distro's webkitgtk.**
+
+`hwatu setup` detects supported coding agents and prints the
+available connections without changing their config. Choose a client
+explicitly when you are ready:
 
 ```sh
 hwatu doctor
@@ -50,18 +108,9 @@ hwatu setup --client claude --scope project
 hwatu demo
 ```
 
-- **Install:** download two binaries and check WebKitGTK.
-- **Detect:** find Claude Code, Cursor, Jcode, or a generic MCP workflow.
-- **Connect:** use Jcode's native socket, MCP, or the CLI fallback.
-- **Verify:** run a headless rendered smoke test with `doctor` or `demo`.
-- **Hand off:** materialize the same live session only when a human is needed.
-
-Setup is previewable, idempotent, and reversible with the same client and
-scope plus `--undo`. Project scope creates shareable configuration; user scope
-keeps it personal. Claude Code asks each user to approve project-scoped MCP
-servers when it next starts.
-
-Manual MCP configuration remains one portable entry:
+Setup is previewable, idempotent, and reversible with the same client
+and scope plus `--undo`. Manual MCP configuration remains one
+portable entry:
 
 ```json
 { "mcpServers": { "hwatu": { "command": "hwatu", "args": ["mcp"] } } }
@@ -70,19 +119,9 @@ Manual MCP configuration remains one portable entry:
 Or skip MCP entirely: every command is a short CLI call or one
 newline-delimited JSON line over a Unix socket.
 
-```sh
-hwatu localhost:3000       # open a window like you open a terminal
-```
-
-Tried hwatu? A successful check, a failed install, and a missing workflow are
-all useful signals. Share a two-minute [use report](https://github.com/hongnoul/hwatu/issues/new?template=use-report.yml)
-or [report a bug](https://github.com/hongnoul/hwatu/issues/new?template=bug-report.yml).
-
-## Tell your agent to use Hwatu
-
-Connecting Hwatu makes its tools available. A project instruction tells the
-agent when to use them and what evidence counts as success. Add this to
-`AGENTS.md`, `CLAUDE.md`, Cursor rules, or the equivalent for your harness:
+Connecting hwatu makes its tools available; a project instruction
+tells the agent when to use them. Add this to `AGENTS.md`,
+`CLAUDE.md`, Cursor rules, or the equivalent for your harness:
 
 ```markdown
 ## Frontend verification
@@ -101,84 +140,7 @@ save it, verify the visible success state, reload, confirm persistence, and
 report any console errors.
 ```
 
-The same instruction works with Hwatu's MCP tools, short CLI commands, or
-Jcode's native integration. Name the user journey and the observable result
-that proves it worked. See the full [agent guide](docs/agents.md), including a
-larger copy-paste policy and verification loops.
-
-## Features
-
-- [x] Pixel-diff scoring: match percent + diff regions + heatmap (`diff`)
-- [x] Animations as numbers: duration, easing, velocity (`motion`)
-- [x] Deterministic animation frames: pin all animations at time t (`seek`)
-- [x] Page state as JSON, tokens not pixels (`snapshot`)
-- [x] Real input events with structured errors (`click` / `type` / `scroll` / `upload`)
-- [x] JS errors, console output, failed requests (`console`)
-- [x] Push event subscriptions as JSON lines or MCP notifications (`watch`)
-- [x] One-call page assertions with polling (`expect`)
-- [x] Headless / background / focused as a *per-window* property, switchable live
-- [x] Human hand-off: `hwatu focus <id>` drops the live session into your tiling WM
-- [x] CAPTCHA / anti-bot detection with structured wait/resume (`challenge`)
-- [x] MCP server, plain CLI, and a 1-line JSON socket protocol
-- [x] A real browser for humans: mainstream keybinds, media-correct video, native ad blocking, crash restore
-
-## A browser for your tiling WM
-
-hwatu is agent-first, but as of v0.7.0 the human side stopped being a
-viewer and became a browser you can actually live in on Hyprland,
-sway, or niri:
-
-- **Your WM is the tab bar.** No tabs, no chrome: `hwatu <url>` opens
-  a window like your terminal opens a shell, at a third of the
-  monitor width, and your tiler does the rest. Ready-made configs:
-  [hyprland](examples/hyprland.conf), [sway](examples/sway.config),
-  [niri](examples/niri.kdl).
-- **Mainstream keybinds, all rebindable.** `ctrl+l` edits the URL,
-  `ctrl+f` finds, `ctrl+k` opens a fuzzy command palette,
-  `~/.config/hwatu/keys.conf` overrides anything.
-- **Video actually works.** Unmuted autoplay, playback that survives
-  focus loss, and a blur-shield that took YouTube Shorts from ~34 to
-  ~95 fps. One shortform control scheme (arrows snap exactly one
-  video, Space pauses, hold ArrowRight for 2x) across Reels, Shorts,
-  and TikTok.
-- **Native ad blocking.** EasyList compiled into WebKit's
-  content-extension engine: ~119k rules, zero JS in the request path,
-  no extension process.
-- **Chromium-curve scrolling** for wheel and keys, replacing
-  WebKitGTK's isolated-pulse scroller.
-- **One warm engine.** Every window shares the daemon (~56 MB per
-  extra window), suspends when unfocused, and crash-restores at its
-  last URL.
-
-Details, keybind table, and setup: [docs/human.md](docs/human.md).
-
-## Why not Playwright or chrome-devtools-mcp?
-
-There are three ways to give an agent a browser, and two of them are bad at it:
-
-| | How it runs | What it costs the agent loop |
-|---|---|---|
-| **Cold library** (Playwright, launched per task) | engine starts when the script does | fast to *call*, slow to *run*: every check pays engine startup; no state survives between tasks |
-| **Warm browser** (your Chrome + devtools-mcp) | a full human browser stays resident | resources spent on tabs, extensions, sync, UI you never render, and its windows steal *your* focus while you work |
-| **hwatu** | **"the coldest warm daemon"**: engine hot, everything else absent | 8 ms spawns, 35 ms verified checks, invisible until *you* ask to see it (`focus`), interruptible in both directions |
-
-hwatu keeps exactly what makes checks instant (engine, GPU context,
-compiled adblock, a prewarmed WebView) and nothing that serves a
-human sitting in front of it. That's why it idles warm without a tab
-bar, and why a kept-warm Playwright server driven the same way still
-costs 341 ms per client to hwatu's 39 ([benchmarks](docs/benchmarks.md)).
-
-The second difference is what comes back. Playwright and
-chrome-devtools-mcp are, at their core, automation
-APIs: they let an agent *drive* a browser, then hand back raw
-screenshots and DOM for the agent to eyeball.
-
-hwatu is different. It is a *verification* browser: the measurement
-primitives are built in, and the browser itself is a warm daemon
-where a window costs 13 ms and headless is a window property, not a
-launch mode.
-
-That is why the loop looks like this, real commands, real output:
+The verification loop, real commands, real output:
 
 ```sh
 hwatu --headless localhost:3000        # its window; you never see it
@@ -198,12 +160,14 @@ hwatu diff --id 2 --other 1
 
 We ran this loop against a clone of stripe.com's landing page: an
 agent took it from **85.1% to 98.8% pixel match**. Reproduce it:
-[scripts/demo/](scripts/demo/). The README hero uses a second, real-agent
-scenario against AIUC: four responsive viewport diffs followed by live human
-hand-off. Reproduce that take, including its evidence manifests, from
-[scripts/demo-aiuc/](scripts/demo-aiuc/). A full verification pass (open, load,
-eval, screenshot, close) is **one command, one tool call, ~35 ms
-median** ([benchmarks](docs/benchmarks.md)):
+[scripts/demo/](scripts/demo/). The README hero uses a second,
+real-agent scenario against AIUC: four responsive viewport diffs
+followed by live human hand-off, reproducible with evidence manifests
+from [scripts/demo-aiuc/](scripts/demo-aiuc/).
+
+A full verification pass (open, load, eval, screenshot, close) is
+**one command, one tool call, ~35 ms median**
+([benchmarks](docs/benchmarks.md)):
 
 ```sh
 hwatu check localhost:5173 --eval 'document.title' --shot=/tmp/after.png
@@ -225,33 +189,76 @@ hwatu watch --kinds load,console
 ```
 
 MCP clients can call `subscribe_events` for the same stream as
-`notifications/hwatu/event`. Each connection gets a strictly monotonic
-sequence starting at zero; closing or stalling the connection drops its
-subscription without blocking the daemon.
+`notifications/hwatu/event`. See the full [agent guide](docs/agents.md),
+including a larger copy-paste policy and verification loops.
+
+## The hand-off: where the two sides meet
+
+Your agent's windows don't exist on your desktop: no focus stolen, no
+WM pollution, at any parallelism. Every invisible session is a live
+window the WM simply hasn't been shown. When the agent hits a
+CAPTCHA, an OAuth consent, a 2FA prompt, or a plain "does this look
+right to you", it runs `hwatu focus <id>` and the session appears in
+your tiler: same cookies, same scroll position, same half-filled
+form. You act for ten seconds. It takes back over.
+
+**This is the adjective no other tool gets to claim: interruptible.**
+Everywhere else, headless is decided at launch and a human can never
+see the session at any price. In hwatu it's a window property,
+switchable live, in both directions. And because hwatu is also the
+browser you already live in, the hand-off lands in a window that
+behaves like every other window on your desk, not a viewer bolted on
+for emergencies.
+
+`challenge` is detection and hand-off only, by design: no solver
+APIs, no token injection, no fingerprint games.
+
+## Features
+
+- [x] A real browser for humans: mainstream keybinds, media-correct video, native ad blocking, crash restore
+- [x] Headless / background / focused as a *per-window* property, switchable live
+- [x] Human hand-off: `hwatu focus <id>` drops the live session into your tiling WM
+- [x] Pixel-diff scoring: match percent + diff regions + heatmap (`diff`)
+- [x] Animations as numbers: duration, easing, velocity (`motion`)
+- [x] Deterministic animation frames: pin all animations at time t (`seek`)
+- [x] Page state as JSON, tokens not pixels (`snapshot`)
+- [x] Real input events with structured errors (`click` / `type` / `scroll` / `upload`)
+- [x] JS errors, console output, failed requests (`console`)
+- [x] Push event subscriptions as JSON lines or MCP notifications (`watch`)
+- [x] One-call page assertions with polling (`expect`)
+- [x] CAPTCHA / anti-bot detection with structured wait/resume (`challenge`)
+- [x] MCP server, plain CLI, and a 1-line JSON socket protocol
+
+## Why not Playwright or chrome-devtools-mcp?
+
+There are three ways to give an agent a browser, and two of them are bad at it:
+
+| | How it runs | What it costs the agent loop |
+|---|---|---|
+| **Cold library** (Playwright, launched per task) | engine starts when the script does | fast to *call*, slow to *run*: every check pays engine startup; no state survives between tasks |
+| **Warm browser** (your Chrome + devtools-mcp) | a full human browser stays resident | resources spent on tabs, extensions, sync, UI you never render, and its windows steal *your* focus while you work |
+| **hwatu** | **"the coldest warm daemon"**: engine hot, everything else absent | 8 ms spawns, 35 ms verified checks, invisible until *you* ask to see it (`focus`), interruptible in both directions |
+
+hwatu keeps exactly what makes checks instant (engine, GPU context,
+compiled adblock, a prewarmed WebView) and nothing that serves a
+human sitting in front of it *unless that human asked for a window*.
+That's why it idles warm without a tab bar, and why a kept-warm
+Playwright server driven the same way still costs 341 ms per client
+to hwatu's 39 ([benchmarks](docs/benchmarks.md)).
+
+The second difference is what comes back. Playwright and
+chrome-devtools-mcp are, at their core, automation APIs: they let an
+agent *drive* a browser, then hand back raw screenshots and DOM for
+the agent to eyeball. hwatu is a *verification* browser: the
+measurement primitives are built in, and the browser itself is a warm
+daemon where a window costs 13 ms and headless is a window property,
+not a launch mode.
 
 The same pass through Playwright's warm in-process CDP connection,
 its best case, is 82 ms and five API calls. Shaped like hwatu
-actually runs (a fresh client each check against a kept-warm
-engine), Playwright's pass is **341 ms vs hwatu's 39**: hwatu is a
-warm daemon by design, Playwright is a library you have to keep warm
-yourself.
-
-And when the agent hits a CAPTCHA or a judgment call, `hwatu focus`
-materializes its live session, cookies and state intact, in your
-tiling WM. You act for ten seconds. It takes back over. **This is
-the adjective no other tool gets to claim: interruptible.**
-Everywhere else, headless is decided at launch and a human can never
-see the session at any price. In hwatu it's a window property,
-switchable live, in both directions.
-
-The speed follows from the same design decision: hwatu is a **warm
-daemon**, not a library you launch. The engine, the GPU context, the
-compiled adblock ruleset, and a prewarmed WebView outlive every
-task, so a check starts from a hot pipeline instead of a cold
-process. Playwright is a library and cold by nature. Keeping it
-warm is something *you* build (a server process, connection
-management, context pooling); hwatu ships warm as the default and
-the only mode.
+actually runs (a fresh client each check against a kept-warm engine),
+Playwright's pass is **341 ms vs hwatu's 39**: hwatu is a warm daemon
+by design, Playwright is a library you have to keep warm yourself.
 
 ## How hwatu compares
 
@@ -288,6 +295,13 @@ summary of easing/velocity/keyframes.
 > engine-specific bugs), and it is Linux-only today. Full
 > head-to-head data and methodology:
 > [docs/benchmarks.md](docs/benchmarks.md).
+
+## Feedback
+
+Tried hwatu? A successful check, a failed install, a missing keybind,
+and a site that broke are all useful signals. Share a two-minute
+[use report](https://github.com/hongnoul/hwatu/issues/new?template=use-report.yml)
+or [report a bug](https://github.com/hongnoul/hwatu/issues/new?template=bug-report.yml).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CI](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml/badge.svg)](https://github.com/hongnoul/hwatu/actions/workflows/ci.yml)
 
-**Your agents loop with real eyes. You watch some reels. One warm browser, native on Linux.**
+**Give your agent harness real eyes. Keep the browser for yourself. Native on Linux.**
 
 </div>
 


### PR DESCRIPTION
Rewrites the apex README with the agent visual-check harness as the primary story.

## What changed
- Tagline and intro now lead with verified page checks, pixel-diff scores, motion-as-numbers, and no-focus-steal headless parallelism.
- The tiling-WM primary-browser section is condensed into a short **"Agents loop, you watch some reels"** section placed after the hand-off, keeping the shortform demo clip and honest gaps (Widevine/passkeys).
- Docs list, install order, and features checklist reordered to match (agent guide before human guide, human-browser feature last).
- Fixed a stale "README hero" reference to the AIUC scenario.

No content invented; everything is a reorder/condense of existing verified copy.
