### PR TITLE
Fix clone parser fixed-point serialization

### DIFF
--- a/crates/hwatu/assets/extract.js
+++ b/crates/hwatu/assets/extract.js
@@ -387,6 +387,87 @@ const interactiveCount = document.querySelectorAll(
   'a[href], button, [role=button], [onclick], input, select, textarea, summary, [role=link], [role=tab], [role=menuitem]'
 ).length;
 
+// Parser fixed-point guard: DOMs produced by JS/React can be valid live
+// trees that are not representable as equivalent text/html. The common
+// case is block-flow line wrappers inside <p>; when reparsed, the HTML
+// parser auto-closes the paragraph and ejects the wrapper siblings. Rewrite
+// only those unsafe paragraphs in the cloned document so serialization is a
+// fixed point while preserving attributes, children, and paragraph semantics.
+function parserFixedPointRewrite(doc) {
+  const BLOCK_IN_P = new Set([
+    'address', 'article', 'aside', 'blockquote', 'details', 'dialog', 'div',
+    'dl', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2',
+    'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'main', 'menu', 'nav',
+    'ol', 'p', 'pre', 'section', 'table', 'ul'
+  ]);
+  const hasBarePSelector = () => {
+    const re = /(^|[^.#\w-])p(?=$|[^\w-])/i;
+    for (const sheet of sheets) {
+      const text = sheet.text || '';
+      if (re.test(text)) return true;
+    }
+    return false;
+  };
+  const stats = {
+    rewritten: [],
+    reparsed_tag_count_deltas: [],
+    injected_css: false,
+  };
+  let i = 0;
+  for (const p of [...doc.querySelectorAll('p')]) {
+    const offenders = [...p.children].filter(c => BLOCK_IN_P.has(c.tagName.toLowerCase()));
+    if (!offenders.length) continue;
+    const div = doc.ownerDocument.createElement('div');
+    for (const attr of [...p.attributes]) div.setAttribute(attr.name, attr.value);
+    div.setAttribute('role', div.getAttribute('role') || 'paragraph');
+    div.setAttribute('data-hwatu-was', 'p');
+    div.setAttribute('data-hwatu-parser-fix', String(i));
+    while (p.firstChild) div.appendChild(p.firstChild);
+    p.replaceWith(div);
+    stats.rewritten.push({
+      i,
+      from: 'p',
+      to: 'div',
+      reason: 'block child inside p would be ejected by text/html reparse',
+      block_children: [...new Set(offenders.map(c => c.tagName.toLowerCase()))],
+      class: div.getAttribute('class') || null,
+      id: div.getAttribute('id') || null,
+    });
+    i += 1;
+  }
+  if (stats.rewritten.length && hasBarePSelector()) {
+    const style = doc.ownerDocument.createElement('style');
+    style.setAttribute('data-hwatu-parser-fix-style', '');
+    style.textContent = ':where([data-hwatu-was="p"][role="paragraph"]) { display: block; margin-block: 1em; }';
+    (doc.querySelector('head') || doc).appendChild(style);
+    stats.injected_css = true;
+  }
+  const html = '<!doctype html>\n' + doc.outerHTML;
+  const reparsed = document.implementation.createHTMLDocument('hwatu-reparse-check');
+  reparsed.open();
+  reparsed.write(html);
+  reparsed.close();
+  const countTags = (root) => {
+    const counts = new Map();
+    for (const el of root.querySelectorAll('*')) {
+      const tag = el.tagName.toLowerCase();
+      counts.set(tag, (counts.get(tag) || 0) + 1);
+    }
+    return counts;
+  };
+  const liveCounts = countTags(doc);
+  const reparsedCounts = countTags(reparsed.documentElement);
+  const tags = new Set([...liveCounts.keys(), ...reparsedCounts.keys()]);
+  for (const tag of [...tags].sort()) {
+    const live = liveCounts.get(tag) || 0;
+    const reparsed = reparsedCounts.get(tag) || 0;
+    if (live !== reparsed) stats.reparsed_tag_count_deltas.push({ tag, live, reparsed });
+  }
+  stats.fixed_point = stats.reparsed_tag_count_deltas.length === 0;
+  stats.html = html;
+  return stats;
+}
+
 // 4. Serialized DOM. Strip scripts (the clone is a static still) and
 //    live stylesheet links (we inline the CSSOM text instead).
 const doc = document.documentElement.cloneNode(true);
@@ -401,10 +482,18 @@ doc.querySelectorAll('noscript').forEach(el => {
   el.replaceWith(span);
 });
 
+const parserFixedPoint = parserFixedPointRewrite(doc);
+
 return {
   base: location.href,
   title: document.title,
-  html: '<!doctype html>\n' + doc.outerHTML,
+  html: parserFixedPoint.html,
+  parserFixedPoint: {
+    rewritten: parserFixedPoint.rewritten,
+    reparsed_tag_count_deltas: parserFixedPoint.reparsed_tag_count_deltas,
+    fixed_point: parserFixedPoint.fixed_point,
+    injected_css: parserFixedPoint.injected_css,
+  },
   sheets,
   assets: [...assets].slice(0, 500),
     canvases,

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -373,6 +373,12 @@ fn clone_with_window(opts: &Opts, live: u64) -> Result<String, String> {
         "unreplicated_motion": unreplicated_motion,
         "stripped_scripts": stripped_scripts,
         "interactive_elements": interactive,
+        "parser_fixed_point": cap.get("parserFixedPoint").cloned().unwrap_or_else(|| serde_json::json!({
+            "fixed_point": true,
+            "rewritten": [],
+            "reparsed_tag_count_deltas": [],
+            "injected_css": false,
+        })),
         "scroll_effects": stats.scroll_effects,
         "summary": honesty,
         "envelope": "still clone; scores cover exactly this viewport and these scroll offsets",

--- a/scripts/fixtures/clone-parser-fixed-point.html
+++ b/scripts/fixtures/clone-parser-fixed-point.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>hwatu parser fixed-point fixture</title>
+  <style>
+    p { margin: 24px 0; color: rgb(20, 20, 20); }
+    .AnimatedText { margin: 0; }
+    .AnimatedText .line { display: block; }
+    .AnimatedText .word { display: inline-block; color: rgb(80, 80, 80); }
+  </style>
+</head>
+<body>
+  <main id="root"></main>
+  <script>
+    const p = document.createElement('p');
+    p.id = 'animated';
+    p.className = 'AnimatedText';
+    const line = document.createElement('div');
+    line.className = 'line';
+    const word = document.createElement('div');
+    word.className = 'word';
+    word.textContent = 'Preserved';
+    line.append('Line ', word);
+    p.append(line);
+    document.getElementById('root').append(p);
+  </script>
+</body>
+</html>

--- a/scripts/test-clone-parser-fixed-point.sh
+++ b/scripts/test-clone-parser-fixed-point.sh
@@ -12,9 +12,22 @@ cargo build --manifest-path "$root/Cargo.toml" >&2
 work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-parser-fixed-point.XXXXXX")"
 export XDG_RUNTIME_DIR="$work/run"
 export XDG_STATE_HOME="$work/state"
-mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
+export XDG_CONFIG_HOME="$work/config"
+export XDG_DATA_HOME="$work/data"
+export XDG_CACHE_HOME="$work/cache"
+mkdir -p \
+    "$XDG_RUNTIME_DIR" \
+    "$XDG_STATE_HOME" \
+    "$XDG_CONFIG_HOME" \
+    "$XDG_DATA_HOME" \
+    "$XDG_CACHE_HOME"
 
+server_pid=""
 cleanup() {
+    if [[ -n "$server_pid" ]]; then
+        kill "$server_pid" >/dev/null 2>&1 || true
+        wait "$server_pid" 2>/dev/null || true
+    fi
     "$bin/hwatu" quit >/dev/null 2>&1 || true
     if [[ -z "${KEEP_HWATU_PARSER_FIXED_POINT_TEST:-}" ]]; then
         rm -rf "$work"
@@ -108,5 +121,3 @@ if (margin !== '0px/0px') throw new Error('class reset margin drifted: ' + margi
 JS
 )
 "$bin/hwatu" eval --id "$clone_id" "$dom_assert_js"
-
-kill "$server_pid" >/dev/null 2>&1 || true

--- a/scripts/test-clone-parser-fixed-point.sh
+++ b/scripts/test-clone-parser-fixed-point.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Focused regression for issue #47: JS-built div-in-p DOMs must serialize
+# to a parser fixed point without ejecting line-wrapper descendants.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin="$root/target/debug"
+
+echo "test-clone-parser-fixed-point: building debug binaries..." >&2
+cargo build --manifest-path "$root/Cargo.toml" >&2
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-parser-fixed-point.XXXXXX")"
+export XDG_RUNTIME_DIR="$work/run"
+export XDG_STATE_HOME="$work/state"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
+
+cleanup() {
+    "$bin/hwatu" quit >/dev/null 2>&1 || true
+    if [[ -z "${KEEP_HWATU_PARSER_FIXED_POINT_TEST:-}" ]]; then
+        rm -rf "$work"
+    else
+        echo "kept $work" >&2
+    fi
+}
+trap cleanup EXIT
+
+fixture_dir="$root/scripts/fixtures"
+port="${HWATU_PARSER_FIXED_POINT_PORT:-$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)}"
+python3 -m http.server "$port" --directory "$fixture_dir" >"$work/http.log" 2>&1 &
+server_pid=$!
+for _ in {1..50}; do
+    if python3 - <<PY >/dev/null 2>&1
+import urllib.request
+urllib.request.urlopen('http://127.0.0.1:$port/clone-parser-fixed-point.html', timeout=.2).read(1)
+PY
+    then
+        break
+    fi
+    sleep .1
+done
+
+out="$work/out"
+"$bin/hwatu" clone "http://127.0.0.1:$port/clone-parser-fixed-point.html" \
+    --out "$out" --viewport 900x600 --no-verify --timeout-ms 60000 >&2
+
+python3 - "$out" <<'PY'
+import json, pathlib, re, sys
+out = pathlib.Path(sys.argv[1])
+cap = json.loads((out / 'capture.json').read_text())
+meta = cap.get('parserFixedPoint') or {}
+rewritten = meta.get('rewritten') or []
+assert meta.get('fixed_point') is True, meta
+assert meta.get('reparsed_tag_count_deltas') == [], meta
+assert meta.get('injected_css') is True, meta
+assert len(rewritten) == 1, rewritten
+entry = rewritten[0]
+assert entry.get('from') == 'p' and entry.get('to') == 'div', entry
+assert entry.get('block_children') == ['div'], entry
+assert entry.get('class') == 'AnimatedText', entry
+
+html = (out / 'index.html').read_text()
+assert '<p id="animated"' not in html, html
+assert 'data-hwatu-was="p"' in html, html
+assert 'role="paragraph"' in html, html
+assert 'data-hwatu-parser-fix="0"' in html, html
+assert re.search(r'id="animated"[^>]*class="AnimatedText"', html), html
+assert re.search(r'data-hwatu-was="p"[^>]*>\s*<div class="line">Line <div class="word">Preserved</div>', html), html
+assert ':where([data-hwatu-was="p"][role="paragraph"])' in html, html
+assert '[data-hwatu-was="p"][role="paragraph"] {' not in html, html
+assert '.AnimatedText { margin: 0; }' in html, html
+assert html.find('.AnimatedText { margin: 0; }') < html.find(':where([data-hwatu-was="p"][role="paragraph"])'), html
+
+report = json.loads((out / 'report.json').read_text())
+report_meta = report.get('parser_fixed_point') or {}
+assert report_meta.get('fixed_point') is True, report_meta
+assert report_meta.get('reparsed_tag_count_deltas') == [], report_meta
+assert report_meta.get('injected_css') is True, report_meta
+assert report_meta.get('rewritten') == rewritten, report_meta
+print('PASS parser fixed point: rewritten=%d fixed_point=%s css=%s' % (
+    len(rewritten), report_meta.get('fixed_point'), report_meta.get('injected_css')))
+PY
+
+clone_url="file://$(python3 - "$out/index.html" <<'PY'
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve())
+PY
+)"
+"$bin/hwatu" --headless "$clone_url" >/dev/null
+clone_id="$("$bin/hwatu" list --json | python3 -c 'import json,sys; d=json.load(sys.stdin); assert len(d)==1,d; print(d[0]["id"])')"
+dom_assert_js=$(cat <<'JS'
+const animated = document.querySelector('#animated');
+if (!animated) throw new Error('#animated missing after clone reparse');
+if (animated.tagName !== 'DIV') throw new Error('#animated should reparse as div, got ' + animated.tagName);
+if (animated.getAttribute('role') !== 'paragraph') throw new Error('role=paragraph missing');
+if (animated.dataset.hwatuWas !== 'p') throw new Error('data-hwatu-was=p missing');
+if (!animated.querySelector(':scope > .line > .word')) throw new Error('.line/.word are not descendants of #animated');
+if (document.querySelector('main#root > .line, main#root > .word')) throw new Error('line/word wrapper ejected as root sibling');
+const margin = getComputedStyle(animated).marginTop + '/' + getComputedStyle(animated).marginBottom;
+if (margin !== '0px/0px') throw new Error('class reset margin drifted: ' + margin);
+'PASS parsed clone DOM: #animated div owns .line/.word and margin=' + margin;
+JS
+)
+"$bin/hwatu" eval --id "$clone_id" "$dom_assert_js"
+
+kill "$server_pid" >/dev/null 2>&1 || true


### PR DESCRIPTION
Closes #47

## Summary
- rewrite JS-built paragraphs that contain block children into paragraph-role divs before serialization so reparsing keeps line-wrapper descendants in place
- add parser fixed-point metadata to capture/report output, including rewrite entries and reparse tag-count deltas
- use zero-specificity paragraph fallback CSS so class resets like .AnimatedText { margin: 0 } still win
- add a deterministic div-in-p fixture and focused clone regression that opens the generated clone, checks the reparsed DOM, and verifies computed margin remains 0

## Validation
- cargo fmt --all --check
- scripts/test-clone-parser-fixed-point.sh
- scripts/test-clone-scroll-effect.sh
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings