### PR TITLE
browser: integrate navigation and input QoL fixes

### DIFF
--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -254,7 +254,10 @@ fn default_open_mode() -> OpenMode {
             .map(|k| k.starts_with("JCODE_") && !JCODE_USER_CONFIG_VARS.contains(&k))
             .unwrap_or(false)
     });
-    if !from_jcode && !AGENT_MARKERS.iter().any(|k| std::env::var_os(k).is_some()) {
+    let from_agent = from_jcode || AGENT_MARKERS.iter().any(|k| std::env::var_os(k).is_some());
+    let user_initiated = std::env::var_os("GIO_LAUNCHED_DESKTOP_FILE").is_some()
+        || std::env::var("JCODE_OPEN_ORIGIN").as_deref() == Ok("user");
+    if should_default_to_normal(user_initiated, from_agent) {
         return OpenMode::Normal;
     }
     if let Ok(v) = std::env::var("HWATU_AGENT_MODE") {
@@ -266,6 +269,16 @@ fn default_open_mode() -> OpenMode {
         );
     }
     config_agent_mode().unwrap_or(OpenMode::Headless)
+}
+
+/// A URL explicitly activated by a user is visible even when the application
+/// that called the system opener is itself an agent UI. GIO marks conforming
+/// desktop-entry launches; jcode supplies `JCODE_OPEN_ORIGIN=user` because some
+/// `xdg-open` implementations execute desktop entries directly without a GIO
+/// marker. Without this exception, the inherited `JCODE_*` environment would
+/// silently create a headless hwatu page.
+fn should_default_to_normal(user_initiated: bool, from_agent: bool) -> bool {
+    user_initiated || !from_agent
 }
 
 /// Parse a user-facing mode name. `focus` is accepted as an alias for
@@ -1247,7 +1260,8 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<UnixStream> {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_onboarding_command, normalize_request_paths, parse_with_default_mode, OpenMode,
+        is_onboarding_command, normalize_request_paths, parse_with_default_mode,
+        should_default_to_normal, OpenMode,
     };
     use hwatu_ipc::Request;
 
@@ -1258,6 +1272,13 @@ mod tests {
         assert!(is_onboarding_command(Some("demo")));
         assert!(!is_onboarding_command(Some("https://example.com")));
         assert!(!is_onboarding_command(None));
+    }
+
+    #[test]
+    fn desktop_entry_launch_is_visible_inside_agent_environment() {
+        assert!(should_default_to_normal(true, true));
+        assert!(should_default_to_normal(false, false));
+        assert!(!should_default_to_normal(false, true));
     }
 
     /// Env-independent parse: tests themselves often run under a

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -64,6 +64,14 @@ fn home_page() -> Option<String> {
         .filter(|v| !v.trim().is_empty())
 }
 
+/// WebKit cancels the in-flight main-frame request when another navigation
+/// replaces it, including back/forward history traversal. That is normal
+/// navigation control flow, not a page failure worth surfacing to the user.
+fn load_was_cancelled(error: &glib::Error) -> bool {
+    error.matches(webkit6::NetworkError::Cancelled)
+        || error.matches(gtk::gio::IOErrorEnum::Cancelled)
+}
+
 /// Media autoplay policy for every WebView. WebKit's own default is
 /// ALLOW_WITHOUT_SOUND, which is why video sites autoplay muted: their
 /// unmuted-play probe is rejected, so they fall back to a muted player.
