### PR TITLE
docs: shortform native-parity research + D3 roadmap workstream

### DIFF
--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -22,7 +22,8 @@
 //! modes), calls `preventDefault()`, and drives the scroller from
 //! `requestAnimationFrame` with Chromium's exact constants. Precise
 //! touchpad deltas (non-integer, small) are left to the engine, which
-//! already handles them well (instant + kinetic).
+//! already handles them well (instant + kinetic) — except on the
+//! Instagram gesture feed, see below.
 //!
 //! Mandatory `scroll-snap` containers (YouTube Shorts, TikTok-style
 //! feeds) get native-app paging instead of the delta glide: one
@@ -40,6 +41,20 @@
 //! by scrollTop freezes the URL and pagination (the feed "runs out"
 //! after the seeded batch); there each page tick dispatches a
 //! synthetic pointer swipe instead (see `swipeFeed` in the script).
+//! Precise touchpad deltas on that feed are claimed for the same
+//! reason: the engine's native precise scroll moves pixels without
+//! advancing IG's gesture state, so accumulated two-finger flicks
+//! are translated into the same synthetic swipe (`preciseFeedScroll`).
+//!
+//! Paging also performs the native clients' commit-time playback
+//! handoff: the moment a page tick commits, the incoming card's video
+//! starts and the outgoing video's audio ramps out over ~40ms and
+//! pauses. Web feeds otherwise wait for their IntersectionObserver
+//! after the scroll settles, which reads as a dead gap between reels
+//! (or, on the synthetic-swipe path, as the old reel's audio playing
+//! over the transition). Deliberately no crossfade: the native apps
+//! hard-cut audio at gesture commit too, and overlapping reel audio
+//! is universally perceived as a bug.
 //!
 //! Keyboard scrolling (Arrow/Page/Space) goes through the same
 //! animator, because WebKit's keydown scroll has the identical
@@ -345,6 +360,65 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     ensureRaf();
   }
 
+  // Commit-time playback handoff, the native clients' trick: the
+  // incoming reel starts playing the moment the page gesture commits
+  // (under the still-running transition), and the outgoing reel's
+  // audio ramps out and pauses. Web feeds only play/pause from an
+  // IntersectionObserver after the scroll settles, which reads as a
+  // dead gap — or, through the synthetic-swipe path, as the old
+  // reel's audio running over the whole transition. Deliberately no
+  // crossfade: native hard-cuts at commit too (the ~40ms ramp only
+  // strips the click of an abrupt cut), and both actions are
+  // idempotent with the site's own later observer work.
+  const RAMP_OUT_MS = 40, RAMP_IN_MS = 80;
+  const ramping = new WeakSet();
+  function rampVolume(v, to, ms, then) {
+    if (ramping.has(v)) return;
+    ramping.add(v);
+    const from = v.volume, t0 = performance.now();
+    function step(now) {
+      const t = Math.min((now - t0) / ms, 1);
+      try { v.volume = from + (to - from) * t; } catch (_) {}
+      if (t < 1) requestAnimationFrame(step);
+      else { ramping.delete(v); if (then) then(); }
+    }
+    requestAnimationFrame(step);
+  }
+  function handoffPlayback(dir) {
+    if (!shortformSite()) return;
+    const out = activeShortformVideo();
+    // The incoming card is still ~one viewport away in the paging
+    // direction at commit time: nearest video at least 40% of a
+    // viewport from center. None found (virtualized card not mounted
+    // yet) fails open — the site's observer handles it as before.
+    const mid = innerHeight / 2;
+    let inc = null, best = Infinity;
+    for (const v of document.querySelectorAll('video')) {
+      if (v === out) continue;
+      const r = v.getBoundingClientRect();
+      if (r.width < 1 || r.height < 1) continue;
+      const d = ((r.top + r.bottom) / 2 - mid) * dir;
+      if (d < innerHeight * 0.4) continue;
+      if (d < best) { best = d; inc = v; }
+    }
+    if (inc && inc.paused && !ramping.has(inc)) {
+      const iv = inc.volume;
+      try { inc.volume = 0; } catch (_) {}
+      const p = inc.play();
+      if (p && p.catch) p.catch(() => {});
+      rampVolume(inc, iv, RAMP_IN_MS);
+    }
+    if (out && !out.paused) {
+      const ov = out.volume;
+      rampVolume(out, 0, RAMP_OUT_MS, () => {
+        // Restore the element's own volume after the pause so a
+        // scroll-back (or the site recycling the element) never
+        // inherits a silenced video.
+        try { out.pause(); out.volume = ov; } catch (_) {}
+      });
+    }
+  }
+
   // Instagram mobile-web Reels ignore programmatic scrolling: the
   // current-reel index lives in gesture state (React pointer handlers
   // on the feed element), so setting scrollTop moves pixels while the
