### PR TITLE
IPC: keep daemon connections persistent

### DIFF
--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -43,6 +43,10 @@ fn accept_next(listener: gio::SocketListener, daemon: Rc<Daemon>) {
 
 fn handle_conn(conn: gio::SocketConnection, daemon: Rc<Daemon>) {
     let input = gio::DataInputStream::new(&conn.input_stream());
+    read_next_request(conn, input, daemon);
+}
+
+fn read_next_request(conn: gio::SocketConnection, input: gio::DataInputStream, daemon: Rc<Daemon>) {
     // read_line_utf8_async, not read_line_async: the byte-slice
     // variant's gio-rs trampoline reads an *uninitialized* length when
     // the stream ends with no line (client connected and closed), and
@@ -59,32 +63,46 @@ fn handle_conn(conn: gio::SocketConnection, daemon: Rc<Daemon>) {
         move |res| {
             let line = match res {
                 Ok(Some(l)) => l.to_string(),
-                // EOF before any line (port scan, dead client) or read
-                // error: nothing to answer.
+                // EOF before the next line (port scan, one-shot client
+                // disconnect, dead persistent client) or read error:
+                // nothing to answer.
                 Ok(None) | Err(_) => return,
             };
             let request = serde_json::from_str::<Request>(line.trim());
-            // Subscriptions keep the connection: hand it to the event
-            // broker instead of the one-shot reply path. Everything
-            // else (including parse errors) keeps the exact one-shot
-            // behavior old clients were built against.
+            // Subscriptions keep the connection as an event stream: hand it
+            // to the broker instead of the request/response loop. Everything
+            // else (including parse errors) gets one response line, then the
+            // loop waits for the next request or EOF.
             let request = match request {
                 Ok(Request::Subscribe { kinds, window }) => {
                     return crate::events::subscribe(&daemon, conn, input, kinds, window);
                 }
                 other => other,
             };
+            let conn_for_reply = conn.clone();
+            let input_for_reply = input.clone();
+            let daemon_for_reply = daemon.clone();
             let reply: automation::Reply = Box::new(move |response: Response| {
                 let mut out = serde_json::to_vec(&response).unwrap_or_default();
                 out.push(b'\n');
-                let stream = conn.output_stream();
+                let stream = conn_for_reply.output_stream();
+                let conn_for_next = conn_for_reply.clone();
+                let input_for_next = input_for_reply.clone();
+                let daemon_for_next = daemon_for_reply.clone();
                 stream.write_all_async(
                     out,
                     glib::Priority::DEFAULT,
                     gio::Cancellable::NONE,
-                    move |_| {
-                        // conn dropped here; client sees EOF after response.
-                        let _ = conn.close(gio::Cancellable::NONE);
+                    move |res| {
+                        // Keep the connection strictly sequential: the next request
+                        // is not read until this response has finished writing. That
+                        // preserves correlation for clients that pipeline by order,
+                        // including deferred automation replies.
+                        if res.is_ok() {
+                            read_next_request(conn_for_next, input_for_next, daemon_for_next);
+                        } else {
+                            let _ = conn_for_next.close(gio::Cancellable::NONE);
+                        }
                     },
                 );
             });

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -2,9 +2,12 @@
 // Copyright (c) 2026 Justin Hong
 //! Wire protocol between the `hana` client and the `hwatud` daemon.
 //!
-//! Newline-delimited JSON over a Unix domain socket. One request per
-//! connection for the MVP: connect, send a [`Request`], read a
-//! [`Response`], disconnect.
+//! Newline-delimited JSON over a Unix domain socket. A connection may
+//! carry multiple [`Request`] lines and receives one [`Response`] line
+//! per request, strictly in request order. Legacy one-shot clients still
+//! work: connect, send one request, read one response, disconnect. A
+//! [`Request::Subscribe`] hands the connection to the event stream and
+//! does not accept further request lines.
 
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]

--- a/crates/ipc/tests/wire_conformance.rs
+++ b/crates/ipc/tests/wire_conformance.rs
@@ -78,6 +78,20 @@ fn minimal_subscription_remains_valid() {
 }
 
 #[test]
+fn persistent_connections_are_newline_delimited_request_sequences() {
+    let wire = "{\"cmd\":\"ping\"}\n{\"cmd\":\"list\"}\n";
+    let requests: Vec<Request> = wire
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("each line is one request"))
+        .collect();
+
+    assert!(matches!(
+        requests.as_slice(),
+        [Request::Ping, Request::List]
+    ));
+}
+
+#[test]
 fn canonical_responses_match_the_wire() {
     assert_golden_roundtrip::<Response>(include_str!("fixtures/responses/window.json"));
     assert_golden_roundtrip::<Response>(include_str!("fixtures/responses/value.json"));

--- a/scripts/test-watch.sh
+++ b/scripts/test-watch.sh
@@ -62,23 +62,35 @@ done
 
 daemon_fds() { ls "/proc/$daemon_pid/fd" 2>/dev/null | wc -l; }
 
-# ---- 1. one-shot back-compat -----------------------------------------
+# ---- 1. one-shot and persistent connection back-compat ----------------
 lines="$(python3 - <<'EOF'
 import json, os, socket
 s = socket.socket(socket.AF_UNIX)
+s.settimeout(2)
 s.connect(os.environ["XDG_RUNTIME_DIR"] + "/hwatu.sock")
 s.sendall(b'{"cmd":"ping"}\n')
-buf = b""
-while True:
-    d = s.recv(65536)
-    if not d:
-        break
-    buf += d
-print(len([l for l in buf.decode().splitlines() if l.strip()]))
+f = s.makefile("rb")
+print(1 if json.loads(f.readline())["status"] == "ok" else 0)
 EOF
 )"
-check "one-shot request: exactly one reply line then EOF (got $lines)" \
+check "one-shot request: exactly one reply line without waiting for EOF (got $lines)" \
     test "$lines" -eq 1
+
+lines="$(python3 - <<'EOF'
+import json, os, socket
+s = socket.socket(socket.AF_UNIX)
+s.settimeout(2)
+s.connect(os.environ["XDG_RUNTIME_DIR"] + "/hwatu.sock")
+f = s.makefile("rwb", buffering=0)
+f.write(b'{"cmd":"ping"}\n')
+first = json.loads(f.readline())
+f.write(b'{"cmd":"ping"}\n')
+second = json.loads(f.readline())
+print(int(first["status"] == "ok") + int(second["status"] == "ok"))
+EOF
+)"
+check "persistent connection serves two sequential requests (got $lines replies)" \
+    test "$lines" -eq 2
 
 python3 - <<'EOF'
 import os, socket


### PR DESCRIPTION
Closes #31

## Summary
- keep hwatud IPC connections open for multiple newline-delimited requests
- chain the next request read only after the prior response write completes
- preserve Subscribe event-stream handoff and EOF behavior
- update test-watch raw socket clients and add persistent connection coverage

## Tests
- cargo test -p hwatu-ipc --locked
- cargo check -p hwatud --locked
- scripts/test-watch.sh