### PR TITLE
ci: remove scheduled workflow runs

### DIFF
--- a/.github/workflows/astrophile.yml
+++ b/.github/workflows/astrophile.yml
@@ -1,11 +1,8 @@
-# Copy to .github/workflows/astrophile.yml in your repo.
-# Weekly growth snapshot + geo check, committed back to the repo so
-# .astrophile/snapshots.jsonl becomes a long-term trend log.
-name: astrophile weekly snapshot
+# Manual growth snapshot + geo check, committed back to the repo so
+# .astrophile/snapshots.jsonl remains an on-demand trend log.
+name: astrophile snapshot
 
 on:
-  schedule:
-    - cron: '0 9 * * 1' # Mondays 09:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -60,6 +57,6 @@ jobs:
           git config user.name 'astrophile-bot'
           git config user.email 'actions@github.com'
           git add -f .astrophile/snapshots.jsonl
-          git diff --cached --quiet || git commit -m 'astrophile: weekly snapshot'
+          git diff --cached --quiet || git commit -m 'astrophile: snapshot'
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push


### PR DESCRIPTION
## Summary
- remove the Monday cron trigger from the Astrophile workflow
- keep the workflow available only through explicit manual dispatch
- rename weekly wording to on-demand wording

## Validation
- all GitHub workflow YAML files parse successfully
- no `cron`, `schedule:` trigger, crontab, or timer unit remains in tracked files
- the live Astrophile workflow was disabled before the next scheduled run