@@ -398,6 +472,9 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
         if (i >= SWIPE_STEPS) {
           clearInterval(iv);
           el.dispatchEvent(mk('pointerup', y1));
+          // Gesture commit: start the incoming reel's playback now
+          // instead of waiting out IG's settle + observer.
+          handoffPlayback(dir);
         }
       } catch (_) {
         clearInterval(iv);
@@ -423,6 +500,33 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
       }
     }
     return null;
+  }
+
+  // Precise touchpad deltas on the IG feed must be claimed too: the
+  // engine's native precise scroll moves pixels without advancing
+  // IG's gesture-held reel index, silently desyncing the feed (URL,
+  // active video, and pagination freeze — the same failure scrollTop
+  // paging has). Accumulate the fine deltas and page via the same
+  // synthetic swipe once a flick's worth arrives. Returns true when
+  // the event belongs to the feed (caller preventDefaults even while
+  // accumulating: leaked pixels are the desync).
+  const PRECISE_TRIGGER = 120, PRECISE_IDLE_MS = 300;
+  let preciseAcc = 0, preciseLast = 0;
+  function preciseFeedScroll(target, dy) {
+    if (shortformSite() !== 'instagram') return false;
+    const feed = gestureFeed(target);
+    if (!feed) return false;
+    const now = performance.now();
+    if (now - preciseLast > PRECISE_IDLE_MS) preciseAcc = 0;
+    preciseLast = now;
+    if (now < swipeUntil) return true; // mid-swipe: absorb the flick
+    preciseAcc += dy;
+    if (Math.abs(preciseAcc) >= PRECISE_TRIGGER) {
+      const dir = preciseAcc > 0 ? 1 : -1;
+      preciseAcc = 0;
+      swipeFeed(feed, dir);
+    }
+    return true;
   }
 
   // Page a snap or card-feed scroller by one page. Returns true if
@@ -466,6 +570,9 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     // glide into an ancestor mid-feed.
     if (target == null) return true;
     animateTo(el, horiz, target);
+    // Page commit on a snap/card feed: same handoff as the swipe
+    // path. handoffPlayback gates itself to shortform sites.
+    if (!horiz) handoffPlayback(dir);
     return true;
   }
 
