### PR TITLE
Clone scroll transform pin and time tracks

### DIFF
--- a/crates/hwatu/assets/extract.js
+++ b/crates/hwatu/assets/extract.js
@@ -65,6 +65,11 @@ async function detectScrollEffects() {
     for (let n = el; n && n !== document.body; n = n.parentElement) {
       const tag = n.tagName && n.tagName.toLowerCase();
       if (tag === 'nav' || tag === 'header' || n.getAttribute('role') === 'navigation') return true;
+    }
+    return false;
+  };
+  const positionedChrome = (el) => {
+    for (let n = el; n && n !== document.body; n = n.parentElement) {
       const st = getComputedStyle(n);
       if (st.position === 'fixed' || st.position === 'sticky') return true;
     }
@@ -72,27 +77,41 @@ async function detectScrollEffects() {
   };
   const all = [...document.querySelectorAll('body *')].slice(0, 12000);
   const candidates = [];
+  const visualCandidate = (el, st) => {
+    const r = el.getBoundingClientRect();
+    const area = Math.max(0, r.width) * Math.max(0, r.height);
+    if (area < Math.min(innerWidth * innerHeight * 0.015, 12000)) return false;
+    if (st.display === 'inline' || st.position === 'fixed') return false;
+    return true;
+  };
   for (const el of all) {
     if (navish(el)) continue;
     const text = ownText(el);
-    if (text.length < 1 || text.length > 80) continue;
     const st = getComputedStyle(el);
     if (st.display === 'none' || st.visibility === 'hidden') continue;
-    candidates.push({ el, text });
+    const isText = text.length >= 1 && text.length <= 80;
+    const isVisual = !isText && visualCandidate(el, st);
+    if (isText && positionedChrome(el)) continue;
+    if (!isText && !isVisual) continue;
+    candidates.push({ el, text, candidateKind: isText ? 'text' : 'visual' });
     if (candidates.length >= 5000) break;
   }
-  if (candidates.length < 3) return [];
+  if (candidates.length < 1) return [];
   const styleOf = (el) => {
     const st = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
     return {
       color: st.color,
       backgroundColor: st.backgroundColor,
       opacity: st.opacity,
       textShadow: st.textShadow,
       transform: st.transform,
+      clipPath: st.clipPath,
+      borderRadius: st.borderRadius,
+      rect: { top: Math.round(r.top), left: Math.round(r.left), width: Math.round(r.width), height: Math.round(r.height) },
     };
   };
-  const styleKey = (s) => `${s.color}|${s.backgroundColor}|${s.opacity}|${s.textShadow}|${s.transform}`;
+  const styleKey = (s) => `${s.color}|${s.backgroundColor}|${s.opacity}|${s.textShadow}|${s.transform}|${s.clipPath}|${s.borderRadius}`;
   const coarse = [...new Set([0, .125, .25, .375, .5, .625, .75, .875, 1]
     .map(f => Math.round(maxScroll * f)))];
   const seen = candidates.map(() => []);
@@ -110,9 +129,102 @@ async function detectScrollEffects() {
     const variants = new Set(seen[i].map(s => s.key));
     if (variants.size >= 2) changed.push({ i, ...candidates[i], observations: seen[i] });
   }
-  if (changed.length < 3) {
+  const effects = [];
+  let effectIndex = 0;
+  const cssPath = (el) => {
+    if (el.id) return `#${CSS.escape(el.id)}`;
+    if (el.dataset.hwatuScrollEffect) return `[data-hwatu-scroll-effect="${el.dataset.hwatuScrollEffect}"]`;
+    const parts = [];
+    for (let n = el; n && n !== document.body && parts.length < 5; n = n.parentElement) {
+      let part = n.tagName.toLowerCase();
+      const cls = [...n.classList].filter(Boolean).slice(0, 2);
+      if (cls.length) part += '.' + cls.map(CSS.escape).join('.');
+      const parent = n.parentElement;
+      if (parent) part += `:nth-child(${[...parent.children].indexOf(n) + 1})`;
+      parts.unshift(part);
+    }
+    return 'body > ' + parts.join(' > ');
+  };
+  const clamp = (y) => Math.max(0, Math.min(maxScroll, Math.round(y)));
+  // Pin candidates: a sizeable element whose viewport top plateaus while scrollY advances.
+  const pinRoots = [];
+  for (let ci = 0; ci < candidates.length; ci++) {
+    const c = candidates[ci];
+    if (pinRoots.some(root => root.contains(c.el) || c.el.contains(root))) continue;
+    if (c.candidateKind !== 'visual' && !c.el.children.length) continue;
+    const obs = seen[ci].filter(o => o.style.rect && o.style.rect.height > 40);
+    let best = null;
+    for (let a = 0; a < obs.length; a++) for (let b = a + 2; b < obs.length; b++) {
+      const slice = obs.slice(a, b + 1);
+      const dy = slice[slice.length - 1].y - slice[0].y;
+      const tops = slice.map(o => o.style.rect.top);
+      const span = Math.max(...tops) - Math.min(...tops);
+      if (dy >= innerHeight * 0.45 && span <= 3 && tops[0] > -innerHeight * 0.2 && tops[0] < innerHeight * 0.85) {
+        if (!best || dy > best.endY - best.startY) best = { startY: slice[0].y, endY: slice[slice.length - 1].y, top: Math.round(tops.reduce((x, y) => x + y, 0) / tops.length) };
+      }
+    }
+    if (!best) continue;
+    const root = c.el.parentElement || c.el;
+    root.dataset.hwatuScrollEffect = effectIndex;
+    effects.push({
+      kind: 'scroll-pin', selector: `[data-hwatu-scroll-effect="${effectIndex}"]`, pinnedSelector: cssPath(c.el),
+      dependency: 'viewport rect plateau across scroll sweep; replay uses stable ancestor rect and child translate, preserving report-only fallback if selector misses',
+      startY: best.startY, endY: best.endY, desiredViewportTop: best.top,
+    });
+    pinRoots.push(root);
+    effectIndex += 1;
+    if (effects.length >= 6) break;
+  }
+  // Non-text transform/clip/opacity scrubs: store raw endpoints for direct replay.
+  for (const c of changed.filter(x => x.candidateKind === 'visual').slice(0, 12)) {
+    const obs = c.observations;
+    const keys = obs.map(o => o.key);
+    const firstChange = keys.findIndex(k => k !== keys[0]);
+    if (firstChange < 1) continue;
+    const lastChange = keys.length - 1 - [...keys].reverse().findIndex(k => k !== keys[keys.length - 1]);
+    const from = obs[Math.max(0, firstChange - 1)];
+    const to = obs[lastChange];
+    c.el.dataset.hwatuScrollEffect = effectIndex;
+    effects.push({
+      kind: 'scroll-coupled-visual-style', selector: `[data-hwatu-scroll-effect="${effectIndex}"]`,
+      dependency: 'non-text paint-area element changes transform/clip-path/opacity after document scroll',
+      progress: { startY: from.y, endY: to.y }, from: from.style, to: to.style,
+    });
+    effectIndex += 1;
+  }
+  // Time-based threshold tracks: constant-scroll dwell changes indicate wall-clock animation.
+  const timeCandidates = candidates
+    .map((c, ci) => ({ c, ci }))
+    .filter(({ c, ci }) => c.candidateKind === 'text' || (seen[ci] || []).some(o => o.key !== ((seen[ci] || [])[0] && (seen[ci] || [])[0].key)))
+    .slice(0, 80);
+  await waitScroll(0);
+  await new Promise(r => setTimeout(r, 180));
+  for (const { c, ci } of timeCandidates) {
+    const obs = seen[ci] || [];
+    const coarseChange = obs.find(o => o.key !== (obs[0] && obs[0].key));
+    const r0 = c.el.getBoundingClientRect();
+    const docTop0 = r0.top + scrollY;
+    const probeY = coarseChange ? coarseChange.y : clamp(docTop0 - innerHeight * 0.7);
+    scrollTo(0, Math.max(0, Math.min(maxScroll, probeY)));
+    window.dispatchEvent(new Event('scroll'));
+    document.dispatchEvent(new Event('scroll'));
+    const before = styleOf(c.el); const beforeKey = styleKey(before);
+    await new Promise(r => setTimeout(r, 520));
+    const after = styleOf(c.el); const afterKey = styleKey(after);
+    if (beforeKey === afterKey) continue;
+    c.el.dataset.hwatuScrollEffect = effectIndex;
+    effects.push({
+      kind: 'scroll-triggered-time-style', selector: `[data-hwatu-scroll-effect="${effectIndex}"]`,
+      dependency: 'computed style changed during dwell at constant scrollY; replay uses threshold-triggered state machine',
+      triggerY: Math.round(probeY), triggerLine: Math.round((before.rect.top / innerHeight) * 1000) / 1000,
+      before, after,
+    });
+    effectIndex += 1;
+    if (effects.filter(e => e.kind === 'scroll-triggered-time-style').length >= 12) break;
+  }
+  if (changed.filter(c => c.candidateKind === 'text').length < 3) {
     await waitScroll(0);
-    return [];
+    return effects;
   }
   const groupRoot = (el) => {
     let best = el.parentElement || el;
@@ -130,10 +242,8 @@ async function detectScrollEffects() {
     prev.push(item);
     groups.set(root, prev);
   }
-  const clamp = (y) => Math.max(0, Math.min(maxScroll, Math.round(y)));
-  const effects = [];
-  let effectIndex = 0;
   for (const [root, items] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    if (!items.some(i => i.candidateKind === 'text')) continue;
     const uniqueText = new Set(items.map(i => i.text.toLowerCase()));
     if (items.length < 3 || uniqueText.size < 3 || navish(root)) continue;
     root.dataset.hwatuScrollEffect = effectIndex;

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -752,20 +752,38 @@ fn materialize(cap: &serde_json::Value, out: &Path) -> Result<MaterializeStats, 
     if let Some(effects) = cap.get("scrollEffects").and_then(|v| v.as_array()) {
         if !effects.is_empty() {
             let mut fits = Vec::new();
+            let mut scroll_tracks = Vec::new();
             for effect in effects {
                 let mut annotated = effect.clone();
                 let entry = annotated.as_object_mut().expect("effect is an object");
                 // The dense per-word sweep is fitting input, not report
                 // material: it dwarfs the rest of the report.
                 entry.remove("words");
-                match fit_scroll_effect(effect) {
-                    Some(fit) => {
+                let kind = effect.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+                if matches!(
+                    kind,
+                    "scroll-coupled-visual-style" | "scroll-pin" | "scroll-triggered-time-style"
+                ) {
+                    if direct_track_supported(effect) {
                         entry.insert("replay".into(), serde_json::json!("replayed"));
-                        entry.insert("replay_fit".into(), fit.to_json());
-                        fits.push(fit);
-                    }
-                    None => {
+                        entry.insert(
+                            "replay_fit".into(),
+                            serde_json::json!({ "model": "direct serialized scroll track runtime" }),
+                        );
+                        scroll_tracks.push(annotated.clone());
+                    } else {
                         entry.insert("replay".into(), serde_json::json!("report-only"));
+                    }
+                } else {
+                    match fit_scroll_effect(effect) {
+                        Some(fit) => {
+                            entry.insert("replay".into(), serde_json::json!("replayed"));
+                            entry.insert("replay_fit".into(), fit.to_json());
+                            fits.push(fit);
+                        }
+                        None => {
+                            entry.insert("replay".into(), serde_json::json!("report-only"));
+                        }
                     }
                 }
                 scroll_effects_out.push(annotated);
@@ -778,6 +796,7 @@ fn materialize(cap: &serde_json::Value, out: &Path) -> Result<MaterializeStats, 
             if !fits.is_empty() {
                 inject.push_str(&scroll_replay_script(&fits));
             }
+            inject.push_str(&scroll_tracks_replay_script(&scroll_tracks));
             if !inject.is_empty() {
                 if let Some(pos) = html.find("</body>") {
                     html.insert_str(pos, &inject);
@@ -1354,6 +1373,240 @@ fn scroll_replay_script(fits: &[ScrollEffectFit]) -> String {
     )
 }
 
+fn supported_matrix(v: &str) -> bool {
+    v == "none" || v.starts_with("matrix(") || v.starts_with("matrix3d(")
+}
+
+fn supported_inset_percent(v: &str) -> bool {
+    if v == "none" {
+        return true;
+    }
+    let Some(body) = v.strip_prefix("inset(").and_then(|s| s.strip_suffix(')')) else {
+        return false;
+    };
+    let main = body.split(" round ").next().unwrap_or(body);
+    !main.is_empty()
+        && main
+            .split_whitespace()
+            .all(|part| part.ends_with('%') && part[..part.len() - 1].parse::<f64>().is_ok())
+}
+
+fn direct_style_supported(from: &serde_json::Value, to: &serde_json::Value) -> bool {
+    let mut supported_change = false;
+    let changed = |field: &str| from.get(field) != to.get(field);
+    if changed("opacity") {
+        let ok = from
+            .get("opacity")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<f64>().ok())
+            .is_some()
+            && to
+                .get("opacity")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<f64>().ok())
+                .is_some();
+        if !ok {
+            return false;
+        }
+        supported_change = true;
+    }
+    if changed("borderRadius") {
+        let ok = from
+            .get("borderRadius")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.trim_end_matches("px").parse::<f64>().ok())
+            .is_some()
+            && to
+                .get("borderRadius")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.trim_end_matches("px").parse::<f64>().ok())
+                .is_some();
+        if !ok {
+            return false;
+        }
+        supported_change = true;
+    }
+    if changed("transform") {
+        let ok = from
+            .get("transform")
+            .and_then(|v| v.as_str())
+            .is_some_and(supported_matrix)
+            && to
+                .get("transform")
+                .and_then(|v| v.as_str())
+                .is_some_and(supported_matrix);
+        if !ok {
+            return false;
+        }
+        supported_change = true;
+    }
+    if changed("clipPath") {
+        let ok = from
+            .get("clipPath")
+            .and_then(|v| v.as_str())
+            .is_some_and(supported_inset_percent)
+            && to
+                .get("clipPath")
+                .and_then(|v| v.as_str())
+                .is_some_and(supported_inset_percent);
+        if !ok {
+            return false;
+        }
+        supported_change = true;
+    }
+    supported_change
+}
+
+fn direct_track_supported(effect: &serde_json::Value) -> bool {
+    let Some(kind) = effect.get("kind").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    if effect.get("selector").and_then(|v| v.as_str()).is_none() {
+        return false;
+    }
+    match kind {
+        "scroll-pin" => {
+            effect
+                .get("pinnedSelector")
+                .and_then(|v| v.as_str())
+                .is_some()
+                && effect.get("startY").and_then(|v| v.as_f64()).is_some()
+                && effect.get("endY").and_then(|v| v.as_f64()).is_some()
+                && effect
+                    .get("desiredViewportTop")
+                    .and_then(|v| v.as_f64())
+                    .is_some()
+                && effect.get("endY").and_then(|v| v.as_f64()).unwrap_or(0.0)
+                    > effect.get("startY").and_then(|v| v.as_f64()).unwrap_or(0.0)
+        }
+        "scroll-coupled-visual-style" => {
+            let Some(progress) = effect.get("progress") else {
+                return false;
+            };
+            let Some(start) = progress.get("startY").and_then(|v| v.as_f64()) else {
+                return false;
+            };
+            let Some(end) = progress.get("endY").and_then(|v| v.as_f64()) else {
+                return false;
+            };
+            end > start
+                && effect
+                    .get("from")
+                    .zip(effect.get("to"))
+                    .is_some_and(|(from, to)| direct_style_supported(from, to))
+        }
+        "scroll-triggered-time-style" => {
+            effect.get("triggerY").and_then(|v| v.as_f64()).is_some()
+                && effect
+                    .get("before")
+                    .zip(effect.get("after"))
+                    .is_some_and(|(before, after)| direct_style_supported(before, after))
+        }
+        _ => false,
+    }
+}
+
+fn scroll_tracks_replay_script(effects: &[serde_json::Value]) -> String {
+    let payload: Vec<serde_json::Value> = effects
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.get("kind").and_then(|v| v.as_str()),
+                Some("scroll-coupled-visual-style" | "scroll-pin" | "scroll-triggered-time-style")
+            )
+        })
+        .cloned()
+        .collect();
+    if payload.is_empty() {
+        return String::new();
+    }
+    format!(
+        r#"<script id="hwatu-scroll-tracks-replay">(function () {{
+  const cfg = {payload};
+  const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const num = (v) => {{ const n = parseFloat(v); return Number.isFinite(n) ? n : null; }};
+  const px = (v) => {{ const n = num(v); return n == null ? null : n + 'px'; }};
+  const matrix = (v) => {{
+    if (!v || v === 'none') return {{ sx: 1, sy: 1, tx: 0, ty: 0 }};
+    let m = /^matrix\(([^)]+)\)$/.exec(v);
+    if (m) {{ const p = m[1].split(',').map(parseFloat); return {{ sx: p[0] || 1, sy: p[3] || 1, tx: p[4] || 0, ty: p[5] || 0 }}; }}
+    m = /^matrix3d\(([^)]+)\)$/.exec(v);
+    if (m) {{ const p = m[1].split(',').map(parseFloat); return {{ sx: p[0] || 1, sy: p[5] || 1, tx: p[12] || 0, ty: p[13] || 0 }}; }}
+    return null;
+  }};
+  const inset = (v) => {{
+    const m = /^inset\(([^)]*)\)$/.exec(v || '');
+    if (!m) return null;
+    const [main, round] = m[1].split(/\s+round\s+/);
+    const vals = main.trim().split(/\s+/).map(num);
+    if (vals.some(x => x == null)) return null;
+    while (vals.length < 4) vals.push(vals[vals.length === 1 ? 0 : vals.length - 2]);
+    return {{ vals, round: round || '' }};
+  }};
+  const states = cfg.map((e) => {{
+    const root = document.querySelector(e.selector || '');
+    if (!root) return null;
+    if (e.kind === 'scroll-pin') {{
+      const child = document.querySelector(e.pinnedSelector || '') || root.firstElementChild || root;
+      const baseTransform = child.style.transform || '';
+      const computedTransform = getComputedStyle(child).transform;
+      const baseline = baseTransform || (computedTransform && computedTransform !== 'none' ? computedTransform : '');
+      return {{ e, root, child, baseline }};
+    }}
+    return {{ e, root }};
+  }}).filter(Boolean);
+  const writeStyle = (el, from, to, t) => {{
+    if (!from || !to) return;
+    const fo = num(from.opacity), toOp = num(to.opacity);
+    if (fo != null && toOp != null && fo !== toOp) el.style.opacity = String(lerp(fo, toOp, t));
+    const fr = px(from.borderRadius), tr = px(to.borderRadius);
+    if (fr != null && tr != null && fr !== tr) el.style.borderRadius = lerp(parseFloat(fr), parseFloat(tr), t) + 'px';
+    const fm = matrix(from.transform), tm = matrix(to.transform);
+    if (fm && tm) el.style.transform = `translate(${{lerp(fm.tx, tm.tx, t)}}px, ${{lerp(fm.ty, tm.ty, t)}}px) scale(${{lerp(fm.sx, tm.sx, t)}}, ${{lerp(fm.sy, tm.sy, t)}})`;
+    const fi = inset(from.clipPath), ti = inset(to.clipPath);
+    if (fi && ti) el.style.clipPath = 'inset(' + fi.vals.map((v, i) => lerp(v, ti.vals[i], t).toFixed(3) + '%').join(' ') + (ti.round ? ' round ' + ti.round : '') + ')';
+  }};
+  const update = () => {{
+    const y = scrollY || document.documentElement.scrollTop || 0;
+    for (const s of states) {{
+      const e = s.e;
+      if (e.kind === 'scroll-pin') {{
+        const start = +e.startY || 0, end = +e.endY || start;
+        const active = y >= start && y <= end && end > start;
+        if (!active) {{ s.child.style.transform = s.baseline; continue; }}
+        const desired = Number.isFinite(+e.desiredViewportTop) ? +e.desiredViewportTop : s.child.getBoundingClientRect().top;
+        // Restore the captured baseline before measuring so our previous
+        // translate never feeds back into the next frame. The stable root
+        // remains the activation anchor; this read only computes the final
+        // correction needed for sticky/native layouts.
+        s.child.style.transform = s.baseline;
+        s.root.getBoundingClientRect();
+        const delta = desired - s.child.getBoundingClientRect().top;
+        s.child.style.transform = `translate3d(0, ${{delta}}px, 0)` + (s.baseline ? ' ' + s.baseline : '');
+        s.child.style.willChange = 'transform';
+      }} else if (e.kind === 'scroll-coupled-visual-style') {{
+        const p = e.progress || {{}};
+        const t = clamp((y - (+p.startY || 0)) / Math.max(1, (+p.endY || 0) - (+p.startY || 0)), 0, 1);
+        writeStyle(s.root, e.from, e.to, t);
+      }} else if (e.kind === 'scroll-triggered-time-style') {{
+        const on = y >= (+e.triggerY || 0);
+        s.root.dataset.hwatuTimeState = on ? 'in' : 'out';
+        s.root.style.transition = 'transform 700ms cubic-bezier(.2,.8,.2,1), opacity 500ms ease, color 500ms ease, background-color 500ms ease, clip-path 700ms ease';
+        writeStyle(s.root, on ? e.before : e.after, on ? e.after : e.before, 1);
+      }}
+    }}
+  }};
+  addEventListener('scroll', update, {{ passive: true }});
+  document.addEventListener('scroll', update, {{ passive: true, capture: true }});
+  if (typeof requestAnimationFrame === 'function') {{ const loop = () => {{ update(); requestAnimationFrame(loop); }}; requestAnimationFrame(loop); }}
+  setInterval(update, 250);
+  update();
+}})();</script>"#,
+        payload = serde_json::Value::Array(payload)
+    )
+}
+
 fn scroll_effect_notice(effects: &[serde_json::Value]) -> Option<String> {
     if effects.is_empty() {
         return None;
@@ -1364,7 +1617,7 @@ fn scroll_effect_notice(effects: &[serde_json::Value]) -> Option<String> {
         .filter(|e| e.get("replay").and_then(|v| v.as_str()) == Some("replayed"))
         .count();
     Some(format!(
-        "\n<!-- hwatu: detected {count} scroll-coupled text style region(s): \
+        "\n<!-- hwatu: detected {count} scroll effect track(s): \
          {replayed} replayed by a generated scrollY->style runtime, {} report-only; \
          see scroll-effects.json for fits and entry/midpoint/exit samples. -->\n",
         count - replayed
@@ -1677,7 +1930,10 @@ mod tests {
             }),
         ];
         let notice = scroll_effect_notice(&effects).unwrap();
-        assert!(notice.contains("detected 2 scroll-coupled"), "{notice}");
+        assert!(
+            notice.contains("detected 2 scroll effect track"),
+            "{notice}"
+        );
         assert!(notice.contains("1 replayed"), "{notice}");
         assert!(notice.contains("1 report-only"), "{notice}");
         assert!(notice.contains("scroll-effects.json"), "{notice}");
@@ -1792,6 +2048,51 @@ mod tests {
             w["i"] = serde_json::json!(k);
         }
         assert!(fit_scroll_effect(&effect).is_none());
+    }
+
+    #[test]
+    fn direct_tracks_gate_unsupported_shapes() {
+        let visual = serde_json::json!({
+            "kind": "scroll-coupled-visual-style",
+            "selector": "#visual",
+            "progress": { "startY": 10, "endY": 100 },
+            "from": { "opacity": "0", "transform": "matrix(1, 0, 0, 1, 0, 0)", "clipPath": "inset(0% 100% 0% 0% round 10px)" },
+            "to": { "opacity": "1", "transform": "matrix(2, 0, 0, 2, 0, 0)", "clipPath": "inset(0% 0% 0% 0% round 10px)" }
+        });
+        assert!(direct_track_supported(&visual));
+        let unsupported = serde_json::json!({
+            "kind": "scroll-coupled-visual-style",
+            "selector": "#visual",
+            "progress": { "startY": 10, "endY": 100 },
+            "from": { "clipPath": "circle(10px at 50% 50%)" },
+            "to": { "clipPath": "circle(50px at 50% 50%)" }
+        });
+        assert!(!direct_track_supported(&unsupported));
+    }
+
+    #[test]
+    fn scroll_tracks_runtime_composes_pin_baseline_transform() {
+        let script = scroll_tracks_replay_script(&[serde_json::json!({
+            "kind": "scroll-pin",
+            "selector": "#pin-root",
+            "pinnedSelector": "#pinned",
+            "startY": 100,
+            "endY": 900,
+            "desiredViewportTop": 120,
+            "replay": "replayed"
+        })]);
+        assert!(script.contains("hwatu-scroll-tracks-replay"), "{script}");
+        assert!(script.contains("baseTransform"), "{script}");
+        assert!(script.contains("computedTransform"), "{script}");
+        assert!(
+            script.contains("s.child.style.transform = s.baseline"),
+            "{script}"
+        );
+        assert!(
+            script.contains("+ (s.baseline ? ' ' + s.baseline"),
+            "{script}"
+        );
+        assert!(script.contains("translate3d(0,"), "{script}");
     }
 
     #[test]

--- a/scripts/fixtures/clone-scroll-tracks.html
+++ b/scripts/fixtures/clone-scroll-tracks.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>hwatu issue 46 scroll tracks fixture</title>
+<style>
+  body { margin:0; font-family:sans-serif; height:5200px; background:#111; color:white; }
+  .spacer { height:900px; }
+  #visual { position:relative; margin:0 auto; width:70vw; height:260px; background:#7c3aed; opacity:.2; transform:scale(.8) translate(0px, 40px); clip-path:inset(0% 70% 0% 0% round 10px); border-radius:16px; }
+  #pin-section { position:relative; height:1500px; margin-top:500px; background:#222; }
+  #pin-root { width:60vw; height:220px; background:#10b981; position:sticky; top:120px; margin:auto; transform:scale(.97); }
+  #pinned { width:100%; height:100%; background:linear-gradient(135deg,#10b981,#0ea5e9); }
+  #timed { margin-top:600px; opacity:0; transform:translate(30px,0) scale(.95); color:rgb(0, 255, 128); font-size:42px; }
+</style>
+<div class="spacer"></div>
+<div id="visual"></div>
+<section id="pin-section"><div id="pin-root"><div id="pinned"></div></div></section>
+<div id="timed">threshold timed reveal</div>
+<script>
+  const visual = document.querySelector('#visual');
+  const timed = document.querySelector('#timed');
+  let played = false;
+  let timer = 0;
+  function update() {
+    const y = scrollY;
+    const t = Math.max(0, Math.min(1, (y - 400) / 900));
+    visual.style.opacity = String(.2 + .6 * t);
+    visual.style.transform = `scale(${.8 + .2 * t}) translate(0px, ${40 - 40*t}px)`;
+    visual.style.clipPath = `inset(0% ${70 - 70*t}% 0% 0% round 10px)`;
+    visual.style.borderRadius = `${16 - 16*t}px`;
+    if (y > 2600 && !played) {
+      played = true;
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        if (!played) return;
+        timed.style.opacity = '1';
+        timed.style.transform = 'translate(0px,0) scale(1)';
+        timed.style.color = 'rgb(180, 120, 255)';
+      }, 120);
+    }
+    if (y < 2500 && played) {
+      played = false;
+      clearTimeout(timer);
+      timed.style.opacity = '0';
+      timed.style.transform = 'translate(30px,0) scale(.95)';
+      timed.style.color = 'rgb(0, 255, 128)';
+    }
+  }
+  addEventListener('scroll', update, {passive:true});
+  update();
+</script>

--- a/scripts/test-clone-scroll-tracks.sh
+++ b/scripts/test-clone-scroll-tracks.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Focused regression for issue #46: clone scroll-effects should serialize and
+# replay visual scrub tracks, stable pins, and threshold-triggered time tracks.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin="$root/target/debug"
+
+echo "test-clone-scroll-tracks: building debug binaries..." >&2
+cargo build --manifest-path "$root/Cargo.toml" >&2
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-scroll-tracks.XXXXXX")"
+export XDG_RUNTIME_DIR="$work/run"
+export XDG_STATE_HOME="$work/state"
+export XDG_CONFIG_HOME="$work/config"
+export XDG_CACHE_HOME="$work/cache"
+export XDG_DATA_HOME="$work/data"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME"
+server_pid=""
+
+cleanup() {
+    "$bin/hwatu" quit >/dev/null 2>&1 || true
+    if [[ -n "${server_pid:-}" ]]; then
+        kill "$server_pid" >/dev/null 2>&1 || true
+        wait "$server_pid" >/dev/null 2>&1 || true
+    fi
+    if [[ -z "${KEEP_HWATU_SCROLL_TRACKS_TEST:-}" ]]; then
+        rm -rf "$work"
+    else
+        echo "kept $work" >&2
+    fi
+}
+trap cleanup EXIT
+
+fixture_dir="$root/scripts/fixtures"
+port="${HWATU_SCROLL_TRACKS_PORT:-$(python3 - <<'PY'
+import socket
+s = socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()
+PY
+)}"
+python3 -m http.server "$port" --directory "$fixture_dir" >"$work/http.log" 2>&1 &
+server_pid=$!
+for _ in {1..50}; do
+    if python3 - <<PY >/dev/null 2>&1
+import urllib.request
+urllib.request.urlopen('http://127.0.0.1:$port/clone-scroll-tracks.html', timeout=.2).read(1)
+PY
+    then break; fi
+    sleep .1
+done
+
+out="$work/out"
+"$bin/hwatu" clone "http://127.0.0.1:$port/clone-scroll-tracks.html" \
+    --out "$out" --viewport 1000x720 --no-verify --timeout-ms 60000 >&2
+
+python3 - "$out" <<'PY'
+import json, pathlib, sys
+out = pathlib.Path(sys.argv[1])
+cap = json.loads((out / 'capture.json').read_text())
+effects = cap.get('scrollEffects') or []
+kinds = {e.get('kind') for e in effects}
+assert 'scroll-coupled-visual-style' in kinds, kinds
+assert 'scroll-pin' in kinds, kinds
+assert 'scroll-triggered-time-style' in kinds, kinds
+visual = next(e for e in effects if e.get('kind') == 'scroll-coupled-visual-style')
+assert visual.get('from', {}).get('clipPath') != visual.get('to', {}).get('clipPath'), visual
+assert visual.get('from', {}).get('transform') != visual.get('to', {}).get('transform'), visual
+pin = next(e for e in effects if e.get('kind') == 'scroll-pin')
+assert pin.get('endY', 0) > pin.get('startY', 0), pin
+assert 'desiredViewportTop' in pin and 'pinnedSelector' in pin, pin
+assert pin.get('pinnedSelector') == '#pin-root', pin
+time = next(e for e in effects if e.get('kind') == 'scroll-triggered-time-style')
+assert time.get('before') and time.get('after') and time.get('triggerY', -1) >= 0, time
+report = json.loads((out / 'scroll-effects.json').read_text())
+reported = {e.get('kind'): e for e in report['effects']}
+for kind in ('scroll-coupled-visual-style', 'scroll-pin', 'scroll-triggered-time-style'):
+    assert reported[kind].get('replay') == 'replayed', reported[kind]
+html = (out / 'index.html').read_text()
+assert 'hwatu-scroll-tracks-replay' in html, 'new replay runtime missing'
+for marker in ('translate3d(0,', 'clipPath', 'hwatuTimeState', 'direct serialized scroll track runtime'):
+    assert marker in html or marker in json.dumps(report), marker
+for marker in ('baseTransform', 'computedTransform', "s.child.style.transform = s.baseline"):
+    assert marker in html, marker
+print('PASS scroll track kinds:', ','.join(sorted(kinds)))
+PY
+
+clone_url="file://$out/index.html"
+"$bin/hwatu" --headless "$clone_url" >/dev/null
+for _ in {1..50}; do
+    "$bin/hwatu" list --json >"$work/list.json"
+    clone_id="$(python3 - "$clone_url" "$work/list.json" <<'PY'
+import json, sys
+want = sys.argv[1]
+path = sys.argv[2]
+try:
+    wins = json.load(open(path))
+except Exception:
+    wins = []
+for w in wins:
+    if w.get('url') == want:
+        print(w.get('id'))
+        break
+PY
+)"
+    [[ -n "${clone_id:-}" ]] && break
+    sleep .1
+done
+[[ -n "${clone_id:-}" ]] || { echo "failed to find clone window" >&2; exit 1; }
+
+"$bin/hwatu" eval --id "$clone_id" --timeout-ms 20000 "
+return (async () => {
+async function settle(y) {
+  scrollTo(0, y);
+  dispatchEvent(new Event('scroll'));
+  document.dispatchEvent(new Event('scroll'));
+  await new Promise(r => setTimeout(r, 450));
+}
+function snap() {
+  const visual = document.querySelector('#visual');
+  const timed = document.querySelector('#timed');
+  const pin = document.querySelector('#pin-root');
+  const vs = getComputedStyle(visual);
+  const ts = getComputedStyle(timed);
+  return {
+    y: scrollY,
+    visual: { opacity: vs.opacity, transform: vs.transform, clipPath: vs.clipPath },
+    timed: { state: timed.dataset.hwatuTimeState || '', opacity: ts.opacity, transform: ts.transform },
+    pin: { top: pin.getBoundingClientRect().top, transform: getComputedStyle(pin).transform }
+  };
+}
+await settle(0); const a = snap();
+await settle(1150); const b = snap();
+await settle(1700); const p1 = snap();
+await settle(2300); const p2 = snap();
+await settle(0); const t0 = snap();
+await settle(3000); const t1 = snap();
+return { a, b, p1, p2, t0, t1 };
+})()
+" >"$work/runtime.json"
+
+python3 - "$work/runtime.json" <<'PY'
+import json, sys
+raw = open(sys.argv[1]).read()
+data = json.loads(raw)
+if isinstance(data, dict) and 'value' in data:
+    data = data['value']
+assert data['a']['visual']['opacity'] != data['b']['visual']['opacity'], data
+assert data['a']['visual']['transform'] != data['b']['visual']['transform'], data
+assert data['a']['visual']['clipPath'] != data['b']['visual']['clipPath'], data
+assert abs(data['p1']['pin']['top'] - data['p2']['pin']['top']) <= 8, data
+assert data['p1']['pin']['transform'] != 'none' and data['p2']['pin']['transform'] != 'none', data
+assert data['t0']['timed']['state'] in ('', 'out'), data
+assert data['t1']['timed']['state'] == 'in', data
+print('PASS runtime replay behavior: visual changed, pin stable, time state flipped')
+PY


### PR DESCRIPTION
## Summary
- extend scroll-effect capture to serialize non-text visual scrub tracks, sticky-safe pin tracks, and threshold-triggered time tracks
- add direct replay runtime with support gating and honest report-only fallback for unsupported shapes
- add deterministic fixture and behavioral script that drives the generated clone at scroll positions and validates visual style changes, pin stability, and time state flips

Closes #46

## Validation
- scripts/test-clone-scroll-tracks.sh
- pgrep -af "python3 -m http.server.*hwatu-issue46-scroll-tracks" || true
- cargo test -q
- cargo clippy -q --all-targets --all-features