### PR TITLE
Add eval opt-out and ephemeral profile mode

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security policy
+
+## Threat model
+
+hwatu is a local browser daemon for trusted local operators and trusted local automation. The `hwatud` daemon owns WebKitGTK browser windows and listens on a Unix-domain socket resolved by the `hwatu-ipc` crate, normally under the current user's runtime directory. The socket protocol is not an Internet-facing API and is not designed to authenticate mutually-distrusting local processes running as the same user.
+
+Treat any process that can connect to the hwatu socket as able to drive the browser session. By default that includes opening pages, clicking, typing, reading page state, taking screenshots, and running page JavaScript through eval-capable automation. The human can see the same live session the agent drives, including authenticated pages and cookies.
+
+## Eval and prompt-injection risk
+
+The default automation surface includes JavaScript evaluation:
+
+- CLI: `hwatu eval ...`
+- CLI one-shots: `hwatu check --eval ...` and `hwatu render --eval ...`
+- MCP: the `eval` tool and `eval` parameters embedded in `check`/`render` style tools
+- Raw IPC: `Request::Eval`, `Request::Check { eval: ... }`, and batches containing either
+
+If an untrusted or prompt-injected agent reaches these tools while the daemon has authenticated browser state, it can execute same-origin JavaScript in pages the daemon loads. That may expose `document.cookie` when cookies are not `HttpOnly`, web storage, visible DOM content, CSRF-protected form state, and other page-accessible secrets. HttpOnly cookies are not readable via `document.cookie`, but authenticated actions may still be possible through normal browser requests.
+
+## Operator opt-outs
+
+For authenticated sessions or untrusted agent workflows, start the daemon with eval disabled:
+
+```sh
+hwatud --no-eval
+```
+
+or set:
+
+```sh
+HWATUD_NO_EVAL=1 hwatud
+```
+
+This policy is enforced in the daemon before dispatch, so direct CLI, MCP, and raw socket requests receive the same rejection. It rejects direct eval, `check`/`render` requests with non-empty eval parameters, and batches containing eval surfaces.
+
+To avoid writing cookies, credentials, crash-recovery sessions, and discarded-window session blobs into the normal profile/cache locations, start an isolated temporary profile:
+
+```sh
+hwatud --ephemeral-profile
+```
+
+or set:
+
+```sh
+HWATUD_EPHEMERAL_PROFILE=1 hwatud
+```
+
+Ephemeral-profile mode creates a daemon-private temporary WebKit data/cache root, disables persistent credential storage, skips persistent cookie setup, skips crash-session restore/save, and skips normal discarded-window state cleanup/writes. The temporary root is removed on clean daemon exit. A hard kill, kernel crash, or WebKit child process still may leave temporary files behind until the OS or operator cleans the temp directory.
+
+For the strictest local handoff mode, combine both:
+
+```sh
+hwatud --no-eval --ephemeral-profile
+```
+
+## Local-socket assumptions and limitations
+
+- hwatu does not sandbox, authenticate, or authorize same-user local clients that can reach the daemon socket.
+- File permissions and the operating system user boundary are the primary trust boundary.
+- A malicious same-user process may still drive non-eval automation such as clicks, typing, screenshots, downloads, or navigation.
+- `--no-eval` closes hwatu's explicit eval surfaces. It does not disable JavaScript that websites load themselves.
+- `--ephemeral-profile` avoids normal persistent browser/session/profile writes for the daemon. It does not make visited sites private from the network, the compositor, the kernel, or other same-user local observation.
+- Secrets visible in page pixels or DOM text may still be exposed by screenshot/snapshot tools even when eval is disabled.
+
+## Reporting security issues
+
+Please report suspected vulnerabilities privately when possible. If GitHub private vulnerability reporting is enabled for this repository, use it. Otherwise contact the maintainer listed on the GitHub repository profile, or open a minimal public issue that describes the impact without publishing exploit details. Include your hwatu version, WebKitGTK version, operating system, session type, the daemon startup line, and whether `--no-eval` or `--ephemeral-profile` was in use.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ HWATUD_NO_EVAL=1 hwatud
 
 This policy is enforced in the daemon before dispatch, so direct CLI, MCP, and raw socket requests receive the same rejection. It rejects direct eval, `check`/`render` requests with non-empty eval parameters, and batches containing eval surfaces.
 
