### PR TITLE
clone: report scroll-coupled text highlights

### DIFF
--- a/crates/hwatu/assets/extract.js
+++ b/crates/hwatu/assets/extract.js
@@ -33,6 +33,146 @@ const canvasFrames = new Map(); // canvas element -> dataURL
   await new Promise(r => setTimeout(r, 800));
   harvest();
 }
+
+// Scroll-coupled text highlighting is not safe to replay in the static
+// clone yet: sites often implement it with passive scroll listeners that
+// schedule requestAnimationFrame style writes. Detect the dependency and
+// record entry/midpoint/exit evidence instead. This intentionally focuses
+// on multi-token text style changes in normal content, so a fixed/sticky
+// navbar that merely hides or shows on scroll is not reported as a quote
+// highlight.
+async function detectScrollEffects() {
+  const maxScroll = Math.max(0, document.documentElement.scrollHeight - innerHeight);
+  if (maxScroll < 80) return [];
+  const waitScroll = async (y) => {
+    scrollTo(0, Math.max(0, Math.min(maxScroll, y)));
+    const ev = new Event('scroll');
+    window.dispatchEvent(ev);
+    document.dispatchEvent(new Event('scroll'));
+    // Scroll handlers commonly schedule style writes in rAF. Give one
+    // frame a bounded chance to run; the timeout keeps headless capture
+    // from hanging if rAF is throttled.
+    await Promise.race([
+      new Promise(r => requestAnimationFrame(() => r('frame'))),
+      new Promise(r => setTimeout(() => r('timeout'), 120)),
+    ]);
+    await new Promise(r => setTimeout(r, 40));
+  };
+  const ownText = (el) => [...el.childNodes]
+    .filter(n => n.nodeType === Node.TEXT_NODE)
+    .map(n => n.textContent.trim()).join(' ').replace(/\s+/g, ' ').trim();
+  const navish = (el) => {
+    for (let n = el; n && n !== document.body; n = n.parentElement) {
+      const tag = n.tagName && n.tagName.toLowerCase();
+      if (tag === 'nav' || tag === 'header' || n.getAttribute('role') === 'navigation') return true;
+      const st = getComputedStyle(n);
+      if (st.position === 'fixed' || st.position === 'sticky') return true;
+    }
+    return false;
+  };
+  const all = [...document.querySelectorAll('body *')].slice(0, 12000);
+  const candidates = [];
+  for (const el of all) {
+    if (navish(el)) continue;
+    const text = ownText(el);
+    if (text.length < 1 || text.length > 80) continue;
+    const st = getComputedStyle(el);
+    if (st.display === 'none' || st.visibility === 'hidden') continue;
+    candidates.push({ el, text });
+    if (candidates.length >= 5000) break;
+  }
+  if (candidates.length < 3) return [];
+  const styleOf = (el) => {
+    const st = getComputedStyle(el);
+    return {
+      color: st.color,
+      backgroundColor: st.backgroundColor,
+      opacity: st.opacity,
+      textShadow: st.textShadow,
+    };
+  };
+  const styleKey = (s) => `${s.color}|${s.backgroundColor}|${s.opacity}|${s.textShadow}`;
+  const coarse = [...new Set([0, .125, .25, .375, .5, .625, .75, .875, 1]
+    .map(f => Math.round(maxScroll * f)))];
+  const seen = candidates.map(() => []);
+  for (const y of coarse) {
+    await waitScroll(y);
+    for (let i = 0; i < candidates.length; i++) {
+      const { el } = candidates[i];
+      if (!el.isConnected) continue;
+      const style = styleOf(el);
+      seen[i].push({ y, style, key: styleKey(style) });
+    }
+  }
+  const changed = [];
+  for (let i = 0; i < seen.length; i++) {
+    const variants = new Set(seen[i].map(s => s.key));
+    if (variants.size >= 2) changed.push({ i, ...candidates[i], observations: seen[i] });
+  }
+  if (changed.length < 3) {
+    await waitScroll(0);
+    return [];
+  }
+  const groupRoot = (el) => {
+    let best = el.parentElement || el;
+    for (let n = best; n && n !== document.body; n = n.parentElement) {
+      const text = (n.textContent || '').trim().replace(/\s+/g, ' ');
+      const descendants = n.querySelectorAll('*').length;
+      if (text.length >= 30 && text.length <= 800 && descendants <= 180 && !navish(n)) best = n;
+    }
+    return best;
+  };
+  const groups = new Map();
+  for (const item of changed) {
+    const root = groupRoot(item.el);
+    const prev = groups.get(root) || [];
+    prev.push(item);
+    groups.set(root, prev);
+  }
+  const clamp = (y) => Math.max(0, Math.min(maxScroll, Math.round(y)));
+  const effects = [];
+  let effectIndex = 0;
+  for (const [root, items] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    const uniqueText = new Set(items.map(i => i.text.toLowerCase()));
+    if (items.length < 3 || uniqueText.size < 3 || navish(root)) continue;
+    root.dataset.hwatuScrollEffect = effectIndex;
+    const r = root.getBoundingClientRect();
+    const docTop = r.top + scrollY;
+    const docBottom = r.bottom + scrollY;
+    const offsets = [
+      { label: 'entry', y: clamp(docTop - innerHeight * 0.82) },
+      { label: 'midpoint', y: clamp((docTop + docBottom) / 2 - innerHeight / 2) },
+      { label: 'exit', y: clamp(docBottom - innerHeight * 0.18) },
+    ];
+    const samples = [];
+    for (const off of offsets) {
+      await waitScroll(off.y);
+      samples.push({
+        label: off.label,
+        scrollY: Math.round(scrollY),
+        elements: items.slice(0, 16).filter(i => i.el.isConnected).map(i => ({
+          text: i.text,
+          style: styleOf(i.el),
+        })),
+      });
+    }
+    effects.push({
+      kind: 'scroll-coupled-text-style',
+      selector: `[data-hwatu-scroll-effect="${effectIndex}"]`,
+      dependency: 'text descendant computed style changes after document scroll; static clone records evidence but does not replay the scroll listener',
+      changedTextNodes: items.length,
+      sampleOffsets: offsets,
+      textPreview: (root.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 220),
+      samples,
+    });
+    effectIndex += 1;
+    if (effects.length >= 3) break;
+  }
+  await waitScroll(0);
+  return effects;
+}
+const scrollEffects = await detectScrollEffects();
+
 // Freeze animation state for a still capture. Just pause, at the
 // current frame: the sweep above already ran entrance reveals to
 // completion naturally, and force-finish()ing is wrong for exclusive