@@ -511,7 +618,14 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     try {
       if (e.defaultPrevented || !e.cancelable) return;
       if (e.ctrlKey || e.altKey || e.metaKey) return; // zoom & friends
-      if (!isDiscrete(e)) return;
+      if (!isDiscrete(e)) {
+        // Precise touchpad deltas normally stay native, but on the
+        // IG gesture feed native pixels desync the reel state: claim
+        // and translate them into synthetic swipes.
+        if (!e.shiftKey && e.deltaY
+            && preciseFeedScroll(e.target, e.deltaY)) e.preventDefault();
+        return;
+      }
 
       let dx = e.deltaX, dy = e.deltaY;
       if (e.deltaMode === 1) { dx *= 40; dy *= 40; }
@@ -864,16 +978,20 @@ mod tests {
     #[test]
     fn script_fails_open() {
         assert!(SMOOTH_WHEEL_JS.contains("e.defaultPrevented || !e.cancelable"));
-        // preventDefault must appear after the discrete/scrollable
-        // guards in the handler body.
+        // Every preventDefault must follow its deciding guard. The
+        // precise-touchpad arm decides via preciseFeedScroll; the
+        // generic path decides via isDiscrete + scrollTarget.
         let handler = SMOOTH_WHEEL_JS
             .split("addEventListener('wheel'")
             .nth(1)
             .unwrap();
-        let pd = handler.find("e.preventDefault()").unwrap();
         let discrete = handler.find("isDiscrete").unwrap();
+        let precise = handler.find("preciseFeedScroll").unwrap();
+        let precise_pd = precise + handler[precise..].find("e.preventDefault()").unwrap();
+        assert!(discrete < precise && precise < precise_pd);
         let target = handler.find("scrollTarget").unwrap();
-        assert!(discrete < pd && target < pd);
+        let pd = target + handler[target..].find("e.preventDefault()").unwrap();
+        assert!(target < pd);
     }
 
     /// ArrowLeft must select the close control before falling back to the
@@ -1067,5 +1185,66 @@ mod tests {
         assert!(SMOOTH_WHEEL_JS.contains("now < swipeUntil"));
         // Pointer-capture guard: swallow only our synthetic id.
         assert!(SMOOTH_WHEEL_JS.contains("if (id !== SWIPE_ID) throw err;"));
+    }
+
+    /// Paging a shortform feed must perform the commit-time playback
+    /// handoff (incoming video plays at gesture commit; outgoing audio
+    /// ramps out then pauses), and must not crossfade: the pause and
+    /// a volume restore both happen, and everything is guarded so a
+    /// missing video fails open to the site's own observer.
+    #[test]
+    fn commit_time_playback_handoff_shape() {
+        assert!(SMOOTH_WHEEL_JS.contains("function handoffPlayback"));
+        assert!(SMOOTH_WHEEL_JS.contains("function rampVolume"));
+        // Gated to shortform sites: nothing happens on ordinary pages.
+        let body = SMOOTH_WHEEL_JS
+            .split("function handoffPlayback")
+            .nth(1)
+            .unwrap();
+        assert!(body.contains("if (!shortformSite()) return;"));
+        // Outgoing: ramp to zero, pause, then restore the element's
+        // own volume so scroll-back never inherits a silenced video.
+        assert!(body.contains("rampVolume(out, 0, RAMP_OUT_MS"));
+        assert!(body.contains("out.pause(); out.volume = ov;"));
+        // Incoming: starts muted-by-volume and ramps in; the play()
+        // rejection is swallowed (autoplay policy).
+        assert!(body.contains("inc.volume = 0;"));
+        assert!(body.contains("p.catch(() => {})"));
+        // Both commit paths fire it: the synthetic IG swipe at
+        // pointerup, and snap/card-feed paging at animation start.
+        let swipe = SMOOTH_WHEEL_JS.split("function swipeFeed").nth(1).unwrap();
+        let sw_body = swipe.split("function gestureFeed").next().unwrap();
+        assert!(sw_body.contains("handoffPlayback(dir)"));
+        let ps = SMOOTH_WHEEL_JS.split("function pageSnap").nth(1).unwrap();
+        let ps_body = ps.split("function animateBy").next().unwrap();
+        assert!(ps_body.contains("handoffPlayback(dir)"));
+    }
+
+    /// Precise touchpad deltas on the Instagram gesture feed must be
+    /// claimed (native precise scroll desyncs IG's gesture-held reel
+    /// state) and accumulated into the same synthetic swipe; precise
+    /// deltas everywhere else must stay engine-native.
+    #[test]
+    fn precise_touchpad_guard_shape() {
+        assert!(SMOOTH_WHEEL_JS.contains("function preciseFeedScroll"));
+        let body = SMOOTH_WHEEL_JS
+            .split("function preciseFeedScroll")
+            .nth(1)
+            .unwrap();
+        // Instagram-only: everything else returns false -> native.
+        assert!(body.contains("shortformSite() !== 'instagram'"));
+        // Pages via the synthetic swipe, never scrollTop.
+        assert!(body.contains("swipeFeed(feed, dir)"));
+        // Mid-swipe flicks are absorbed like discrete ticks.
+        assert!(body.contains("now < swipeUntil"));
+        // The wheel handler consults it inside the !isDiscrete arm and
+        // preventDefaults claimed events so no pixels leak to the feed.
+        let handler = SMOOTH_WHEEL_JS
+            .split("addEventListener('wheel'")
+            .nth(1)
+            .unwrap();
+        let arm = handler.split("let dx = e.deltaX").next().unwrap();
+        assert!(arm.contains("!isDiscrete(e)"));
+        assert!(arm.contains("preciseFeedScroll(e.target, e.deltaY)) e.preventDefault()"));
     }
 }

--- a/docs/research-shortform-native-parity.md
+++ b/docs/research-shortform-native-parity.md
@@ -1,0 +1,102 @@
+# Research: native short-form parity (Reels / Shorts / TikTok)
+
+Date: 2026-08-01. Method: three parallel research agents (gesture and
+scroll mechanics, media pipeline, UI/session/performance) comparing
+native Android/iOS clients (including Meta's published Media3
+PreloadManager engineering writeup) against the mobile-web versions of
+the same feeds running in hwatu (WebKitGTK 2.52.5 + GStreamer 1.28.5),
+grounded in the current code (`smoothwheel.rs`, `mediashim.rs`,
+`window.rs`, `siteua.rs`, `focusshield.rs`, `session.rs`).
+
+Feeds referenced: instagram.com Reels (mobile-UA spoof per
+`siteua.rs`), m.youtube.com Shorts, tiktok.com.
+
+## The headline finding
+
+Native apps do **not** crossfade video or audio between reels. Audio
+overlap between two reels is universally perceived as a bug. The
+perceived seamlessness comes from three other mechanisms:
+
+1. **Gesture-coupled rendering**: both video surfaces translate with
+   the finger; the incoming video's first frame is already decoded
+   and visible as it slides in.
+2. **Commit-time playback handoff**: the incoming video starts
+   playing the moment the gesture crosses the paging threshold
+   (~50%), under the still-running transition animation, hiding
+   200-350 ms of start latency. The outgoing audio is hard-cut at
+   commit (at most a tens-of-ms ramp to avoid a click).
+3. **Adjacent preload**: Media3 `DefaultPreloadManager` keeps the
+   next/previous videos ready *in memory* (buffered samples for the
+   codec, not just disk cache), so time-to-first-frame on swipe is
+   near zero. Meta reports tiered readiness: N±1 gets ~5s/~3s of
+   samples, N±2 track selection, N±4 prepared source.
+
+Mobile-web feeds instead start the incoming video only after the
+scroll settles and an IntersectionObserver fires. The dead gap
+(old audio stops → silence → settle → load → play) is what makes the
+browser version feel discrete. In hwatu the Instagram path is
+currently *worse* than plain web: the synthetic swipe (~160 ms) plus
+the 650 ms `SWIPE_ABSORB` window run before IG's observer even fires,
+so outgoing audio audibly overlaps the transition.
+
+## Findings by area
+
+Severity is impact on a seamless scrolling session.
+
+### A. Playback handoff and preload (media pipeline)
+
+| # | Aspect | Native | hwatu/web today | Sev | Suggestion |
+|---|--------|--------|-----------------|-----|------------|
+| A1 | Start point | Play at gesture commit, under the animation | Play after settle via site IntersectionObserver; IG path adds swipe+absorb delay | HIGH | In smoothwheel's shortform layer, at synthetic pointerup (IG) or snap-animation start (CSS-snap feeds), find the incoming card's `<video>` and `play()` immediately; pause the outgoing one. Idempotent with the site's later observer call; fail-open. ~50 lines. |
+| A2 | Audio cut | Hard cut at commit, tens-of-ms ramp against clicks | Outgoing audio keeps playing 300-700 ms into the transition | MED | Same hook: ramp outgoing `volume` 1→0 over ~40 ms (4 rAF steps) then `pause()`; incoming starts at 0 and ramps to 1 after `playing`. Coalesce play/pause to one per frame per element (GStreamer `changePipelineState` main-thread wedge, see `mediashim.rs` history). No true crossfade: native doesn't do one. |
+| A3 | Adjacent preload | N±1 samples in memory (Media3 PreloadManager) | Site-controlled only; at best first bytes in HTTP cache | HIGH | "reelwarm" user script: extract N±1 cards' video URLs (`src`, `<source>`, or PerformanceObserver resource entries) and `fetch` with `Range: bytes=0-1048575` to pull moov + first GOP into WebKit's network-process disk cache. Media loads go through the same cache, so preroll becomes a cache hit. No pipeline objects created (avoids the multi-pipeline deadlock class in `mediashim.rs`). |
+| A4 | First-frame pre-decode | Cover frame always ready; never black | IG recycles elements and re-srcs on swipe, losing WebKit's `preload="metadata"` preroll | MED | Force `preload="metadata"` on the N+1 card only. Never ±2+: each preroll is a live GStreamer pipeline and >3-4 concurrent pipelines is the documented deadlock/perf zone. `requestVideoFrameCallback` can verify frame arrival. |
+| A5 | Loop wrap | Gapless repeat-one from memory | WebKit uses SEGMENT seeks when seamless seeking is on; older path was a flushing seek-to-0 hiccup every loop | LOW-MED | Empirically check 2.52.5 with `GST_DEBUG=webkitmediaplayer:6`. If flushing, not fixable from a user script; track upstream. |
+| A6 | Autoplay gating | N/A | hwatu already overrides WebKit's ALLOW_WITHOUT_SOUND to full Allow | NONE | Already ahead; keep. |
+| A7 | Stream format per site | — | IG (iPhone UA): progressive MP4 fallback if `ManagedMediaSource` absent — Range warming targets this perfectly. TikTok: progressive MP4, signed Range URLs — warmable. YT Shorts: MSE (SABR/UMP) under desktop UA; keep youtube out of `HWATU_MOBILE_UA_SITES` (iOS UA would push it to native HLS via gst hlsdemux, shakier than MSE) | — | Verify `typeof ManagedMediaSource` under the IG UA live before building. |
+
+### B. Gesture and scroll mechanics
+
+| # | Aspect | Native | hwatu today | Sev | Suggestion |
+|---|--------|--------|-------------|-----|------------|
+| B1 | Precise touchpad on IG Reels | Finger-tracked paging | Two-finger touchpad scroll bypasses the swipeFeed protection (only discrete wheel ticks are claimed), silently breaking IG's gesture-state feed | HIGH | Extend the IG feed guard to claim precise deltas too: accumulate them and translate to synthetic swipes (or at minimum absorb them so the feed doesn't desync). |
+| B2 | Settle curve | Settle starts at gesture velocity, decelerates | Fixed 350 ms ease-in-out from zero velocity | MED-HIGH | Reuse `easeWithSlope` with a synthetic initial slope; ~300 ms ease-out. |
+| B3 | Feed extents | Rubber-band bounce | Ticks silently consumed, zero feedback | MED | Transform-based bounce using the iOS rubber-band formula (c=0.55) on the feed container. |
+| B4 | Synthetic IG swipe feel | Eased, velocity-shaped | Constant-velocity pointer spacing, fixed 650 ms absorb | LOW-MED | Ease-out pointer spacing; release the absorb early on URL/mutation change instead of the fixed timer. |
+| B5 | Wheel glide, retarget, keyboard scheme | — | Chromium-curve animator, velocity-preserving retarget, absorb window, unified shortform keys | NONE | Already matches or beats desktop-web comparators. |
+
+### C. UI chrome, session, system
+
+| # | Aspect | Native | hwatu/web today | Sev | Suggestion |
+|---|--------|--------|-----------------|-----|------------|
+| C1 | Hardware video decode | Mandatory | Software unless `gst-plugin-va` + driver installed (roadmap H3) | HIGH (power), MED (smoothness) | Ship H3: doctor probe, docs, AUR optdepends. Software decode inflates every TTFF number in section A. |
+| C2 | Stream quality | Top ladder (AV1/HEVC 1080p+) | IG serves a reduced H.264/HLS ladder to the iPhone-Safari UA; YT web ladder depends on MSE+VP9/AV1 advertisement; soft upscale on big monitors | MED-HIGH | Audit: (i) gst `canPlayType`/MediaCapabilities answers for vp9/av1, (ii) desktop-Chrome UA on youtube.com/shorts gets the desktop ladder + quality menu, (iii) honest devicePixelRatio (ABR picks rungs by element size × dpr), (iv) mpv+yt-dlp hand-off (H17) for the true top rung. Verify ladders live first. |
+| C3 | Missing interaction verbs | Double-tap like, share, scrub, save | Only play/pause, 2x hold, comments, mute | MED | One batch via the existing aria-label matching (`nearestButton()`): like, share, save, profile, plus keyboard seek (`,`/`.` = ±2 s on `activeShortformVideo()`) — fixes IG mobile web having no scrubber at all. Bind Esc as a second comment-sheet close. |
+| C4 | Media keys | Lock-screen/headset controls | No MediaSession→MPRIS bridge | MED | Minimal `org.mpris.MediaPlayer2.hwatu` D-Bus object driving `toggleShortformPlayback()` via the existing JS-eval IPC (~150 lines); makes `playerctl` work. |
+| C5 | Resume position | Reopens mid-feed with per-video resume | session.json restores URL only; shortform URLs carry the current reel, so last-URL ≈ resume | MED | Persist `{url, currentTime}` on discard, seek on restore via user script. |
+| C6 | Picture-in-picture | System PiP tile | W3C PiP not implemented in the GTK port | MED-HIGH | hwatu-level instead of engine-level: `hwatu open --pip` always-on-top 9:16 window + WM float rule, or the H17 mpv hand-off. |
+| C7 | Long-session memory | Recycler views, 3-5 pooled surfaces | Discard (120 s) only fires on unfocused windows; a focused 2 h session never discards | MED | (i) `WebKitMemoryPressureSettings` on the WebContext; (ii) soft-reload-to-current-reel-URL past an RSS threshold (URL carries position → near-seamless); (iii) telemetry via observe.rs first to quantify. |
+| C8 | Compositing during transitions | 60-120 fps | Largely solved (Chromium-curve animator, snap suspend, blurshield, DMABuf off = 142.9 vs 58.8 fps) | LOW | Re-test DMABuf + PropagateDamagingInformation each WebKitGTK release (upstream 305560/305758 landed after 2.52). |
+| C9 | Background audio on focus loss | Pauses by policy | hwatu is BETTER: focusshield pins `visibilityState`, autoplay Allow avoids the muted fallback | NO GAP | Document as a differentiator. |
+| C10 | Fullscreen immersion | Edge-to-edge | Already near-native (no chrome by design, F11) | LOW | Optional per-site kiosk flag using the existing `shortformSite()` classifier. |
+| C11 | Haptics | Haptic ticks | No actuator on desktop | NONE | Not addressable; the fixed snap cadence is the perceptual substitute. |
+
+## Recommended order (seamlessness per unit effort)
+
+1. **Commit-time playback handoff** (A1+A2): play incoming / ramp-out
+   outgoing at gesture commit in smoothwheel. Biggest perceived win,
+   ~50 lines, reuses existing plumbing.
+2. **Touchpad guard on IG** (B1): the one currently *broken* path.
+3. **reelwarm prefetch** (A3+A4): Range-warm N±1, `preload="metadata"`
+   on N+1.
+4. **Hardware decode** (C1 = existing H3): multiplies every latency
+   number above.
+5. **Settle-curve velocity** (B2) and extent bounce (B3).
+6. **Interaction verb batch** (C3), MPRIS (C4).
+7. **Quality audit** (C2), resume timestamp (C5), PiP window (C6),
+   memory telemetry (C7).
+
+Caveats: native-behavior claims are from Meta's published writeup,
+Android Media3 docs, and training knowledge; IG/YT web bitrate
+ladders and the `ManagedMediaSource`/loop-seek behaviors should be
+verified live before building on them.

--- a/docs/research-shortform-native-parity.md
+++ b/docs/research-shortform-native-parity.md
@@ -11,6 +11,11 @@ grounded in the current code (`smoothwheel.rs`, `mediashim.rs`,
 Feeds referenced: instagram.com Reels (mobile-UA spoof per
 `siteua.rs`), m.youtube.com Shorts, tiktok.com.
 
+> Status note: this is a point-in-time snapshot. A1/A2 (commit-time
+> handoff, roadmap H20) and B1 (IG touchpad guard, H21) shipped on
+> main the same day (`handoffPlayback` / `preciseFeedScroll` in
+> smoothwheel); the "today" columns below describe the pre-fix state.
+
 ## The headline finding
 
 Native apps do **not** crossfade video or audio between reels. Audio

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -583,18 +583,17 @@ H20. **Commit-time playback handoff.** Native clients start the
     running transition, and hard-cut the outgoing audio (tens-of-ms
     ramp against clicks). Web feeds wait for IntersectionObserver
     after settle; hwatu's IG swipe path adds a 650ms absorb on top,
-    so audio audibly overlaps. Fix in smoothwheel's shortform layer:
-    at synthetic pointerup / snap-animation start, `play()` the
-    incoming card's video and ramp-out+pause the outgoing one
-    (volume 1→0 over ~40ms). Idempotent with the site's own observer;
-    fail-open; coalesce play/pause per frame per element (GStreamer
-    pipeline-state wedge, see mediashim.rs). ~50 lines, biggest
-    perceived win.
+    so audio audibly overlaps. **Shipped 2026-08-01** (smoothwheel
+    `handoffPlayback`): at synthetic pointerup / snap-animation
+    start, `play()` the incoming card's video and ramp-out+pause the
+    outgoing one (volume 1→0 over ~40ms). Idempotent with the site's
+    own observer; fail-open. No crossfade: native hard-cuts too.
 H21. **Touchpad guard on Instagram Reels.** Precise two-finger
-    deltas bypass the swipeFeed protection (only discrete wheel is
-    claimed) and silently desync IG's gesture-state feed — the one
-    currently *broken* path. Claim precise deltas on the IG feed:
-    accumulate and translate to synthetic swipes.
+    deltas bypassed the swipeFeed protection (only discrete wheel
+    was claimed) and silently desynced IG's gesture-state feed.
+    **Shipped 2026-08-01** (smoothwheel `preciseFeedScroll`): precise
+    deltas on the IG feed are claimed, accumulated to a flick's worth
+    (120px within 300ms), and paged via the same synthetic swipe.
 H22. **reelwarm adjacent prefetch.** Native keeps N±1 in memory
     (Media3 PreloadManager). Browser equivalent: user script Range-
     fetches ~1MB (moov + first GOP) of the N±1 cards' video URLs

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -566,6 +566,72 @@ H19. **Session restore to WM workspaces.** Crash-restore exists;
     app_id/title conventions, documented) that WM rules can re-place
     restored windows, and restore on clean quit too (opt-in).
 