@@ -894,6 +902,13 @@ impl BrowserWindow {
         {
             let this = self.clone();
             webview.connect_load_failed(move |_, _, failing_uri, error| {
+                // Back/forward (and any navigation that supersedes an
+                // in-flight load) cancels the old main-frame request. The
+                // replacement load is already underway, so treating this as
+                // a failure leaves a false overlay on top of the new page.
+                if load_was_cancelled(error) {
+                    return true;
+                }
                 // A navigation converted into a download (attachment
                 // disposition or unrenderable MIME) aborts the frame
                 // load with FrameLoadInterruptedByPolicyChange. That
@@ -2023,7 +2038,7 @@ impl BrowserWindow {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_feature_overrides;
+    use super::{load_was_cancelled, parse_feature_overrides};
 
     #[test]
     fn parses_on_off_pairs() {
@@ -2076,5 +2091,26 @@ mod tests {
         assert_eq!(super::ratio_from_value(&json!("0.25")), None);
         assert_eq!(super::ratio_from_value(&json!(null)), None);
         assert_eq!(super::ratio_from_value(&json!({})), None);
+    }
+
+    #[test]
+    fn cancelled_webkit_load_is_not_a_page_failure() {
+        let error = glib::Error::new(
+            webkit6::NetworkError::Cancelled,
+            "Load request cancelled",
+        );
+        assert!(load_was_cancelled(&error));
+    }
+
+    #[test]
+    fn cancelled_gio_load_is_not_a_page_failure() {
+        let error = glib::Error::new(gtk::gio::IOErrorEnum::Cancelled, "Operation cancelled");
+        assert!(load_was_cancelled(&error));
+    }
+
+    #[test]
+    fn genuine_network_error_remains_a_page_failure() {
+        let error = glib::Error::new(webkit6::NetworkError::Failed, "Connection failed");
+        assert!(!load_was_cancelled(&error));
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -158,6 +158,25 @@ fn preferred_width(viewport_width: i32, ratio: f64) -> i32 {
     ((viewport_width as f64) * ratio).floor().max(1.0) as i32
 }
 
+/// Interpret only the keys owned by a confirmation prompt. Everything else
+/// must keep propagating to the page, otherwise a prompt appearing while the
+/// user types into a form can silently eat characters.
+fn confirm_answer(key: gtk::gdk::Key, state: gtk::gdk::ModifierType) -> Option<bool> {
+    let command_modifiers = gtk::gdk::ModifierType::CONTROL_MASK
+        | gtk::gdk::ModifierType::ALT_MASK
+        | gtk::gdk::ModifierType::SUPER_MASK
+        | gtk::gdk::ModifierType::HYPER_MASK
+        | gtk::gdk::ModifierType::META_MASK;
+    if state.intersects(command_modifiers) {
+        return None;
+    }
+    match key {
+        gtk::gdk::Key::y | gtk::gdk::Key::Y => Some(true),
+        gtk::gdk::Key::n | gtk::gdk::Key::N | gtk::gdk::Key::Escape => Some(false),
+        _ => None,
+    }
+}
+
 /// State saved across a discard. The session blob itself lives on disk
 /// (see [`discard_dir`]): keeping it in RAM would leak per-window
 /// memory exactly when the point of discarding is to reclaim it, and
@@ -727,13 +746,10 @@ impl BrowserWindow {
                 let BarMode::Confirm { tag } = this2.bar.mode() else {
                     return glib::Propagation::Proceed;
                 };
-                match key {
-                    gtk::gdk::Key::y | gtk::gdk::Key::Y => this2.answer_confirm(&tag, true),
-                    gtk::gdk::Key::n | gtk::gdk::Key::N | gtk::gdk::Key::Escape => {
-                        this2.answer_confirm(&tag, false)
-                    }
-                    _ => {}
-                }
+                let Some(answer) = confirm_answer(key, state) else {
+                    return glib::Propagation::Proceed;
+                };
+                this2.answer_confirm(&tag, answer);
                 glib::Propagation::Stop
             });
             window.add_controller(ctrl);
@@ -1743,13 +1759,10 @@ impl BrowserWindow {
             // don't leak into the page under the bar.
             BarMode::Find { .. } | BarMode::Url | BarMode::Palette => glib::Propagation::Proceed,
             BarMode::Confirm { tag } => {
-                match key {
-                    gtk::gdk::Key::y | gtk::gdk::Key::Y => self.answer_confirm(&tag, true),
-                    gtk::gdk::Key::n | gtk::gdk::Key::N | gtk::gdk::Key::Escape => {
-                        self.answer_confirm(&tag, false)
-                    }
-                    _ => {}
-                }
+                let Some(answer) = confirm_answer(key, state) else {
+                    return glib::Propagation::Proceed;
+                };
+                self.answer_confirm(&tag, answer);
                 glib::Propagation::Stop
             }
         }
@@ -2094,11 +2107,34 @@ mod tests {
     }
 
     #[test]
-    fn cancelled_webkit_load_is_not_a_page_failure() {
-        let error = glib::Error::new(
-            webkit6::NetworkError::Cancelled,
-            "Load request cancelled",
+    fn confirmation_keys_only_claim_explicit_answers() {
+        let none = gtk::gdk::ModifierType::empty();
+        assert_eq!(super::confirm_answer(gtk::gdk::Key::y, none), Some(true));
+        assert_eq!(
+            super::confirm_answer(gtk::gdk::Key::Y, gtk::gdk::ModifierType::SHIFT_MASK),
+            Some(true)
         );
+        assert_eq!(super::confirm_answer(gtk::gdk::Key::n, none), Some(false));
+        assert_eq!(super::confirm_answer(gtk::gdk::Key::N, none), Some(false));
+        assert_eq!(
+            super::confirm_answer(gtk::gdk::Key::Escape, none),
+            Some(false)
+        );
+        assert_eq!(super::confirm_answer(gtk::gdk::Key::a, none), None);
+        assert_eq!(super::confirm_answer(gtk::gdk::Key::exclam, none), None);
+        assert_eq!(
+            super::confirm_answer(gtk::gdk::Key::y, gtk::gdk::ModifierType::CONTROL_MASK),
+            None
+        );
+        assert_eq!(
+            super::confirm_answer(gtk::gdk::Key::n, gtk::gdk::ModifierType::ALT_MASK),
+            None
+        );
+    }
+
+    #[test]
+    fn cancelled_webkit_load_is_not_a_page_failure() {
+        let error = glib::Error::new(webkit6::NetworkError::Cancelled, "Load request cancelled");
         assert!(load_was_cancelled(&error));
     }
 

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -120,7 +120,7 @@ const DEFAULT_WINDOW_HEIGHT: i32 = 768;
 /// mapped window. Tiling WMs use this as the initial size hint when deciding
 /// how to place a new toplevel, while floating WMs still get a useful
 /// desktop-sized window instead of an arbitrary fixed width. The built-in
-/// default is one third; users can override it with `"preferred_width"` in
+/// default is one half; users can override it with `"preferred_width"` in
 /// `~/.config/hwatu/config.json`.
 fn default_window_width() -> i32 {
     let Some(display) = gtk::gdk::Display::default() else {
@@ -137,7 +137,7 @@ fn default_window_width() -> i32 {
     preferred_width(monitor.geometry().width(), preferred_width_ratio())
 }
 
-const DEFAULT_PREFERRED_WIDTH: f64 = 1.0 / 3.0;
+const DEFAULT_PREFERRED_WIDTH: f64 = 1.0 / 2.0;
 
 fn preferred_width_ratio() -> f64 {
     config_value("preferred_width")
@@ -2082,6 +2082,15 @@ mod tests {
         assert_eq!(super::preferred_width(1920, 1.0 / 3.0), 640);
         assert_eq!(super::preferred_width(1366, 1.0 / 3.0), 455);
         assert_eq!(super::preferred_width(1920, 0.25), 480);
+    }
+
+    #[test]
+    fn preferred_width_defaults_to_one_half() {
+        assert_eq!(super::DEFAULT_PREFERRED_WIDTH, 0.5);
+        assert_eq!(
+            super::preferred_width(1920, super::DEFAULT_PREFERRED_WIDTH),
+            960
+        );
     }
 
     #[test]

--- a/docs/human.md
+++ b/docs/human.md
@@ -16,7 +16,7 @@ content-extension engine, zero JS in the request path), sane
 downloads, crash-restore sessions, TLS and permission prompts as
 one-line y/n bar prompts.
 
-New windows open at a third of the monitor width, matching the first
+New windows open at half the monitor width, matching the middle
 stop of niri's default 1/3, 1/2, 2/3 preset-width cycle and a
 comfortable reading width on 1080p-class monitors. Prefer a different
 fraction? Set `"preferred_width"` in `~/.config/hwatu/config.json`
@@ -115,7 +115,7 @@ hwatu quit                 # stop the daemon
   - `"autoplay": "muted"|"deny"`: the env var wins for a single run
     but vanishes on daemon restart.
   - `"preferred_width": 0.25`: initial window width as a fraction of
-    the monitor width, between 0 and 1. Default is one third.
+    the monitor width, between 0 and 1. Default is one half.
 - Env-only gates, read at window creation: `HWATU_FOCUS_SHIELD=0`,
   `HWATU_BLUR_SHIELD=0`, `HWATU_DISABLE_MEDIA=1`.
 


### PR DESCRIPTION
## Summary
- suppress false failure overlays for cancelled history navigation
- allow non-answer keys through browser confirmation prompts
- default new windows to half-width while preserving preferred_width configuration
- keep user-activated desktop links visible inside agent environments

## Validation
- cargo fmt --all --check
- cargo test --workspace (252 passed, 1 ignored)