### PR TITLE
docs: revive the AIUC verification demo as the README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **Your agents are blind without hwatu**
 
+<a href="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-aiuc.mp4"><img src="https://github.com/hongnoul/hwatu/releases/download/readme-assets/demo-aiuc.webp" alt="An agent verifies aiuc.com with hwatu: one command returns pixel-match scores for four responsive viewports, then the live page pops into view for human hand-off" width="800"></a>
+
 </div>
 
 hwatu is a visual verification harness for coding agents, built as a


### PR DESCRIPTION
Puts the original aiuc.com verification demo back at the top of the apex README, directly under the tagline.

Asset (uploaded to `readme-assets`, same URLs):
- `demo-aiuc.mp4` / `demo-aiuc.webp`: recut from the original recording. The ~17s static intro is trimmed, but the beat of input lag before the browser window pops in is preserved, then the four responsive viewport scores and the live aiuc.com render play at original speed. 8.5s total, webp at 1120x630.

GitHub's CDN may cache the old webp briefly.