+### D3: native-parity shortform scrolling
+
+Adopted 2026-08-01 after a three-agent research pass comparing native
+Reels/Shorts/TikTok clients against the mobile-web feeds in hwatu;
+full findings in
+[research-shortform-native-parity.md](research-shortform-native-parity.md).
+The headline: native apps do NOT crossfade between reels — the
+seamlessness is commit-time playback handoff plus in-memory adjacent
+preload, both replicable from injected user scripts because hwatu
+already owns the gesture (smoothwheel's snap pager and synthetic IG
+swipe). Ordered by seamlessness per unit effort:
+
+H20. **Commit-time playback handoff.** Native clients start the
+    incoming video the moment the gesture commits, under the still-
+    running transition, and hard-cut the outgoing audio (tens-of-ms
+    ramp against clicks). Web feeds wait for IntersectionObserver
+    after settle; hwatu's IG swipe path adds a 650ms absorb on top,
+    so audio audibly overlaps. Fix in smoothwheel's shortform layer:
+    at synthetic pointerup / snap-animation start, `play()` the
+    incoming card's video and ramp-out+pause the outgoing one
+    (volume 1→0 over ~40ms). Idempotent with the site's own observer;
+    fail-open; coalesce play/pause per frame per element (GStreamer
+    pipeline-state wedge, see mediashim.rs). ~50 lines, biggest
+    perceived win.
+H21. **Touchpad guard on Instagram Reels.** Precise two-finger
+    deltas bypass the swipeFeed protection (only discrete wheel is
+    claimed) and silently desync IG's gesture-state feed — the one
+    currently *broken* path. Claim precise deltas on the IG feed:
+    accumulate and translate to synthetic swipes.
+H22. **reelwarm adjacent prefetch.** Native keeps N±1 in memory
+    (Media3 PreloadManager). Browser equivalent: user script Range-
+    fetches ~1MB (moov + first GOP) of the N±1 cards' video URLs
+    into WebKit's network-process cache (IG mobile and TikTok are
+    progressive MP4 — warmable), and forces `preload="metadata"` on
+    the N+1 element only so GStreamer prerolls one decoded frame.
+    Never ±2+: >3-4 concurrent pipelines is the documented deadlock
+    zone.
+H23. **Settle-curve velocity + extent bounce.** Snap settle is a
+    fixed 350ms ease-in-out from zero velocity; native settles start
+    at gesture velocity (reuse `easeWithSlope`, ~300ms ease-out).
+    Ticks at feed extents are silently eaten; add an iOS-style
+    rubber-band transform bounce (c=0.55).
+H24. **Shortform verb batch.** Like, share, save, profile, and
+    keyboard seek (`,`/`.` = ±2s — IG mobile web has no scrubber at
+    all), plus Esc closing the comment sheet. All via the existing
+    aria-label matching in smoothwheel.
+H25. **MPRIS bridge.** `org.mpris.MediaPlayer2.hwatu` driving the
+    shortform play/pause via the existing JS-eval IPC (~150 lines);
+    makes playerctl and headset keys work.
+H26. **Quality + decode audit.** H3 hardware decode multiplies every
+    latency number here. Then: codec advertisement (canPlayType for
+    vp9/av1), honest devicePixelRatio (ABR picks rungs by element
+    size × dpr), desktop-UA option for youtube shorts (quality menu),
+    and verifying IG's ladder under the iPhone UA live.
+H27. **Long-session hygiene.** Focused windows never discard, so a
+    2h reel session accumulates; add memory telemetry (observe.rs),
+    then `WebKitMemoryPressureSettings` and a soft reload-to-current-
+    reel-URL past an RSS threshold (shortform URLs carry position,
+    so the reload is near-seamless). Same property enables resume:
+    persist {url, currentTime} on discard.
+
+Non-gap worth stating: focusshield already beats native on background
+audio (WM focus loss never pauses playback), and the compositing path
+is measured solid (142.9fps). No crossfade will be added — native
+does not have one either.
+
 ### Engine-bound gaps (documented honestly, not planned)
 
 - **Widevine/DRM:** WebKitGTK has ClearKey only; no distro ships


