### PR TITLE
browser: hand off rejected Turnstile challenges

### DIFF
--- a/crates/hwatud/src/console.rs
+++ b/crates/hwatud/src/console.rs
@@ -48,6 +48,17 @@ pub struct Entry {
     pub page: Option<String>,
 }
 
+/// True when Cloudflare says its challenge cannot run in this browser.
+///
+/// 110500 is the documented unsupported-browser error.  The 600 family is a
+/// generic execution rejection, and is what Turnstile currently emits after
+/// detecting WebKitGTK's deliberately generic WebGL fingerprint.
+pub fn is_turnstile_compat_error(entry: &Entry) -> bool {
+    entry.kind == "console"
+        && entry.text.contains("[Cloudflare Turnstile] Error:")
+        && (entry.text.contains("Error: 110500") || entry.text.contains("Error: 600"))
+}
+
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -237,7 +248,7 @@ pub fn attach(buffer: &Buffer, view: &webkit6::WebView) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Buffer, Entry, CAP};
+    use super::{is_turnstile_compat_error, Buffer, Entry, CAP};
 
     fn entry(text: &str) -> Entry {
         Entry {
@@ -273,5 +284,17 @@ mod tests {
         b.push(entry("b"));
         assert_eq!(b.read(true, Some(1)).len(), 1);
         assert!(b.read(false, None).is_empty());
+    }
+
+    #[test]
+    fn detects_turnstile_browser_rejections_only() {
+        let mut e = entry("[Cloudflare Turnstile] Error: 600010.");
+        assert!(is_turnstile_compat_error(&e));
+        e.text = "[Cloudflare Turnstile] Error: 110500.".into();
+        assert!(is_turnstile_compat_error(&e));
+        e.text = "unrelated API Error: 600010".into();
+        assert!(!is_turnstile_compat_error(&e));
+        e.text = "[Cloudflare Turnstile] Error: 200500.".into();
+        assert!(!is_turnstile_compat_error(&e));
     }
 }

--- a/crates/hwatud/src/external.rs
+++ b/crates/hwatud/src/external.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Justin Hong
+//! Open compatibility-blocked pages in an installed non-WebKit browser.
+//!
+//! Cloudflare explicitly gives embedded/custom WebKit environments limited
+//! support.  Current Turnstile challenges reject WebKitGTK's privacy-preserving
+//! WebGL fingerprint, so retrying inside the same view cannot recover.  Keep
+//! the fallback explicit (the user answers a y/n prompt) and launch a browser
+//! with a different engine instead of weakening WebKit's fingerprinting
+//! protections or pretending that the challenge succeeded.
+
+use std::io;
+use std::process::{Command, Stdio};
+
+const FALLBACKS: &[&str] = &[
+    "helium",
+    "firefox",
+    "google-chrome-stable",
+    "google-chrome",
+    "chromium",
+    "chromium-browser",
+    "brave-browser",
+];
+
+fn candidates() -> Vec<String> {
+    let mut out = Vec::new();
+    if let Ok(browser) = std::env::var("HWATU_EXTERNAL_BROWSER") {
+        let browser = browser.trim();
+        if !browser.is_empty() {
+            out.push(browser.to_string());
+        }
+    }
+    out.extend(FALLBACKS.iter().map(|name| (*name).to_string()));
+    out.dedup();
+    out
+}
+
+pub fn open(uri: &str) -> io::Result<String> {
+    let mut last_not_found = None;
+    for browser in candidates() {
+        match Command::new(&browser)
+            .arg(uri)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(_) => return Ok(browser),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                last_not_found = Some(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_not_found.unwrap_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "no external browser is installed")
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FALLBACKS;
+
+    #[test]
+    fn fallbacks_are_non_webkit_browsers() {
+        assert!(FALLBACKS.contains(&"firefox"));
+        assert!(FALLBACKS.contains(&"chromium"));
+        assert!(!FALLBACKS.contains(&"epiphany"));
+        assert!(!FALLBACKS.contains(&"hwatu"));
+    }
+}

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -17,6 +17,7 @@ mod compositor;
 mod console;
 mod downloads;
 mod events;
+mod external;
 mod focusshield;
 mod ipc_server;
 mod keys;

--- a/crates/hwatud/src/prompts.rs
+++ b/crates/hwatud/src/prompts.rs
@@ -26,6 +26,10 @@ pub enum Prompt {
         certificate: gio::TlsCertificate,
         reason: String,
     },
+    /// The page's anti-bot provider rejected WebKitGTK.  A different engine
+    /// is the only honest recovery: do not spoof hardware fingerprints or
+    /// silently claim that the challenge passed.
+    ExternalBrowser { uri: String },
 }
 
 impl Prompt {
@@ -35,6 +39,10 @@ impl Prompt {
             Prompt::Tls { host, reason, .. } => {
                 format!("TLS error for {host} ({reason}), proceed?")
             }
+            Prompt::ExternalBrowser { uri } => format!(
+                "Cloudflare rejected WebKitGTK; open {} in another browser?",
+                host_of(uri)
+            ),
         }
     }
 
@@ -43,6 +51,8 @@ impl Prompt {
             Prompt::Permission { host, kind, .. } => Some(format!("perm:{host}:{kind}")),
             // TLS exceptions are handled by the network session itself.
             Prompt::Tls { .. } => None,
+            // Launching another application is always an explicit action.
+            Prompt::ExternalBrowser { .. } => None,
         }
     }
 }