-To avoid writing cookies, credentials, crash-recovery sessions, and discarded-window session blobs into the normal profile/cache locations, start an isolated temporary profile:
+To avoid persisting cookies, credentials, crash-recovery sessions, and discarded-window session blobs, start an ephemeral profile:
 
 ```sh
 hwatud --ephemeral-profile
@@ -45,7 +45,7 @@ or set:
 HWATUD_EPHEMERAL_PROFILE=1 hwatud
 ```
 
-Ephemeral-profile mode creates a daemon-private temporary WebKit data/cache root, disables persistent credential storage, skips persistent cookie setup, skips crash-session restore/save, and skips normal discarded-window state cleanup/writes. The temporary root is removed on clean daemon exit. A hard kill, kernel crash, or WebKit child process still may leave temporary files behind until the OS or operator cleans the temp directory.
+Ephemeral-profile mode uses WebKitGTK's memory-only ephemeral network session, disables persistent credential storage, skips persistent cookie setup, skips crash-session restore/save, and skips normal discarded-window state cleanup/writes. No temporary browser profile is created on disk.
 
 For the strictest local handoff mode, combine both:
 

--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -119,6 +119,13 @@ fn read_next_request(conn: gio::SocketConnection, input: gio::DataInputStream, d
 /// automation commands (eval/navigate/screenshot/wait_load) complete
 /// later on the main loop and consume `reply` when they finish.
 fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
+    if !daemon.security.eval_enabled && req.uses_eval() {
+        reply(Response::err(
+            "eval disabled by daemon policy (--no-eval)".to_string(),
+        ));
+        return;
+    }
+
     let req = match req {
         Request::Batch { actions } => return dispatch_batch(daemon.clone(), actions, reply),
         other => other,

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -41,6 +41,7 @@ use gtk::{gio, glib};
 use hwatu_ipc::OpenMode;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::rc::Rc;
 use webkit6::prelude::*;
 
@@ -97,10 +98,91 @@ pub struct Daemon {
     /// Next hanafuda card to deal on a launcher window (see
     /// [`launcher::deal_uri`]). Wraps modulo the deck size.
     pub next_deal: RefCell<usize>,
+    /// Operator security policy selected at daemon startup.
+    pub security: SecurityConfig,
+    /// Isolated network session used by every WebView when the daemon is
+    /// running in ephemeral-profile mode. Holding the object here keeps the
+    /// in-memory cookie jar alive while the daemon runs.
+    pub network_session: Option<webkit6::NetworkSession>,
+    /// Temporary website-data/cache root removed on clean exit when the daemon
+    /// runs in ephemeral-profile mode.
+    _ephemeral_profile: Option<EphemeralProfile>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecurityConfig {
+    pub eval_enabled: bool,
+    pub ephemeral_profile: bool,
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            eval_enabled: true,
+            ephemeral_profile: false,
+        }
+    }
+}
+
+struct EphemeralProfile {
+    root: PathBuf,
+}
+
+impl EphemeralProfile {
+    fn create() -> std::io::Result<Self> {
+        let root = std::env::temp_dir().join(format!(
+            "hwatud-ephemeral-{}-{}",
+            std::process::id(),
+            glib::monotonic_time()
+        ));
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn root(&self) -> &std::path::Path {
+        &self.root
+    }
+}
+
+impl Drop for EphemeralProfile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
 }
 
 impl Daemon {
-    fn new(app: gtk::Application) -> Rc<Self> {
+    fn new(app: gtk::Application, security: SecurityConfig) -> Rc<Self> {
+        let (network_session, ephemeral_profile) = if security.ephemeral_profile {
+            match EphemeralProfile::create() {
+                Ok(profile) => {
+                    let data = profile.root().join("data");
+                    let cache = profile.root().join("cache");
+                    if let Err(e) =
+                        std::fs::create_dir_all(&data).and_then(|_| std::fs::create_dir_all(&cache))
+                    {
+                        eprintln!("hwatud: failed to create ephemeral profile directories: {e}");
+                        std::process::exit(1);
+                    }
+                    let session = webkit6::NetworkSession::new(
+                        Some(&data.to_string_lossy()),
+                        Some(&cache.to_string_lossy()),
+                    );
+                    session.set_persistent_credential_storage_enabled(false);
+                    println!(
+                        "hwatud: ephemeral profile enabled under {} (removed on exit)",
+                        profile.root().display()
+                    );
+                    (Some(session), Some(profile))
+                }
+                Err(e) => {
+                    eprintln!("hwatud: failed to create ephemeral profile: {e}");
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            (None, None)
+        };
+
         Rc::new(Self {
             app,
             windows: RefCell::new(HashMap::new()),
@@ -115,6 +197,9 @@ impl Daemon {
             session_save_timer: RefCell::new(None),
             events: events::Broker::default(),
             next_deal: RefCell::new(0),
+            security,
+            network_session,
+            _ephemeral_profile: ephemeral_profile,
         })
     }
 
@@ -130,7 +215,7 @@ impl Daemon {
     /// Take the warm WebView (or build one) and immediately warm the next.
     pub fn take_webview(self: &Rc<Self>) -> webkit6::WebView {
         let view = self.prewarmed.borrow_mut().take().unwrap_or_else(|| {
-            let view = window::build_webview();
+            let view = window::build_webview(self);
             self.adblock.apply_to(&view);
             view
         });
@@ -151,7 +236,7 @@ impl Daemon {
         let daemon = self.clone();
         glib::idle_add_local_once(move || {
             if daemon.prewarmed.borrow().is_none() {
-                let view = window::build_webview();
+                let view = window::build_webview(&daemon);
                 daemon.adblock.apply_to(&view);
                 // Deep warm: loading about:blank realizes the web
                 // process and the GPU compositor path while idle, so a
@@ -175,6 +260,9 @@ impl Daemon {
     /// bursty navigation doesn't thrash the disk. The trailing save
     /// always runs, so the file converges on the true state.
     pub fn schedule_session_save(self: &Rc<Self>) {
+        if self.security.ephemeral_profile {
+            return;
+        }
         if self.session_save_timer.borrow().is_some() {
             return;
         }
@@ -187,6 +275,9 @@ impl Daemon {
     }
 
     pub fn save_session_now(&self) {
+        if self.security.ephemeral_profile {
+            return;
+        }
         let entries: Vec<session::SessionEntry> = {
             let windows = self.windows.borrow();
             let mut infos: Vec<_> = windows.values().map(|w| w.info()).collect();
@@ -212,7 +303,11 @@ impl Daemon {
 /// the XDG data dir, so logins survive daemon restarts. All WebViews
 /// share the default session (persistence is what makes the shared
 /// engine feel like one browser instead of a fleet of incognito tabs).
-fn persist_cookies() {
+fn persist_cookies(security: SecurityConfig) {
+    if security.ephemeral_profile {
+        println!("hwatud: ephemeral profile enabled; persistent cookies disabled");
+        return;
+    }
     let Some(session) = webkit6::NetworkSession::default() else {
         eprintln!("hwatud: no default network session; cookies will not persist");
         return;
@@ -290,6 +385,18 @@ fn open_sandbox_for_media() {
 }
 
 fn main() -> glib::ExitCode {
+    let security = match parse_security_args(std::env::args().skip(1)) {
+        Ok(ParseSecurity::Run(security)) => security,
+        Ok(ParseSecurity::Help) => {
+            println!("usage: hwatud [--no-eval] [--ephemeral-profile]");
+            return glib::ExitCode::SUCCESS;
+        }
+        Err(message) => {
+            eprintln!("hwatud: {message}");
+            eprintln!("usage: hwatud [--no-eval] [--ephemeral-profile]");
+            return glib::ExitCode::FAILURE;
+        }
+    };
     // Keep RAM predictable: cap glibc arena explosion under GTK threads.
     std::env::set_var("MALLOC_ARENA_MAX", "2");
     // Full-refresh-rate scrolling: WebKitGTK's default DMA-BUF
@@ -351,15 +458,17 @@ fn main() -> glib::ExitCode {
     app.connect_startup(move |app| {
         bar::install_css();
         // Reclaim session blobs orphaned by a crashed/killed daemon.
-        window::sweep_discard_dir();
-        let daemon = Daemon::new(app.clone());
+        if !security.ephemeral_profile {
+            window::sweep_discard_dir();
+        }
+        let daemon = Daemon::new(app.clone(), security);
         // Cookies persist across daemon restarts. WebKit's default
         // network session keeps its jar in RAM only until told
         // otherwise, which makes every restart look like a brand-new
         // browser: logins vanish, and sites like GitHub answer the
         // fresh jar with their strictest anti-bot login path (device
         // verification, captcha). Must run before any WebView exists.
-        persist_cookies();
+        persist_cookies(security);
         // Local media playback needs the web-process sandbox to see
         // the files. Before any web process exists (hard requirement).
         open_sandbox_for_media();
@@ -374,7 +483,11 @@ fn main() -> glib::ExitCode {
         // Crash resilience: a leftover session file means the previous
         // daemon died uncleanly (clean quits delete it); reopen its
         // windows. After the socket is up so spawn timing stays honest.
-        let leftovers = session::take();
+        let leftovers = if security.ephemeral_profile {
+            Vec::new()
+        } else {
+            session::take()
+        };
         if !leftovers.is_empty() {
             println!(
                 "hwatud: restoring {} window(s) from a previous session",
@@ -437,9 +550,40 @@ fn parse_dpr(raw: Option<&str>) -> Option<i32> {
     raw?.trim().parse::<i32>().ok().filter(|&n| n > 0)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseSecurity {
+    Run(SecurityConfig),
+    Help,
+}
+
+fn parse_security_args<I, S>(args: I) -> Result<ParseSecurity, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut config = SecurityConfig::default();
+
+    if std::env::var_os("HWATUD_NO_EVAL").is_some_and(|v| !v.is_empty() && v != "0") {
+        config.eval_enabled = false;
+    }
+    if std::env::var_os("HWATUD_EPHEMERAL_PROFILE").is_some_and(|v| !v.is_empty() && v != "0") {
+        config.ephemeral_profile = true;
+    }
+
+    for arg in args {
+        match arg.as_ref() {
+            "--no-eval" => config.eval_enabled = false,
+            "--ephemeral-profile" | "--ephemeral" => config.ephemeral_profile = true,
+            "--help" | "-h" => return Ok(ParseSecurity::Help),
+            other => return Err(format!("unknown argument `{other}`")),
+        }
+    }
+    Ok(ParseSecurity::Run(config))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_dpr;
+    use super::{parse_dpr, parse_security_args, ParseSecurity, SecurityConfig};
 
     /// The DPR pin only accepts positive integers: GDK_SCALE cannot
     /// express fractions, and 0/negative are nonsense. Everything
@@ -455,5 +599,37 @@ mod tests {
         assert_eq!(parse_dpr(Some("1")), Some(1));
         assert_eq!(parse_dpr(Some(" 2 ")), Some(2));
         assert_eq!(parse_dpr(Some("3")), Some(3));
+    }
+
+    #[test]
+    fn security_args_default_open_profile() {
+        assert_eq!(
+            parse_security_args(std::iter::empty::<&str>()).unwrap(),
+            ParseSecurity::Run(SecurityConfig::default())
+        );
+    }
+
+    #[test]
+    fn security_args_accept_eval_and_profile_opt_outs() {
+        assert_eq!(
+            parse_security_args(["--no-eval", "--ephemeral-profile"]).unwrap(),
+            ParseSecurity::Run(SecurityConfig {
+                eval_enabled: false,
+                ephemeral_profile: true,
+            })
+        );
+    }
+
+    #[test]
+    fn security_args_help_is_successful_control_flow() {
+        assert_eq!(
+            parse_security_args(["--help"]).unwrap(),
+            ParseSecurity::Help
+        );
+    }
+
+    #[test]
+    fn security_args_reject_unknown_flags() {
+        assert!(parse_security_args(["--cookies-please"]).is_err());
     }
 }

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -135,7 +135,17 @@ impl EphemeralProfile {
             std::process::id(),
             glib::monotonic_time()
         ));
-        std::fs::create_dir_all(&root)?;
+        // The profile may contain authenticated cookies and page data.
+        // Create the predictable-by-design path atomically instead of
+        // accepting an existing directory, and keep other OS users out.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+
+            std::fs::DirBuilder::new().mode(0o700).create(&root)?;
+        }
+        #[cfg(not(unix))]
+        std::fs::create_dir(&root)?;
         Ok(Self { root })
     }
 
@@ -583,7 +593,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_dpr, parse_security_args, ParseSecurity, SecurityConfig};
+    use super::{parse_dpr, parse_security_args, EphemeralProfile, ParseSecurity, SecurityConfig};
 
     /// The DPR pin only accepts positive integers: GDK_SCALE cannot
     /// express fractions, and 0/negative are nonsense. Everything
@@ -631,5 +641,18 @@ mod tests {
     #[test]
     fn security_args_reject_unknown_flags() {
         assert!(parse_security_args(["--cookies-please"]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ephemeral_profile_is_private_and_removed_on_drop() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let profile = EphemeralProfile::create().unwrap();
+        let root = profile.root().to_path_buf();
+        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+        drop(profile);
+        assert!(!root.exists());
     }
 }

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -41,7 +41,6 @@ use gtk::{gio, glib};
 use hwatu_ipc::OpenMode;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::rc::Rc;
 use webkit6::prelude::*;
 
@@ -104,9 +103,6 @@ pub struct Daemon {
     /// running in ephemeral-profile mode. Holding the object here keeps the
     /// in-memory cookie jar alive while the daemon runs.
     pub network_session: Option<webkit6::NetworkSession>,
-    /// Temporary website-data/cache root removed on clean exit when the daemon
-    /// runs in ephemeral-profile mode.
-    _ephemeral_profile: Option<EphemeralProfile>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -124,73 +120,15 @@ impl Default for SecurityConfig {
     }
 }
 
-struct EphemeralProfile {
-    root: PathBuf,
-}
-
-impl EphemeralProfile {
-    fn create() -> std::io::Result<Self> {
-        let root = std::env::temp_dir().join(format!(
-            "hwatud-ephemeral-{}-{}",
-            std::process::id(),
-            glib::monotonic_time()
-        ));
-        // The profile may contain authenticated cookies and page data.
-        // Create the predictable-by-design path atomically instead of
-        // accepting an existing directory, and keep other OS users out.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::DirBuilderExt;
-
-            std::fs::DirBuilder::new().mode(0o700).create(&root)?;
-        }
-        #[cfg(not(unix))]
-        std::fs::create_dir(&root)?;
-        Ok(Self { root })
-    }
-
-    fn root(&self) -> &std::path::Path {
-        &self.root
-    }
-}
-
-impl Drop for EphemeralProfile {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.root);
-    }
-}
-
 impl Daemon {
     fn new(app: gtk::Application, security: SecurityConfig) -> Rc<Self> {
-        let (network_session, ephemeral_profile) = if security.ephemeral_profile {
-            match EphemeralProfile::create() {
-                Ok(profile) => {
-                    let data = profile.root().join("data");
-                    let cache = profile.root().join("cache");
-                    if let Err(e) =
-                        std::fs::create_dir_all(&data).and_then(|_| std::fs::create_dir_all(&cache))
-                    {
-                        eprintln!("hwatud: failed to create ephemeral profile directories: {e}");
-                        std::process::exit(1);
-                    }
-                    let session = webkit6::NetworkSession::new(
-                        Some(&data.to_string_lossy()),
-                        Some(&cache.to_string_lossy()),
-                    );
-                    session.set_persistent_credential_storage_enabled(false);
-                    println!(
-                        "hwatud: ephemeral profile enabled under {} (removed on exit)",
-                        profile.root().display()
-                    );
-                    (Some(session), Some(profile))
-                }
-                Err(e) => {
-                    eprintln!("hwatud: failed to create ephemeral profile: {e}");
-                    std::process::exit(1);
-                }
-            }
+        let network_session = if security.ephemeral_profile {
+            let session = webkit6::NetworkSession::new_ephemeral();
+            session.set_persistent_credential_storage_enabled(false);
+            println!("hwatud: ephemeral profile enabled (memory-only WebKit session)");
+            Some(session)
         } else {
-            (None, None)
+            None
         };
 
         Rc::new(Self {
@@ -209,7 +147,6 @@ impl Daemon {
             next_deal: RefCell::new(0),
             security,
             network_session,
-            _ephemeral_profile: ephemeral_profile,
         })
     }
 
@@ -593,7 +530,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_dpr, parse_security_args, EphemeralProfile, ParseSecurity, SecurityConfig};
+    use super::{parse_dpr, parse_security_args, ParseSecurity, SecurityConfig};
 
     /// The DPR pin only accepts positive integers: GDK_SCALE cannot
     /// express fractions, and 0/negative are nonsense. Everything
@@ -641,18 +578,5 @@ mod tests {
     #[test]
     fn security_args_reject_unknown_flags() {
         assert!(parse_security_args(["--cookies-please"]).is_err());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ephemeral_profile_is_private_and_removed_on_drop() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let profile = EphemeralProfile::create().unwrap();
-        let root = profile.root().to_path_buf();
-        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o700);
-        drop(profile);
-        assert!(!root.exists());
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -345,15 +345,17 @@ fn set_wayland_app_id(window: &gtk::Window, app_id: &str) {
 
 /// Build a fully configured WebView. Called for the prewarm pool and as
 /// a fallback; all engine knobs live here, never on the spawn path.
-pub fn build_webview() -> webkit6::WebView {
+pub fn build_webview(daemon: &Daemon) -> webkit6::WebView {
     // website-policies is construct-only, hence the builder. Autoplay
     // defaults to full allow (with sound); see autoplay_policy().
     let policies = webkit6::WebsitePolicies::builder()
         .autoplay(autoplay_policy())
         .build();
-    let view = webkit6::WebView::builder()
-        .website_policies(&policies)
-        .build();
+    let mut builder = webkit6::WebView::builder().website_policies(&policies);
+    if let Some(session) = &daemon.network_session {
+        builder = builder.network_session(session);
+    }
+    let view = builder.build();
     apply_view_settings(&view);
     crate::console::wire_view(&view);
     crate::clock::wire_view(&view);
@@ -1067,15 +1069,21 @@ impl BrowserWindow {
         let url = webview.uri().map(|u| u.to_string()).unwrap_or_default();
         let title = webview.title().map(|t| t.to_string()).unwrap_or_default();
         // Serialize history to disk, not RAM: the whole point is to
-        // give memory back. Write failures degrade to a URL reload.
-        let session_file = webview
-            .session_state()
-            .and_then(|state| state.serialize())
-            .and_then(|bytes| {
-                let path = discard_dir()?.join(format!("window-{}.session", self.id));
-                std::fs::write(&path, bytes).ok()?;
-                Some(path)
-            });
+        // give memory back. Write failures degrade to a URL reload. In
+        // ephemeral-profile mode no normal profile/cache state may be
+        // written, so discards deliberately keep only the URL/title.
+        let session_file = if self.daemon.security.ephemeral_profile {
+            None
+        } else {
+            webview
+                .session_state()
+                .and_then(|state| state.serialize())
+                .and_then(|bytes| {
+                    let path = discard_dir()?.join(format!("window-{}.session", self.id));
+                    std::fs::write(&path, bytes).ok()?;
+                    Some(path)
+                })
+        };
         self.saved.replace(Some(SavedState {
             session_file,
             url,

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -584,6 +584,18 @@ impl Request {
         }
     }
 
+    /// True when this request asks the daemon to execute page JavaScript.
+    /// Operators can disable this entire surface at the daemon boundary so
+    /// direct CLI, MCP, and raw socket clients all get the same policy.
+    pub fn uses_eval(&self) -> bool {
+        match self {
+            Request::Eval { .. } => true,
+            Request::Check { eval, .. } => eval.as_ref().is_some_and(|js| !js.is_empty()),
+            Request::Batch { actions } => actions.iter().any(Self::uses_eval),
+            _ => false,
+        }
+    }
+
     /// Whether this request is safe and coherent as one step inside a batch.
     /// Keep this deliberately smaller than the full protocol: lifecycle,
     /// streaming, browser-global, file-upload, and long-lived watcher actions
@@ -1232,6 +1244,77 @@ mod tests {
         };
         assert_eq!(actions.len(), 3);
         Request::validate_batch(&actions).unwrap();
+    }
+
+    #[test]
+    fn uses_eval_covers_direct_check_and_batch_surfaces() {
+        assert!(Request::Eval {
+            id: None,
+            js: "return document.cookie".into(),
+            timeout_ms: None,
+        }
+        .uses_eval());
+
+        let mut check = Request::Check {
+            url: Some("https://example.test".into()),
+            render: None,
+            base: None,
+            eval: None,
+            shot: false,
+            shot_path: None,
+            full: false,
+            baseline: None,
+            tolerance: None,
+            heatmap: None,
+            until: LoadStage::default(),
+            keep: false,
+            timeout_ms: None,
+            viewports: vec![],
+            baseline_dir: None,
+        };
+        assert!(!check.uses_eval());
+        if let Request::Check { eval, .. } = &mut check {
+            *eval = Some("".into());
+        }
+        assert!(!check.uses_eval());
+        if let Request::Check { eval, .. } = &mut check {
+            *eval = Some("localStorage.secret".into());
+        }
+        assert!(check.uses_eval());
+
+        assert!(!Request::Navigate {
+            id: Some(1),
+            url: "https://example.test".into(),
+            wait: true,
+            until: LoadStage::default(),
+            timeout_ms: None,
+        }
+        .uses_eval());
+
+        assert!(Request::Batch {
+            actions: vec![
+                Request::Navigate {
+                    id: Some(1),
+                    url: "https://example.test".into(),
+                    wait: true,
+                    until: LoadStage::default(),
+                    timeout_ms: None,
+                },
+                check,
+            ],
+        }
+        .uses_eval());
+
+        assert!(Request::Batch {
+            actions: vec![Request::Batch {
+                actions: vec![Request::Eval {
+                    id: Some(1),
+                    js: "document.cookie".into(),
+                    timeout_ms: None,
+                }],
+            }],
+        }
+        .uses_eval());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #49.

Adds operator security opt-outs for the browser daemon:

- `hwatud --no-eval` / `HWATUD_NO_EVAL=1` rejects every daemon eval surface before dispatch.
- `hwatud --ephemeral-profile` / `HWATUD_EPHEMERAL_PROFILE=1` uses WebKitGTK's memory-only ephemeral network session, disables persistent credential storage, skips persistent cookie setup, skips crash-session restore/save, and avoids normal discarded-window session blob writes/cleanup.
- Adds `Request::uses_eval()` so direct CLI, MCP-generated requests, and raw IPC batches all share the same daemon-side policy check.
- Adds `SECURITY.md` documenting the local-socket trust boundary, eval risks, limitations, reporting guidance, and safe-mode examples.

## Threat-model decisions

- The trust boundary remains the OS user and local Unix socket. hwatu does not try to authenticate mutually distrusting same-user clients.
- `--no-eval` closes hwatu-owned JavaScript execution paths only. It does not disable JavaScript loaded by websites and does not prevent screenshots/snapshots from exposing visible secrets.
- Enforcement is daemon-side, not just CLI/MCP-side, so a raw socket client cannot bypass the policy.
- Ephemeral profile mode does not create a browser profile on disk and does not touch the normal cookie jar, crash session, or discarded-window state.

## Validation

- `cargo fmt --all --check`
- `cargo test -p hwatu-ipc uses_eval_covers_direct_check_and_batch_surfaces`
- `cargo test -p hwatud security_args`
- `cargo check --workspace --locked`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Real isolated daemon check: direct `eval` and `check --eval` both rejected; plain `check` succeeded; memory-only session logged; no persistent cookie/session files written.