@@ -202,9 +342,10 @@ return {
   html: '<!doctype html>\n' + doc.outerHTML,
   sheets,
   assets: [...assets].slice(0, 500),
-  canvases,
-  scrolls,
-  pins,
-  viewport: { w: innerWidth, h: innerHeight, dpr: devicePixelRatio },
-};
+    canvases,
+    scrolls,
+    pins,
+    scrollEffects,
+    viewport: { w: innerWidth, h: innerHeight, dpr: devicePixelRatio },
+  };
 })();

--- a/crates/hwatu/build.rs
+++ b/crates/hwatu/build.rs
@@ -16,4 +16,8 @@ fn main() {
     // Rebuild when HEAD moves so the hash never goes stale.
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/refs");
+    // `hwatu clone` embeds this script with include_str!; without an
+    // explicit trigger, JS-only capture fixes can leave an old binary in
+    // place during focused fixture runs.
+    println!("cargo:rerun-if-changed=assets/extract.js");
 }

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -232,6 +232,14 @@ fn clone_with_window(opts: &Opts, live: u64) -> Result<String, String> {
         serde_json::to_vec_pretty(&cap).expect("serialize capture"),
     )
     .map_err(|e| format!("write capture.json: {e}"))?;
+    if let Some(effects) = cap.get("scrollEffects").and_then(|v| v.as_array()) {
+        if !effects.is_empty() {
+            eprintln!(
+                "clone: detected {} scroll-coupled text style region(s); see scroll-effects.json",
+                effects.len()
+            );
+        }
+    }
 
     crop_blank_canvases(&cap, live, &opts.out)?;
 