### PR DESCRIPTION
## What

Three-agent swarm research pass comparing native short-form clients (Instagram Reels, TikTok, YouTube Shorts) against the mobile-web feeds running in hwatu, focused on making scrolling as seamless as native.

- `docs/research-shortform-native-parity.md`: full findings tables across three areas — playback handoff/preload, gesture/scroll mechanics, UI/session/system — each with native behavior, hwatu behavior today, severity, and a concrete browser-side suggestion.
- `docs/roadmap.md`: new **D3: native-parity shortform scrolling** workstream (H20-H27), ordered by seamlessness per unit effort.

## Headline finding

Native apps do **not** crossfade between reels (audio overlap is perceived as a bug). Seamlessness comes from (1) commit-time playback handoff — incoming video plays the moment the gesture commits, outgoing audio hard-cuts, (2) in-memory adjacent preload (Media3 PreloadManager, per Meta's published writeup), and (3) gesture-coupled rendering. All three have browser-side equivalents because hwatu already owns the gesture via smoothwheel.

## Top items

- H20 commit-time playback handoff (~50 lines in smoothwheel, biggest perceived win)
- H21 touchpad guard on IG Reels (precise deltas currently bypass swipeFeed — broken path)
- H22 reelwarm N±1 Range prefetch + preload=metadata preroll

Per repo docs policy: branch + PR, not merging myself.