### PR TITLE
Recover auth windows after web process crashes

### DIFF
--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -2422,7 +2422,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
     fn confirmation_keys_only_claim_explicit_answers() {
         let none = gtk::gdk::ModifierType::empty();
         assert_eq!(super::confirm_answer(gtk::gdk::Key::y, none), Some(true));

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -16,7 +16,7 @@ use crate::launcher;
 use crate::prompts::{self, Prompt, Prompts};
 use crate::Daemon;
 use gtk::prelude::*;
-use hwatu_ipc::{OpenMode, WindowInfo};
+use hwatu_ipc::{OpenMode, WebProcessTerminationInfo, WindowInfo};
 use std::cell::RefCell;
 use std::rc::Rc;
 use webkit6::prelude::*;
@@ -228,6 +228,31 @@ struct SavedState {
     title: String,
 }
 
+fn termination_info(
+    reason: webkit6::WebProcessTerminationReason,
+    url: String,
+) -> WebProcessTerminationInfo {
+    let (reason, message) = match reason {
+        webkit6::WebProcessTerminationReason::Crashed => ("crashed", "crashed"),
+        webkit6::WebProcessTerminationReason::ExceededMemoryLimit => {
+            ("oom", "was killed (out of memory)")
+        }
+        _ => ("terminated", "terminated unexpectedly"),
+    };
+    WebProcessTerminationInfo {
+        reason: reason.to_string(),
+        message: message.to_string(),
+        url,
+    }
+}
+
+fn recovery_url(live_url: Option<&str>, last_url: &str) -> Option<String> {
+    live_url
+        .filter(|url| !url.is_empty())
+        .or((!last_url.is_empty()).then_some(last_url))
+        .map(str::to_string)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum RecoveryOverlay {
     Loading,
@@ -320,6 +345,16 @@ pub struct BrowserWindow {
     /// stale prewarm `about:blank` commit from a genuine navigation
     /// to about:blank.
     nav_target: RefCell<Option<String>>,
+    /// Last non-empty URL observed or requested for this window. WebKit can
+    /// return an empty URI after web-process termination; keep enough state
+    /// for diagnostics and recovery instead of reporting a blank page.
+    last_url: RefCell<String>,
+    /// Last non-empty title, for the same post-termination fallback as URL.
+    last_title: RefCell<String>,
+    /// Last web-process termination diagnostic. Kept in the window model so
+    /// `hwatu list --json` exposes the reason even when hwatud was auto-
+    /// spawned with stdout/stderr discarded.
+    web_process_terminated: RefCell<Option<WebProcessTerminationInfo>>,
     /// True once the current load has Committed: the new document has
     /// replaced the old one. Together with `nav_pending` this lets
     /// stage-aware waits (`wait-load --until committed|dom`) know
@@ -549,12 +584,14 @@ impl BrowserWindow {
         let target = match url.or_else(home_page) {
             Some(url) => {
                 this.mark_nav_pending(&url);
+                this.remember_url(&url);
                 webview.load_uri(&url);
                 url
             }
             None => {
                 let uri = launcher::deal_uri(daemon.take_deal());
                 this.mark_nav_pending(&uri);
+                this.remember_url(&uri);
                 webview.load_uri(&uri);
                 if mode == OpenMode::Normal {
                     this.bar.open_url("");
@@ -571,6 +608,7 @@ impl BrowserWindow {
             suspended: false,
             app_id,
             mode,
+            web_process_terminated: None,
         }
     }
 
@@ -745,6 +783,9 @@ impl BrowserWindow {
             viewport: std::cell::Cell::new(None),
             nav_pending: RefCell::new(None),
             nav_target: RefCell::new(None),
+            last_url: RefCell::new(String::new()),
+            last_title: RefCell::new(String::new()),
+            web_process_terminated: RefCell::new(None),
             load_committed: std::cell::Cell::new(true),
             snapshot_baseline: RefCell::new(None),
             console: crate::console::Buffer::default(),
@@ -897,8 +938,12 @@ impl BrowserWindow {
         crate::console::attach(&self.console, &webview);
         crate::net::attach(&self.net, &webview);
         let win = self.window.clone();
+        let this = self.clone();
         webview.connect_title_notify(move |wv| {
             let title = wv.title().unwrap_or_default();
+            if !title.is_empty() {
+                this.last_title.replace(title.to_string());
+            }
             win.set_title(Some(if title.is_empty() {
                 "hwatu"
             } else {
@@ -909,7 +954,11 @@ impl BrowserWindow {
         // (debounced in the daemon).
         {
             let daemon = self.daemon.clone();
-            webview.connect_uri_notify(move |_| daemon.schedule_session_save());
+            let this = self.clone();
+            webview.connect_uri_notify(move |wv| {
+                this.remember_webview_url(wv);
+                daemon.schedule_session_save();
+            });
         }
         // A gray WebKit surface during a slow or wedged load used to look
         // like hwatu itself had broken. Surface a low-priority overlay if
@@ -921,6 +970,7 @@ impl BrowserWindow {
             webview.connect_load_changed(move |wv, event| match event {
                 webkit6::LoadEvent::Started => {
                     this.note_load_engaged(wv);
+                    this.web_process_terminated.replace(None);
                     this.turnstile_handoff_offered.set(false);
                     this.load_committed.set(false);
                     this.clear_recovery_overlay();
@@ -1051,17 +1101,32 @@ impl BrowserWindow {
                 if this.webview.borrow().as_ref() != Some(wv) {
                     return;
                 }
-                let reason = match reason {
-                    webkit6::WebProcessTerminationReason::Crashed => "crashed",
-                    webkit6::WebProcessTerminationReason::ExceededMemoryLimit => {
-                        "was killed (out of memory)"
-                    }
-                    _ => "terminated unexpectedly",
-                };
-                eprintln!("hwatud: web process for window {} {reason}", this.id);
+                let url = wv
+                    .uri()
+                    .map(|u| u.to_string())
+                    .filter(|u| !u.is_empty())
+                    .unwrap_or_else(|| this.last_url.borrow().clone());
+                let info = termination_info(reason, url.clone());
+                this.web_process_terminated.replace(Some(info.clone()));
+                this.daemon.events.emit(
+                    "web_process",
+                    Some(this.id),
+                    serde_json::json!({
+                        "state": "terminated",
+                        "reason": info.reason,
+                        "message": info.message,
+                        "url": info.url,
+                    }),
+                );
+                eprintln!(
+                    "hwatud: web process for window {} {} at {}",
+                    this.id,
+                    info.message,
+                    if url.is_empty() { "(unknown URL)" } else { &url }
+                );
                 this.show_recovery_overlay(
                     "Page crashed",
-                    &format!("The web process {reason}. Press Ctrl+r or F5 to reload, or Ctrl+l to open a URL."),
+                    &format!("The web process {}. Press Ctrl+r or F5 to reload, or Ctrl+l to open a URL.", info.message),
                     RecoveryOverlay::Failure,
                 );
             });
@@ -1426,6 +1491,11 @@ impl BrowserWindow {
     /// need for a human (not focused, no bar prompt, no CAPTCHA)
     /// demotes itself instead of squatting in the WM forever.
     pub fn present(self: &Rc<Self>) {
+        // Do not depend on the compositor granting activation (and emitting
+        // is-active-notify) to preserve the promoted page. Cancel a pending
+        // discard and restore before mapping the window.
+        self.cancel_discard_timer();
+        self.restore();
         let prev = self.mode.get();
         if prev != OpenMode::Normal && self.promoted_from.get().is_none() {
             self.promoted_from.set(Some(prev));
@@ -1534,15 +1604,31 @@ impl BrowserWindow {
 
     pub fn info(&self) -> WindowInfo {
         match &*self.webview.borrow() {
-            Some(wv) => WindowInfo {
-                id: self.id,
-                url: wv.uri().map(|u| u.to_string()).unwrap_or_default(),
-                title: wv.title().map(|t| t.to_string()).unwrap_or_default(),
-                focused: self.window.is_active(),
-                suspended: false,
-                app_id: self.app_id.clone(),
-                mode: self.mode.get(),
-            },
+            Some(wv) => {
+                let url = wv.uri().map(|u| u.to_string()).unwrap_or_default();
+                WindowInfo {
+                    id: self.id,
+                    url: if url.is_empty() {
+                        self.last_url.borrow().clone()
+                    } else {
+                        url
+                    },
+                    title: wv
+                        .title()
+                        .map(|t| t.to_string())
+                        .filter(|title| !title.is_empty())
+                        .unwrap_or_else(|| self.last_title.borrow().clone()),
+                    focused: self.window.is_active(),
+                    suspended: false,
+                    app_id: self.app_id.clone(),
+                    mode: self.mode.get(),
+                    web_process_terminated: self
+                        .web_process_terminated
+                        .borrow()
+                        .clone()
+                        .map(Box::new),
+                }
+            }
             None => {
                 let saved = self.saved.borrow();
                 let (url, title) = saved
@@ -1551,12 +1637,25 @@ impl BrowserWindow {
                     .unwrap_or_default();
                 WindowInfo {
                     id: self.id,
-                    url,
-                    title,
+                    url: if url.is_empty() {
+                        self.last_url.borrow().clone()
+                    } else {
+                        url
+                    },
+                    title: if title.is_empty() {
+                        self.last_title.borrow().clone()
+                    } else {
+                        title
+                    },
                     focused: false,
                     suspended: true,
                     app_id: self.app_id.clone(),
                     mode: self.mode.get(),
+                    web_process_terminated: self
+                        .web_process_terminated
+                        .borrow()
+                        .clone()
+                        .map(Box::new),
                 }
             }
         }
@@ -1597,6 +1696,18 @@ impl BrowserWindow {
     /// adblock toggle to re-apply filters across all windows.
     pub fn live_webview(&self) -> Option<webkit6::WebView> {
         self.webview.borrow().clone()
+    }
+
+    fn remember_webview_url(&self, webview: &webkit6::WebView) {
+        if let Some(uri) = webview.uri().filter(|uri| !uri.is_empty()) {
+            self.remember_url(uri.as_str());
+        }
+    }
+
+    fn remember_url(&self, url: &str) {
+        if !url.is_empty() {
+            self.last_url.replace(url.to_string());
+        }
     }
 
     /// Re-assert the offscreen viewport of a headless window. The
@@ -1833,6 +1944,14 @@ impl BrowserWindow {
         let Some(webview) = self.live_webview() else {
             return;
         };
+        if webview.uri().is_none_or(|uri| uri.is_empty()) {
+            let last_url = self.last_url.borrow().clone();
+            if let Some(url) = recovery_url(None, &last_url) {
+                self.mark_nav_pending(&url);
+                webview.load_uri(&url);
+            }
+            return;
+        }
         if bypass_cache {
             webview.reload_bypass_cache();
         } else {
@@ -2089,6 +2208,7 @@ impl BrowserWindow {
         if let Some(webview) = self.live_webview() {
             let url = crate::ipc_server::normalize_url(input.to_string());
             self.mark_nav_pending(&url);
+            self.remember_url(&url);
             webview.load_uri(&url);
         }
     }
@@ -2200,6 +2320,7 @@ impl BrowserWindow {
 mod tests {
     use super::{
         external_uri_scheme, is_ctrl_click_link, load_was_cancelled, parse_feature_overrides,
+        recovery_url, termination_info,
     };
 
     #[test]
@@ -2301,6 +2422,7 @@ mod tests {
     }
 
     #[test]
+<<<<<<< HEAD
     fn confirmation_keys_only_claim_explicit_answers() {
         let none = gtk::gdk::ModifierType::empty();
         assert_eq!(super::confirm_answer(gtk::gdk::Key::y, none), Some(true));
@@ -2397,5 +2519,34 @@ mod tests {
         assert_eq!(external_uri_scheme("hwatu://launcher"), None);
         assert_eq!(external_uri_scheme("not a uri"), None);
         assert_eq!(external_uri_scheme("1invalid:value"), None);
+    }
+
+    #[test]
+    fn recovery_url_prefers_live_and_falls_back_to_last_non_empty_url() {
+        assert_eq!(
+            recovery_url(Some("https://live.test/"), "https://last.test/"),
+            Some("https://live.test/".into())
+        );
+        assert_eq!(
+            recovery_url(Some(""), "https://last.test/"),
+            Some("https://last.test/".into())
+        );
+        assert_eq!(recovery_url(None, ""), None);
+    }
+
+    #[test]
+    fn web_process_termination_reasons_are_stable_and_keep_url() {
+        let url = "https://example.test/sign-up".to_string();
+        let crashed = termination_info(webkit6::WebProcessTerminationReason::Crashed, url.clone());
+        let oom = termination_info(
+            webkit6::WebProcessTerminationReason::ExceededMemoryLimit,
+            url.clone(),
+        );
+
+        assert_eq!(crashed.reason, "crashed");
+        assert_eq!(crashed.message, "crashed");
+        assert_eq!(crashed.url, url);
+        assert_eq!(oom.reason, "oom");
+        assert_eq!(oom.message, "was killed (out of memory)");
     }
 }

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -999,6 +999,20 @@ pub struct WindowInfo {
     /// promotes a window to normal.
     #[serde(default, skip_serializing_if = "is_normal")]
     pub mode: OpenMode,
+    /// Last WebKit web-process termination observed for this window, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_process_terminated: Option<Box<WebProcessTerminationInfo>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebProcessTerminationInfo {
+    /// Stable, machine-readable reason: crashed, oom, or terminated.
+    pub reason: String,
+    /// Human-readable description suitable for diagnostics.
+    pub message: String,
+    /// Best-known URL at the time the web process died.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub url: String,
 }
 
 fn is_normal(mode: &OpenMode) -> bool {
@@ -1064,6 +1078,40 @@ mod tests {
         };
         assert_eq!(render.as_deref(), Some("<h1>hi</h1>"));
         assert_eq!(base.as_deref(), Some("http://localhost:3000/"));
+    }
+
+    #[test]
+    fn old_window_info_defaults_recovery_fields() {
+        let old = r#"{"id":7,"url":"","title":"","focused":false,"suspended":false}"#;
+        let info: WindowInfo = serde_json::from_str(old).expect("old WindowInfo parses");
+
+        assert_eq!(info.web_process_terminated, None);
+    }
+
+    #[test]
+    fn window_info_serializes_recoverable_crash_state() {
+        let info = WindowInfo {
+            id: 7,
+            url: "https://example.test/sign-up".into(),
+            title: String::new(),
+            focused: true,
+            suspended: false,
+            app_id: None,
+            mode: OpenMode::Normal,
+            web_process_terminated: Some(Box::new(WebProcessTerminationInfo {
+                reason: "oom".into(),
+                message: "was killed (out of memory)".into(),
+                url: "https://example.test/sign-up".into(),
+            })),
+        };
+
+        let json = serde_json::to_value(&info).expect("WindowInfo serializes");
+
+        assert_eq!(json["web_process_terminated"]["reason"], "oom");
+        assert_eq!(
+            json["web_process_terminated"]["url"],
+            "https://example.test/sign-up"
+        );
     }
 
     /// A viewport-sweep check roundtrips through the wire format; an

--- a/scripts/test-crash-recovery.sh
+++ b/scripts/test-crash-recovery.sh
@@ -15,11 +15,32 @@ work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-crash-recovery.XXXXXX")"
 daemon_pid=""
 server_pid=""
 cleanup() {
+    set +e
     "$bin/hwatu" quit >/dev/null 2>&1 || true
-    [[ -n "$daemon_pid" ]] && kill "$daemon_pid" 2>/dev/null || true
-    [[ -n "$server_pid" ]] && kill "$server_pid" 2>/dev/null || true
-    wait 2>/dev/null || true
-    rm -rf "$work"
+    if [[ -n "$daemon_pid" ]]; then
+        # A recovered WebKit process may still be flushing cache files after
+        # the daemon accepts quit. Reap the daemon before removing its XDG
+        # roots so a child cannot recreate entries under rm.
+        for _ in $(seq 1 100); do
+            kill -0 "$daemon_pid" 2>/dev/null || break
+            sleep 0.02
+        done
+        kill "$daemon_pid" 2>/dev/null || true
+        wait "$daemon_pid" 2>/dev/null || true
+    fi
+    if [[ -n "$server_pid" ]]; then
+        kill "$server_pid" 2>/dev/null || true
+        wait "$server_pid" 2>/dev/null || true
+    fi
+    # Sandboxed WebKit helpers can outlive their parent for a few scheduler
+    # ticks. Retry bounded removal rather than reporting a false test failure
+    # or leaking the fixture directory.
+    for _ in $(seq 1 100); do
+        rm -rf "$work" 2>/dev/null && return
+        sleep 0.02
+    done
+    echo "failed to remove test directory: $work" >&2
+    return 1
 }
 trap cleanup EXIT INT TERM
 

--- a/scripts/test-crash-recovery.sh
+++ b/scripts/test-crash-recovery.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Behavioral regression for issue #51: kill the isolated daemon's WebKit web
+# process, verify list keeps the URL and termination reason, then explicitly
+# navigate to prove the window recovers. No user daemon or external site is used.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin="$root/target/debug"
+if [[ ! -x "$bin/hwatu" || ! -x "$bin/hwatud" ]]; then
+    echo "test-crash-recovery: building debug binaries..." >&2
+    cargo build --manifest-path "$root/Cargo.toml" >&2
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hwatu-crash-recovery.XXXXXX")"
+daemon_pid=""
+server_pid=""
+cleanup() {
+    "$bin/hwatu" quit >/dev/null 2>&1 || true
+    [[ -n "$daemon_pid" ]] && kill "$daemon_pid" 2>/dev/null || true
+    [[ -n "$server_pid" ]] && kill "$server_pid" 2>/dev/null || true
+    wait 2>/dev/null || true
+    rm -rf "$work"
+}
+trap cleanup EXIT INT TERM
+
+# Keep the compositor's runtime dir, but isolate every Hwatu-owned path.
+export HWATU_SOCKET="$work/hwatu.sock"
+export XDG_STATE_HOME="$work/state"
+export XDG_CONFIG_HOME="$work/config"
+export XDG_DATA_HOME="$work/data"
+export XDG_CACHE_HOME="$work/cache"
+mkdir -p "$XDG_STATE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" \
+    "$XDG_CACHE_HOME" "$work/site"
+printf '<!doctype html><title>crash sentinel</title><h1>alive</h1>\n' \
+    >"$work/site/index.html"
+
+python3 - "$work/site" "$work/port" <<'PY' &
+import http.server
+import pathlib
+import socketserver
+import sys
+
+root, port_file = sys.argv[1:]
+
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+handler = lambda *args, **kwargs: Quiet(*args, directory=root, **kwargs)
+with socketserver.TCPServer(("127.0.0.1", 0), handler) as server:
+    pathlib.Path(port_file).write_text(str(server.server_address[1]))
+    server.serve_forever()
+PY
+server_pid=$!
+for _ in $(seq 1 100); do
+    [[ -s "$work/port" ]] && break
+    sleep 0.05
+done
+[[ -s "$work/port" ]] || { echo "fixture server failed" >&2; exit 1; }
+url="http://127.0.0.1:$(cat "$work/port")/index.html"
+
+"$bin/hwatud" >"$work/hwatud.log" 2>&1 &
+daemon_pid=$!
+for _ in $(seq 1 100); do
+    [[ -S "$HWATU_SOCKET" ]] && break
+    sleep 0.05
+done
+if [[ ! -S "$HWATU_SOCKET" ]]; then
+    cat "$work/hwatud.log" >&2
+    exit 1
+fi
+
+"$bin/hwatu" --headless "$url" >/dev/null
+"$bin/hwatu" wait-load --until dom >/dev/null
+id="$("$bin/hwatu" list --json | python3 -c \
+    'import json,sys; d=json.load(sys.stdin); assert len(d)==1,d; print(d[0]["id"])')"
+
+# Select only real WebKitWebProcess leaves descended from this isolated daemon,
+# excluding the similarly named processes owned by the user's normal daemon.
+mapfile -t web_pids < <(python3 - "$daemon_pid" <<'PY'
+import subprocess
+import sys
+
+root = int(sys.argv[1])
+rows = []
+for line in subprocess.check_output(
+    ["ps", "-eo", "pid=,ppid=,args="], text=True
+).splitlines():
+    parts = line.strip().split(None, 2)
+    if len(parts) == 3:
+        rows.append((int(parts[0]), int(parts[1]), parts[2]))
+parent = {pid: ppid for pid, ppid, _ in rows}
+
+def descends_from_root(pid):
+    seen = set()
+    while pid not in seen and pid in parent:
+        if parent[pid] == root:
+            return True
+        seen.add(pid)
+        pid = parent[pid]
+    return False
+
+for pid, _, args in rows:
+    executable = args.split(None, 1)[0]
+    if executable.endswith("/WebKitWebProcess") and descends_from_root(pid):
+        print(pid)
+PY
+)
+if ((${#web_pids[@]} == 0)); then
+    echo "no isolated WebKitWebProcess found" >&2
+    cat "$work/hwatud.log" >&2
+    exit 1
+fi
+kill -KILL "${web_pids[@]}"
+
+crash_json=""
+for _ in $(seq 1 100); do
+    crash_json="$("$bin/hwatu" list --json)"
+    if python3 -c \
+        'import json,sys; d=json.load(sys.stdin)[0]; assert d.get("web_process_terminated",{}).get("reason")' \
+        <<<"$crash_json" 2>/dev/null; then
+        break
+    fi
+    sleep 0.05
+done
+python3 -c \
+    'import json,sys; want=sys.argv[1]; d=json.load(sys.stdin)[0]; t=d["web_process_terminated"]; assert d["url"]==want,(d,want); assert t["url"]==want,t; assert t["reason"] in {"crashed","oom","terminated"},t' \
+    "$url" <<<"$crash_json"
+
+# Recovery is explicit. This deliberately performs a safe GET instead of
+# attempting to replay an unknown authentication POST.
+"$bin/hwatu" goto --id "$id" --until dom "$url" >/dev/null
+recovered="$("$bin/hwatu" list --json)"
+python3 -c \
+    'import json,sys; d=json.load(sys.stdin)[0]; assert d["url"]==sys.argv[1],d; assert "web_process_terminated" not in d,d; assert d["title"]=="crash sentinel",d' \
+    "$url" <<<"$recovered"
+
+echo "PASS crash recovery: retained URL/diagnostic and explicit navigation recovered"


### PR DESCRIPTION
## Summary
- preserve the last non-empty URL and title when WebKit clears live metadata after a web-process crash
- expose a structured `web_process_terminated` diagnostic through `WindowInfo` and the event stream, including a stable reason and recoverable URL
- harden headless-to-focus promotion by cancelling discard and restoring synchronously before asking the compositor to present the window
- make explicit reload recover an empty-URI crashed view from the retained URL without automatically replaying an unknown authentication POST
- add a fully isolated behavioral regression that kills the daemon's real WebKit process, verifies retained diagnostics, and proves explicit navigation recovery

Closes #51

## Validation
- `cargo fmt --all --check`
- `cargo test -p hwatu-ipc`
- focused `hwatud` recovery tests
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bash -n scripts/test-crash-recovery.sh`
- `scripts/test-crash-recovery.sh`