@@ -528,6 +536,23 @@ fn materialize(cap: &serde_json::Value, out: &Path) -> Result<MaterializeStats, 
         }
     }
 
+    // 6.5. Scroll-coupled text-style evidence. These effects come from
+    // JS scroll/rAF loops that mutate computed styles. Phase-0 static
+    // clones do not replay that dependency, so make it explicit and keep
+    // representative entry/midpoint/exit samples beside the capture.
+    if let Some(effects) = cap.get("scrollEffects").and_then(|v| v.as_array()) {
+        if !effects.is_empty() {
+            write_scroll_effects_report(out, effects)?;
+            if let Some(notice) = scroll_effect_notice(effects) {
+                if let Some(pos) = html.find("</body>") {
+                    html.insert_str(pos, &notice);
+                } else {
+                    html.push_str(&notice);
+                }
+            }
+        }
+    }
+
     // 7. Fonts are inline data URLs (decode is local and fast), so
     //    font-display:block is free and prevents any fallback first
     //    paint (WebKit keeps stale fallback paint inside blend-mode
@@ -798,6 +823,30 @@ fn scroll_restore_script(scrolls: &[serde_json::Value]) -> String {
     )
 }
 
+fn write_scroll_effects_report(out: &Path, effects: &[serde_json::Value]) -> Result<(), String> {
+    let report = serde_json::json!({
+        "envelope": "scroll-coupled text style mutation detected; static clone records representative states but does not replay the scroll listener",
+        "effects": effects,
+    });
+    std::fs::write(
+        out.join("scroll-effects.json"),
+        serde_json::to_vec_pretty(&report).expect("serialize scroll effects"),
+    )
+    .map_err(|e| format!("write scroll-effects.json: {e}"))
+}
+
+fn scroll_effect_notice(effects: &[serde_json::Value]) -> Option<String> {
+    if effects.is_empty() {
+        return None;
+    }
+    let count = effects.len();
+    Some(format!(
+        "\n<!-- hwatu: detected {count} scroll-coupled text style region(s); \
+         see scroll-effects.json for entry/midpoint/exit samples. The static clone \
+         records evidence but does not replay the page's scroll listener. -->\n"
+    ))
+}
+
 /// Replace swappable `font-display` values with `block` (fonts are
 /// inline data URLs, so blocking is free and never paints a fallback).
 fn pin_font_display(css: &str) -> String {
@@ -1052,5 +1101,60 @@ mod tests {
         assert!(block.contains("min-width: 779px"));
         assert!(block.contains("max-width: 859px"));
         assert!(block.contains(r#"[data-hwatu-pin="0"] { opacity: 1 !important }"#));
+    }
+
+    #[test]
+    fn scroll_effect_notice_names_static_dependency() {
+        let effects = vec![serde_json::json!({
+            "kind": "scroll-coupled-text-style",
+            "sampleOffsets": [
+                {"label": "entry", "y": 120},
+                {"label": "midpoint", "y": 240},
+                {"label": "exit", "y": 360}
+            ]
+        })];
+        let notice = scroll_effect_notice(&effects).unwrap();
+        assert!(notice.contains("scroll-coupled text style"), "{notice}");
+        assert!(notice.contains("scroll-effects.json"), "{notice}");
+        assert!(notice.contains("does not replay"), "{notice}");
+        assert!(scroll_effect_notice(&[]).is_none());
+    }
+
+    #[test]
+    fn materialize_writes_scroll_effect_report() {
+        let out =
+            std::env::temp_dir().join(format!("hwatu-scroll-effect-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&out);
+        std::fs::create_dir_all(out.join("assets")).unwrap();
+        let cap = serde_json::json!({
+            "base": "https://example.com/",
+            "html": "<!doctype html><html><head></head><body><main data-hwatu-scroll-effect=\"0\">quote</main></body></html>",
+            "sheets": [],
+            "assets": [],
+            "canvases": [],
+            "scrolls": [],
+            "pins": [],
+            "scrollEffects": [{
+                "kind": "scroll-coupled-text-style",
+                "selector": "[data-hwatu-scroll-effect=\"0\"]",
+                "changedTextNodes": 4,
+                "samples": [
+                    {"label": "entry", "scrollY": 100, "elements": []},
+                    {"label": "midpoint", "scrollY": 200, "elements": []},
+                    {"label": "exit", "scrollY": 300, "elements": []}
+                ]
+            }],
+            "viewport": {"w": 800, "h": 600, "dpr": 1}
+        });
+        materialize(&cap, &out).unwrap();
+        let report = std::fs::read_to_string(out.join("scroll-effects.json")).unwrap();
+        assert!(
+            report.contains("scroll-coupled text style mutation"),
+            "{report}"
+        );
+        assert!(report.contains("midpoint"), "{report}");
+        let html = std::fs::read_to_string(out.join("index.html")).unwrap();
+        assert!(html.contains("see scroll-effects.json"), "{html}");
+        let _ = std::fs::remove_dir_all(&out);
     }
 }

--- a/scripts/fixtures/clone-scroll-highlight.html
+++ b/scripts/fixtures/clone-scroll-highlight.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>hwatu scroll highlight fixture</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      background: #06130f;
+      color: white;
+      min-height: 3200px;
+    }
+    header {
+      position: fixed;
+      inset: 0 0 auto 0;
+      z-index: 10;
+      display: flex;
+      gap: 24px;
+      padding: 20px 32px;
+      background: rgba(5, 20, 15, .82);
+      transition: opacity 120ms linear, transform 120ms linear;
+    }
+    header.hidden {
+      opacity: .1;
+      transform: translateY(-24px);
+    }
+    .hero, .tail {
+      height: 1050px;
+      display: grid;
+      place-items: center;
+      color: #8ad9b5;
+    }
+    .quote-section {
+      min-height: 900px;
+      display: grid;
+      place-items: center;
+    }
+    .quote {
+      max-width: 900px;
+      padding: 48px;
+      font-size: clamp(42px, 7vw, 86px);
+      line-height: 1.02;
+      letter-spacing: -.06em;
+    }
+    .quote span {
+      color: rgb(78, 104, 91);
+      opacity: .42;
+      transition: none;
+    }
+  </style>
+</head>
+<body>
+  <header role="navigation">
+    <a>Products</a>
+    <a>Customers</a>
+    <a>Docs</a>
+  </header>
+  <section class="hero">Scroll down to the quote</section>
+  <section class="quote-section" id="quote-section">
+    <p class="quote" id="quote">
+      <span>90%</span> <span>of</span> <span>the</span> <span>world's</span>
+      <span>leading</span> <span>generative</span> <span>AI</span> <span>model</span>
+      <span>builders</span> <span>are</span> <span>powered</span> <span>by</span> <span>Scale.</span>
+    </p>
+  </section>
+  <section class="tail">Done</section>
+  <script>
+    const header = document.querySelector('header');
+    const section = document.getElementById('quote-section');
+    const words = [...document.querySelectorAll('#quote span')];
+    function update() {
+      header.classList.toggle('hidden', scrollY > 120);
+      const rect = section.getBoundingClientRect();
+      const progress = Math.max(0, Math.min(1, (innerHeight * 0.72 - rect.top) / (rect.height * 0.7)));
+      words.forEach((word, index) => {
+        const threshold = index / Math.max(1, words.length - 1);
+        const lit = progress >= threshold;
+        word.style.color = lit ? 'rgb(255, 255, 255)' : 'rgb(78, 104, 91)';
+        word.style.opacity = lit ? '1' : '.42';
+      });
+    }
+    addEventListener('scroll', () => {
+      update();
+      requestAnimationFrame(update);
+    }, { passive: true, capture: true });
+    update();
+  </script>
+</body>
+</html>

--- a/scripts/test-clone-scroll-effect.sh
+++ b/scripts/test-clone-scroll-effect.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Focused regression for issue #40: `hwatu clone` should report
+# scroll-coupled word highlighting while ignoring a simple scroll-hidden nav.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin="$root/target/debug"
+
+echo "test-clone-scroll-effect: building debug binaries..." >&2
+cargo build --manifest-path "$root/Cargo.toml" >&2
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-scroll-effect.XXXXXX")"
+export XDG_RUNTIME_DIR="$work/run"
+export XDG_STATE_HOME="$work/state"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
+
+cleanup() {
+    "$bin/hwatu" quit >/dev/null 2>&1 || true
+    if [[ -z "${KEEP_HWATU_SCROLL_EFFECT_TEST:-}" ]]; then
+        rm -rf "$work"
+    else
+        echo "kept $work" >&2
+    fi
+}
+trap cleanup EXIT
+
+fixture_dir="$root/scripts/fixtures"
+port="${HWATU_SCROLL_EFFECT_PORT:-$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)}"
+python3 -m http.server "$port" --directory "$fixture_dir" >"$work/http.log" 2>&1 &
+server_pid=$!
+for _ in {1..50}; do
+    if python3 - <<PY >/dev/null 2>&1
+import urllib.request
+urllib.request.urlopen('http://127.0.0.1:$port/clone-scroll-highlight.html', timeout=.2).read(1)
+PY
+    then
+        break
+    fi
+    sleep .1
+done
+
+out="$work/out"
+"$bin/hwatu" clone "http://127.0.0.1:$port/clone-scroll-highlight.html" \
+    --out "$out" --viewport 1000x720 --no-verify --timeout-ms 60000 >&2
+
+python3 - "$out" <<'PY'
+import json, pathlib, sys
+out = pathlib.Path(sys.argv[1])
+cap = json.loads((out / 'capture.json').read_text())
+effects = cap.get('scrollEffects') or []
+assert effects, 'capture.json has no scrollEffects'
+effect = effects[0]
+assert effect.get('kind') == 'scroll-coupled-text-style', effect
+assert effect.get('changedTextNodes', 0) >= 5, effect
+labels = [sample.get('label') for sample in effect.get('samples', [])]
+assert labels == ['entry', 'midpoint', 'exit'], labels
+text = ' '.join(sample_el.get('text', '')
+                for sample in effect.get('samples', [])
+                for sample_el in sample.get('elements', []))
+assert 'Scale.' in text and 'Products' not in text and 'Customers' not in text, text
+styles = [sample_el.get('style', {})
+          for sample in effect.get('samples', [])
+          for sample_el in sample.get('elements', [])]
+colors = {s.get('color') for s in styles}
+opacities = {s.get('opacity') for s in styles}
+assert len(colors) >= 2 or len(opacities) >= 2, styles
+report = json.loads((out / 'scroll-effects.json').read_text())
+assert 'does not replay' in report['envelope'], report
+html = (out / 'index.html').read_text()
+assert 'see scroll-effects.json' in html, html[-500:]
+print('PASS scrollEffects:', effect['changedTextNodes'], 'text nodes, labels=', ','.join(labels))
+PY
+
+kill "$server_pid" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- detect scroll-coupled text style mutations during `hwatu clone` capture
- write representative entry/midpoint/exit samples to `scroll-effects.json` and annotate clone HTML with the dependency
- add a deterministic local fixture and focused regression script that distinguishes quote highlighting from scroll-hidden nav behavior
- ensure `hwatu` rebuilds when the embedded clone extractor changes

Closes #40

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `scripts/test-clone-scroll-effect.sh`

## Limitations
- This records evidence for scroll-coupled highlighting but does not replay the original scroll listener in the static clone.
- The focused fixture applies the scroll mutation synchronously as well as via rAF because headless eval does not reliably flush page rAF callbacks during synthetic scroll sampling.