@@ -124,6 +134,15 @@ fn answer(prompt: &Prompt, allow: bool, webview: Option<&webkit6::WebView>) {
                 println!("hwatud: TLS exception for {host} (this session)");
                 session.allow_tls_certificate_for_host(certificate, host);
                 webview.load_uri(failing_uri);
+            }
+        }
+        Prompt::ExternalBrowser { uri } => {
+            if !allow {
+                return;
+            }
+            match crate::external::open(uri) {
+                Ok(browser) => println!("hwatud: opened {uri} in {browser}"),
+                Err(error) => eprintln!("hwatud: cannot open {uri} externally: {error}"),
             }
         }
     }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -249,6 +249,9 @@ pub struct BrowserWindow {
     /// (method, url, status, type, timing), not just failures.
     /// Outlives discards for the same reason the console buffer does.
     pub net: crate::net::Buffer,
+    /// Suppress a retry storm: Turnstile emits the same 600010 rejection
+    /// repeatedly in one document.  Reset on the next top-level load.
+    turnstile_handoff_offered: std::cell::Cell<bool>,
     /// Command-palette state while the bar is in Palette mode: the
     /// current ranked matches and which one is highlighted. Cleared on
     /// close so a reopened palette starts fresh.
@@ -609,6 +612,7 @@ impl BrowserWindow {
             snapshot_baseline: RefCell::new(None),
             console: crate::console::Buffer::default(),
             net: crate::net::Buffer::default(),
+            turnstile_handoff_offered: std::cell::Cell::new(false),
             palette: RefCell::new(None),
         });
 
@@ -622,12 +626,29 @@ impl BrowserWindow {
         {
             let daemon = daemon.clone();
             let win_id = id;
+            let weak = Rc::downgrade(&this);
             this.console.set_hook(move |entry| {
                 daemon.events.emit(
                     "console",
                     Some(win_id),
                     serde_json::to_value(entry).unwrap_or_default(),
                 );
+                if crate::console::is_turnstile_compat_error(entry) {
+                    let Some(this) = weak.upgrade() else { return };
+                    if this.turnstile_handoff_offered.replace(true) {
+                        return;
+                    }
+                    let Some(uri) = entry
+                        .page
+                        .as_deref()
+                        .filter(|uri| uri.starts_with("https://") || uri.starts_with("http://"))
+                    else {
+                        return;
+                    };
+                    this.push_prompt(Prompt::ExternalBrowser {
+                        uri: uri.to_string(),
+                    });
+                }
             });
         }
         daemon.events.emit(
@@ -763,6 +784,7 @@ impl BrowserWindow {
             webview.connect_load_changed(move |wv, event| match event {
                 webkit6::LoadEvent::Started => {
                     this.note_load_engaged(wv);
+                    this.turnstile_handoff_offered.set(false);
                     this.load_committed.set(false);
                     this.clear_recovery_overlay();
                     this.emit_load(wv, "started");

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -635,9 +635,6 @@ impl BrowserWindow {
                 );
                 if crate::console::is_turnstile_compat_error(entry) {
                     let Some(this) = weak.upgrade() else { return };
-                    if this.turnstile_handoff_offered.replace(true) {
-                        return;
-                    }
                     let Some(uri) = entry
                         .page
                         .as_deref()
@@ -645,6 +642,12 @@ impl BrowserWindow {
                     else {
                         return;
                     };
+                    // Invalid/non-web page provenance must not consume the
+                    // one-shot offer: a later valid main-page rejection in
+                    // this document still deserves a recovery prompt.
+                    if this.turnstile_handoff_offered.replace(true) {
+                        return;
+                    }
                     this.push_prompt(Prompt::ExternalBrowser {
                         uri: uri.to_string(),
                     });


### PR DESCRIPTION
## Summary
- detect Cloudflare Turnstile browser-compatibility failures
- offer an explicit, once-per-document handoff to an installed non-WebKit browser
- validate the source URL before suppressing duplicate prompts

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --workspace --locked`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `cargo test -p hwatu-ipc --locked`
- Rust 1.85 workspace/all-targets check
- release build
- display-free behavioral suite: 19 passed, 0 failed