### PR TITLE
Browser QoL: ctrl-click tabs, trusted paste, contenteditable fixes, MediaStream wedge fix

### DIFF
--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -989,6 +989,28 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                 timeout_ms,
             })
         }
+        Some("paste") => {
+            let selector = if r#ref.is_some() {
+                None
+            } else {
+                Some(
+                    rest.get(1)
+                        .ok_or("usage: hwatu paste [--id <id>] (<selector> | --ref <n>)")?
+                        .to_string(),
+                )
+            };
+            if selector.is_none() && r#ref.is_none() {
+                return Err("usage: hwatu paste [--id <id>] (<selector> | --ref <n>)".into());
+            }
+            Ok(Request::Paste {
+                id,
+                selector,
+                nth,
+                contains,
+                r#ref,
+                timeout_ms,
+            })
+        }
         Some("console") => Ok(Request::Console { id, clear, limit }),
         Some("net") => Ok(Request::Net { id, clear, limit }),
         Some("focus") => {
@@ -1053,9 +1075,10 @@ const USAGE: &str = "usage: hwatu [--app-id <id>] [--background|--headless|--foc
 | scroll [--id <id>] [<selector> [nth]] [--contains <text>] [--to-y <px>] [--by <pages>] \
 | snapshot [--id <id>] [--diff] [--rect] \
 | expect [--id <id>] <selector> [--contains <filter>] [--text <substring>] [--absent] [--visible] [--nth <n>] [--timeout-ms <ms>] [--watch] \
-| click [--id <id>] [--trusted] (<selector> [nth] [--contains <text>] | --ref <n>) \
-| type [--id <id>] [--trusted] (<selector> | --ref <n>) <text> [--enter] [--no-clear] \
-| console [--id <id>] [--clear] [--limit <n>] \
+	| click [--id <id>] [--trusted] (<selector> [nth] [--contains <text>] | --ref <n>) \
+	| type [--id <id>] [--trusted] (<selector> | --ref <n>) <text> [--enter] [--no-clear] \
+	| paste [--id <id>] (<selector> | --ref <n>) \
+	| console [--id <id>] [--clear] [--limit <n>] \
 | net [--id <id>] [--clear] [--limit <n>] \
 | motion [--id <id>] [--observe [--ms <ms>]] \
 | resize [--id <id>] <width>x<height> \
@@ -2094,6 +2117,41 @@ mod tests {
         assert!(!clear);
         assert!(parse(&args(&["type", "input"])).is_err());
         assert!(parse(&args(&["type"])).is_err());
+    }
+
+    #[test]
+    fn paste_targets_selector_or_ref() {
+        let Ok(Request::Paste {
+            selector,
+            nth,
+            contains,
+            r#ref,
+            ..
+        }) = parse(&args(&[
+            "paste",
+            "textarea",
+            "--nth",
+            "2",
+            "--contains",
+            "Bio",
+        ]))
+        else {
+            panic!("expected Paste");
+        };
+        assert_eq!(selector.as_deref(), Some("textarea"));
+        assert_eq!(nth, Some(2));
+        assert_eq!(contains.as_deref(), Some("Bio"));
+        assert!(r#ref.is_none());
+
+        let Ok(Request::Paste {
+            selector, r#ref, ..
+        }) = parse(&args(&["paste", "--ref", "4"]))
+        else {
+            panic!("expected Paste");
+        };
+        assert!(selector.is_none());
+        assert_eq!(r#ref, Some(4));
+        assert!(parse(&args(&["paste"])).is_err());
     }
 
     #[test]

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -694,7 +694,9 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
             "click",
             "Click an element by CSS selector (disambiguate with nth/contains) or \
              by `ref` from the last snapshot. Dispatches JS pointer events by \
-             default; trusted=true requests native trusted input synthesis.",
+             default; trusted=true requests native trusted input synthesis. \
+             Trusted input is refused for background/headless windows because \
+             compositor delivery would visibly focus them.",
             json!({
                 "id": prop("integer", ID_DESC),
                 "selector": prop("string", "CSS selector."),
@@ -709,7 +711,9 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
             "type_text",
             "Type into an input/textarea/select/contenteditable, targeted like \
              click. Uses native setters + input/change events by default; \
-             trusted=true requests native trusted key input synthesis.",
+             trusted=true requests native trusted key input synthesis. Trusted \
+             input is refused for background/headless windows because compositor \
+             delivery would visibly focus them.",
             json!({
                 "id": prop("integer", ID_DESC),
                 "selector": prop("string", "CSS selector."),
@@ -727,7 +731,9 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
             "paste",
             "Paste from the compositor clipboard into an element targeted like click. \
              Always uses native trusted input: clicks/focuses the element, then \
-             presses Ctrl+V with wtype while the daemon owns compositor focus.",
+             presses Ctrl+V with wtype while the daemon owns compositor focus. \
+             Refused for background/headless windows to preserve headless focus \
+             isolation.",
             json!({
                 "id": prop("integer", ID_DESC),
                 "selector": prop("string", "CSS selector."),

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -403,6 +403,21 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
                 timeout_ms,
             })
         }
+        "paste" => {
+            let selector = opt_str(args, "selector");
+            let r#ref = opt_u32(args, "ref");
+            if selector.is_none() && r#ref.is_none() {
+                return Err("paste needs `selector` or `ref`".into());
+            }
+            Ok(Request::Paste {
+                id,
+                selector,
+                nth: opt_u32(args, "nth"),
+                contains: opt_str(args, "contains"),
+                r#ref,
+                timeout_ms,
+            })
+        }
         "scroll" => Ok(Request::Scroll {
             id,
             selector: opt_str(args, "selector"),
@@ -707,6 +722,20 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
                 "enter": prop("boolean", "Press Enter afterwards (submits the form if unhandled)."),
             }),
             &["text"],
+        ),
+        tool(
+            "paste",
+            "Paste from the compositor clipboard into an element targeted like click. \
+             Always uses native trusted input: clicks/focuses the element, then \
+             presses Ctrl+V with wtype while the daemon owns compositor focus.",
+            json!({
+                "id": prop("integer", ID_DESC),
+                "selector": prop("string", "CSS selector."),
+                "nth": prop("integer", "0-based index among selector matches."),
+                "contains": prop("string", "Keep only matches whose text contains this."),
+                "ref": prop("integer", "Interactable index from the last snapshot."),
+            }),
+            &[],
         ),
         tool(
             "eval",
@@ -1084,6 +1113,33 @@ mod tests {
     }
 
     #[test]
+    fn paste_requires_selector_or_ref() {
+        assert!(build_request("paste", &json!({})).is_err());
+        let Request::Paste { r#ref, .. } = build_request("paste", &json!({ "ref": 4 })).unwrap()
+        else {
+            panic!("expected Paste");
+        };
+        assert_eq!(r#ref, Some(4));
+
+        let Request::Paste {
+            selector,
+            nth,
+            contains,
+            ..
+        } = build_request(
+            "paste",
+            &json!({ "selector": "textarea", "nth": 1, "contains": "Bio" }),
+        )
+        .unwrap()
+        else {
+            panic!("expected Paste");
+        };
+        assert_eq!(selector.as_deref(), Some("textarea"));
+        assert_eq!(nth, Some(1));
+        assert_eq!(contains.as_deref(), Some("Bio"));
+    }
+
+    #[test]
     fn batch_actions_builds_and_rejects_unsupported_steps() {
         let Request::Batch { actions } = build_request(
             "batch_actions",
@@ -1182,6 +1238,7 @@ mod tests {
             "expect": { "selector": "h1" },
             "click": { "ref": 0 },
             "type_text": { "ref": 0, "text": "x" },
+            "paste": { "ref": 0 },
             "eval": { "js": "1+1" },
             "console": {},
             "net": {},

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -2807,7 +2807,18 @@ if (el instanceof HTMLSelectElement) {{
   setter.call(el, clear ? text : el.value + text);
   fire('input'); fire('change');
 }} else if (el.isContentEditable) {{
-  if (clear) el.textContent = '';
+  if (clear) {{
+    // Select the existing editor contents instead of mutating textContent.
+    // Rich editors such as Google Sheets keep an internal model that only
+    // observes editing commands; direct DOM clearing desynchronizes it and
+    // causes the replacement text to be appended to the old value.
+    const doc = el.ownerDocument;
+    const selection = doc.getSelection();
+    const range = doc.createRange();
+    range.selectNodeContents(el);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }}
   el.dispatchEvent(new InputEvent('beforeinput', {{ bubbles: true, cancelable: true, inputType: 'insertText', data: text }}));
   document.execCommand ? document.execCommand('insertText', false, text) : el.textContent += text;
   fire('input');
@@ -2817,6 +2828,7 @@ if (el instanceof HTMLSelectElement) {{
 if (enter) {{
   const key = {{ bubbles: true, cancelable: true, key: 'Enter', code: 'Enter', keyCode: 13, which: 13 }};
   const handled = !el.dispatchEvent(new KeyboardEvent('keydown', key));
+  el.dispatchEvent(new KeyboardEvent('keypress', key));
   el.dispatchEvent(new KeyboardEvent('keyup', key));
   if (!handled && el.form) el.form.requestSubmit ? el.form.requestSubmit() : el.form.submit();
 }}

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -2534,6 +2534,17 @@ enum TrustedAction {
     },
 }
 
+fn trusted_input_mode_error(mode: OpenMode) -> Option<&'static str> {
+    match mode {
+        OpenMode::Normal => None,
+        OpenMode::Background | OpenMode::Headless => Some(
+            "trusted input is unavailable for background/headless windows because native \
+             compositor events would promote and focus the window; use standard headless \
+             automation or explicitly open a normal window",
+        ),
+    }
+}
+
 /// Shared driver for trusted click/type. Sequence, all on the GTK main
 /// thread (the injection itself talks to the compositor over a private
 /// Wayland connection, which is fine to block on for a few ms):
@@ -2572,6 +2583,9 @@ fn trusted_input_run(
         Ok(w) => w,
         Err(resp) => return reply.send(*resp),
     };
+    if let Some(message) = trusted_input_mode_error(win.mode()) {
+        return reply.send(Response::err(format!("{what} refused: {message}")));
+    }
     let view = match live_view(&win) {
         Ok(v) => v,
         Err(resp) => return reply.send(*resp),
@@ -2941,8 +2955,9 @@ fn mime_from_extension(path: &str) -> &'static str {
 mod tests {
     use super::{
         base64, challenge_detect_js, challenge_wait_js, expect_watch_js, plan_eval_source,
-        ExpectSpec, VISIBILITY_INSPECTOR_JS,
+        trusted_input_mode_error, ExpectSpec, VISIBILITY_INSPECTOR_JS,
     };
+    use hwatu_ipc::OpenMode;
 
     #[test]
     fn base64_matches_rfc_vectors() {
@@ -2953,6 +2968,15 @@ mod tests {
         assert_eq!(base64(b"foob"), "Zm9vYg==");
         assert_eq!(base64(b"fooba"), "Zm9vYmE=");
         assert_eq!(base64(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn trusted_input_never_promotes_non_normal_windows() {
+        assert_eq!(trusted_input_mode_error(OpenMode::Normal), None);
+        for mode in [OpenMode::Background, OpenMode::Headless] {
+            let message = trusted_input_mode_error(mode).expect("mode must be refused");
+            assert!(message.contains("would promote and focus the window"));
+        }
     }
 
     #[test]

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -2526,6 +2526,7 @@ fn trusted_report(
 /// What a trusted injection does with the resolved target point.
 enum TrustedAction {
     Click,
+    Paste,
     Type {
         text: String,
         clear: bool,
@@ -2563,6 +2564,7 @@ fn trusted_input_run(
 ) {
     let what: &'static str = match action {
         TrustedAction::Click => "trusted click",
+        TrustedAction::Paste => "trusted paste",
         TrustedAction::Type { .. } => "trusted type",
     };
     let reply = OnceReply::new(reply);
@@ -2642,6 +2644,9 @@ fn trusted_input_run(
                         TrustedAction::Click => {
                             crate::trusted_input::inject_click(&win, &view_for_cb, &target).await
                         }
+                        TrustedAction::Paste => {
+                            crate::trusted_input::inject_paste(&win, &view_for_cb, &target).await
+                        }
                         TrustedAction::Type { text, clear, enter } => {
                             crate::trusted_input::inject_type(
                                 &win,
@@ -2661,6 +2666,7 @@ fn trusted_input_run(
                     let url = view_for_cb.uri().map(|u| u.to_string());
                     let done = match action {
                         TrustedAction::Click => "clicked",
+                        TrustedAction::Paste => "pasted",
                         TrustedAction::Type { .. } => "typed",
                     };
                     // Give the compositor round-trip + page handlers a
@@ -2809,6 +2815,33 @@ return {{ typed: matched, value: String(value).slice(0, 200), url: location.href
         enter = enter,
     );
     eval_with(daemon, id, js, timeout_ms, NavPolicy::Success, reply);
+}
+
+/// Paste from the compositor clipboard into an element with native trusted
+/// input. This intentionally has no JS fallback: clipboard pasting must happen
+/// through the compositor while the trusted input session owns focus.
+#[allow(clippy::too_many_arguments)]
+pub fn paste(
+    daemon: &Rc<Daemon>,
+    id: Option<u64>,
+    selector: Option<String>,
+    nth: Option<u32>,
+    contains: Option<String>,
+    ref_idx: Option<u32>,
+    timeout_ms: Option<u64>,
+    reply: Reply,
+) {
+    trusted_input_run(
+        daemon,
+        id,
+        selector,
+        nth,
+        contains,
+        ref_idx,
+        TrustedAction::Paste,
+        timeout_ms,
+        reply,
+    );
 }
 
 /// Read a window's console/error/network capture buffer. Synchronous

--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -282,6 +282,18 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
                 timeout_ms, reply,
             );
         }
+        Request::Paste {
+            id,
+            selector,
+            nth,
+            contains,
+            r#ref,
+            timeout_ms,
+        } => {
+            return automation::paste(
+                daemon, id, selector, nth, contains, r#ref, timeout_ms, reply,
+            );
+        }
         Request::Motion {
             id,
             observe,
@@ -439,6 +451,7 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
         | Request::Snapshot { .. }
         | Request::Click { .. }
         | Request::Type { .. }
+        | Request::Paste { .. }
         | Request::Motion { .. }
         | Request::Seek { .. }
         | Request::Clock { .. }

--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -90,6 +90,14 @@
 //! the handler is swallowed before `preventDefault`, so a bug degrades
 //! to engine-native scrolling, never to a dead wheel.
 //!
+//! Sensitivity: WebKitGTK synthesizes ~100px per discrete wheel notch
+//! while Chromium on Linux moves 120px (3 lines x 40px), so an
+//! otherwise identical curve still reads as "stiffer" — every click
+//! travels ~17% less. Discrete deltas are therefore scaled by
+//! `HWATU_WHEEL_SENSITIVITY` (default 1.2, matching Chromium) before
+//! entering the animator. Precise touchpad deltas are untouched: they
+//! are real hardware pixel values, not synthesized line steps.
+//!
 //! `HWATU_SMOOTH_WHEEL=0` disables the whole thing.
 
 /// See module docs. Constants mirror Chromium
@@ -106,6 +114,13 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
   const SLOPE = (MIN_DUR - MAX_DUR) / (RAMP_END - RAMP_START);
   const OFFSET = MAX_DUR - RAMP_START * SLOPE;
   const EPS = 0.01;
+
+  // Discrete-notch multiplier, substituted at injection time from
+  // HWATU_WHEEL_SENSITIVITY. Default 1.2: WebKitGTK synthesizes ~100px
+  // per notch where Chromium moves 120px, and matching Chromium's
+  // travel-per-click is what kills the "stiff" feel. Precise touchpad
+  // deltas are never scaled (real hardware values).
+  const SENS = /*HWATU_WHEEL_SENSITIVITY*/1.2;
 
   function durationMs(delta) {
     const frames = Math.min(Math.max(OFFSET + Math.abs(delta) * SLOPE, MIN_DUR), MAX_DUR);
@@ -654,6 +669,9 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
       let dx = e.deltaX, dy = e.deltaY;
       if (e.deltaMode === 1) { dx *= 40; dy *= 40; }
       else if (e.deltaMode === 2) { dx *= innerWidth; dy *= innerHeight; }
+      // Sensitivity applies to synthesized notch deltas (pixel/line
+      // modes); page-mode deltas are already viewport-sized.
+      if (e.deltaMode !== 2) { dx *= SENS; dy *= SENS; }
       if (e.shiftKey && !dx) { dx = dy; dy = 0; }
 
       const horiz = Math.abs(dx) > Math.abs(dy);
@@ -956,6 +974,29 @@ fn enabled() -> bool {
     )
 }
 
+/// Discrete-notch multiplier from `HWATU_WHEEL_SENSITIVITY`.
+/// Default 1.2 (Chromium's 120px per notch vs WebKitGTK's ~100px).
+/// Unparseable or non-positive values fall back to the default;
+/// the value is clamped to [0.1, 10] so a typo can't produce a
+/// dead or teleporting wheel.
+fn sensitivity() -> f64 {
+    const DEFAULT: f64 = 1.2;
+    std::env::var("HWATU_WHEEL_SENSITIVITY")
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .map(|v| v.clamp(0.1, 10.0))
+        .unwrap_or(DEFAULT)
+}
+
+/// The injected script with the sensitivity constant substituted.
+fn script_source() -> String {
+    SMOOTH_WHEEL_JS.replace(
+        "/*HWATU_WHEEL_SENSITIVITY*/1.2",
+        &format!("{}", sensitivity()),
+    )
+}
+
 /// Inject the wheel animator into a WebView. Must run on every view
 /// (prewarm pool and popups) before page content loads, same contract
 /// as `console::wire_view`.
@@ -968,7 +1009,7 @@ pub fn wire_view(view: &webkit6::WebView) {
         return;
     };
     let script = webkit6::UserScript::new(
-        SMOOTH_WHEEL_JS,
+        &script_source(),
         webkit6::UserContentInjectedFrames::AllFrames,
         webkit6::UserScriptInjectionTime::Start,
         &[],
@@ -995,6 +1036,57 @@ mod tests {
         std::env::set_var("HWATU_SMOOTH_WHEEL", "1");
         assert!(enabled());
         std::env::remove_var("HWATU_SMOOTH_WHEEL");
+    }
+
+    /// Sensitivity: default 1.2 (Chromium's per-notch travel), env
+    /// override honored, garbage and out-of-range values fail safe,
+    /// and the templating substitutes the constant into the script.
+    /// One test because parallel tests must not race the env var.
+    #[test]
+    fn sensitivity_env_semantics() {
+        std::env::remove_var("HWATU_WHEEL_SENSITIVITY");
+        assert_eq!(sensitivity(), 1.2);
+        let src = script_source();
+        assert!(src.contains("const SENS = 1.2;"));
+        assert!(!src.contains("/*HWATU_WHEEL_SENSITIVITY*/"));
+        std::env::set_var("HWATU_WHEEL_SENSITIVITY", "1.0");
+        assert_eq!(sensitivity(), 1.0);
+        std::env::set_var("HWATU_WHEEL_SENSITIVITY", "2.5");
+        assert_eq!(sensitivity(), 2.5);
+        std::env::set_var("HWATU_WHEEL_SENSITIVITY", "1.5");
+        assert!(script_source().contains("const SENS = 1.5;"));
+        // Clamped, not rejected: stays usable.
+        std::env::set_var("HWATU_WHEEL_SENSITIVITY", "50");
+        assert_eq!(sensitivity(), 10.0);
+        std::env::set_var("HWATU_WHEEL_SENSITIVITY", "0.01");
+        assert_eq!(sensitivity(), 0.1);
+        // Garbage / non-positive fall back to the default.
+        for bad in ["", "abc", "0", "-1", "nan", "inf"] {
+            std::env::set_var("HWATU_WHEEL_SENSITIVITY", bad);
+            assert_eq!(sensitivity(), 1.2, "value {bad:?} must fall back");
+        }
+        std::env::remove_var("HWATU_WHEEL_SENSITIVITY");
+    }
+
+    /// The scale must apply to discrete pixel/line deltas but never to
+    /// page-mode deltas or the precise-touchpad path.
+    #[test]
+    fn sensitivity_script_shape() {
+        // Scaling happens after page-mode normalization and skips it,
+        // and before the shift-key axis swap so both axes are scaled.
+        let handler = SMOOTH_WHEEL_JS
+            .split("addEventListener('wheel'")
+            .nth(1)
+            .unwrap();
+        let page = handler.find("e.deltaMode === 2").unwrap();
+        let sens = handler
+            .find("if (e.deltaMode !== 2) { dx *= SENS; dy *= SENS; }")
+            .unwrap();
+        let swap = handler.find("if (e.shiftKey && !dx)").unwrap();
+        assert!(page < sens && sens < swap);
+        // The precise arm returns before the scaling line.
+        let precise = handler.find("!isDiscrete(e)").unwrap();
+        assert!(precise < sens);
     }
 
     /// The injected script must keep its fail-open shape: bail on

--- a/crates/hwatud/src/trusted_input.rs
+++ b/crates/hwatud/src/trusted_input.rs
@@ -364,6 +364,20 @@ pub async fn inject_type(
     Ok(report)
 }
 
+pub async fn inject_paste(
+    win: &Rc<BrowserWindow>,
+    view: &webkit6::WebView,
+    target: &TargetPoint,
+) -> Result<InputReport, String> {
+    // The click both proves delivery (calibration) and moves keyboard
+    // focus to the target's window + element before wtype sends Ctrl+V.
+    let report = inject_click(win, view, target).await?;
+    glib::timeout_future(Duration::from_millis(60)).await;
+    run_wtype(&["-M", "ctrl", "v", "-m", "ctrl"])?;
+    glib::timeout_future(Duration::from_millis(180)).await;
+    Ok(report)
+}
+
 struct WlState;
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for WlState {

--- a/crates/hwatud/src/trusted_input.rs
+++ b/crates/hwatud/src/trusted_input.rs
@@ -231,25 +231,30 @@ pub struct InputReport {
 }
 
 /// Window-state guard for a trusted-input run: promotes + fullscreens
-/// the window on `prepare`, restores the previous state on `finish`
-/// (idempotent, shared across the racing callbacks via `Clone`).
+/// the window on `prepare`, restores the previous state and compositor
+/// focus on `finish` (idempotent, shared across the racing callbacks via
+/// `Clone`).
 #[derive(Clone)]
 pub struct TrustedSession {
     win: Rc<BrowserWindow>,
     was_fullscreen: bool,
     promoted: bool,
+    prior_niri_focus: Option<u64>,
     finished: Rc<Cell<bool>>,
 }
 
 pub fn prepare(win: &Rc<BrowserWindow>) -> TrustedSession {
     let was_fullscreen = win.window.is_fullscreen();
     let promoted = win.mode() != OpenMode::Normal;
+    // Native trusted input must temporarily focus a mapped compositor
+    // surface. Remember what the user was actually using before doing so;
+    // merely hiding the promoted headless window afterwards lets the WM
+    // choose an arbitrary successor and visibly strands keyboard focus.
+    let prior_niri_focus = focused_niri_window();
     // Best-effort compositor-side focus first: on niri this also switches
     // to the window's workspace, which fullscreen alone does not do.
     if let Ok(id) = find_niri_window(win) {
-        let _ = Command::new("niri")
-            .args(["msg", "action", "focus-window", "--id", &id.to_string()])
-            .status();
+        let _ = focus_niri_window(id);
     }
     win.present();
     if !was_fullscreen {
@@ -259,6 +264,7 @@ pub fn prepare(win: &Rc<BrowserWindow>) -> TrustedSession {
         win: win.clone(),
         was_fullscreen,
         promoted,
+        prior_niri_focus,
         finished: Rc::new(Cell::new(false)),
     }
 }
@@ -273,6 +279,9 @@ impl TrustedSession {
         }
         if self.promoted {
             self.win.unfocus();
+        }
+        if let Some(id) = self.prior_niri_focus {
+            let _ = focus_niri_window(id);
         }
     }
 }
@@ -688,6 +697,38 @@ fn run_wtype(args: &[&str]) -> Result<(), String> {
     }
 }
 
+fn focus_niri_window(id: u64) -> Result<(), String> {
+    let status = Command::new("niri")
+        .args(["msg", "action", "focus-window", "--id", &id.to_string()])
+        .status()
+        .map_err(|e| format!("failed to focus niri window {id}: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("niri failed to focus window {id}: {status}"))
+    }
+}
+
+fn focused_niri_window_id(windows: &Value) -> Option<u64> {
+    let focused = windows
+        .as_array()?
+        .iter()
+        .find(|window| window.get("is_focused").and_then(Value::as_bool) == Some(true))?;
+    focused.get("id").and_then(Value::as_u64)
+}
+
+fn focused_niri_window() -> Option<u64> {
+    let out = Command::new("niri")
+        .args(["msg", "--json", "windows"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let windows: Value = serde_json::from_slice(&out.stdout).ok()?;
+    focused_niri_window_id(&windows)
+}
+
 /// Best-effort niri window lookup (pid + title). Used only to ask niri
 /// to focus the window (which also switches to its workspace); all
 /// coordinate work is calibration-based and compositor-agnostic.
@@ -738,7 +779,8 @@ fn find_niri_window(win: &Rc<BrowserWindow>) -> Result<u64, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::RESOLVER_JS;
+    use super::{focused_niri_window_id, RESOLVER_JS};
+    use serde_json::json;
 
     #[test]
     fn resolver_is_all_frames_shape() {
@@ -752,5 +794,17 @@ mod tests {
         assert!(RESOLVER_JS.contains("__hwatuLastTrustedMove"));
         assert!(RESOLVER_JS.contains("__hwatuTrustedMove"));
         assert!(RESOLVER_JS.contains("mousemove"));
+    }
+
+    #[test]
+    fn focused_niri_window_id_selects_only_focused_window() {
+        let windows = json!([
+            {"id": 10, "is_focused": false},
+            {"id": 11, "is_focused": true},
+            {"id": 12, "is_focused": false}
+        ]);
+        assert_eq!(focused_niri_window_id(&windows), Some(11));
+        assert_eq!(focused_niri_window_id(&json!([])), None);
+        assert_eq!(focused_niri_window_id(&json!({"id": 11})), None);
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -85,6 +85,32 @@ fn is_ctrl_click_link(
         && modifiers & gtk::gdk::ModifierType::CONTROL_MASK.bits() != 0
 }
 
+/// Return the scheme for a URI that should leave the browser.
+///
+/// WebKit does not launch desktop handlers for custom schemes on behalf of
+/// embedders. Keep browser-owned schemes in the WebView and hand protocols
+/// such as `zoommtg:`, `mailto:`, and `tel:` to GIO instead. Callers must also
+/// require a user gesture so a page cannot launch native applications merely
+/// by loading.
+fn external_uri_scheme(uri: &str) -> Option<String> {
+    let (scheme, _) = uri.split_once(':')?;
+    if scheme.is_empty()
+        || !scheme.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_alphabetic()
+                || (index > 0 && (byte.is_ascii_digit() || matches!(byte, b'+' | b'-' | b'.')))
+        })
+    {
+        return None;
+    }
+
+    let scheme = scheme.to_ascii_lowercase();
+    match scheme.as_str() {
+        "http" | "https" | "about" | "data" | "blob" | "file" | "javascript" | "ws" | "wss"
+        | "hwatu" => None,
+        _ => Some(scheme),
+    }
+}
+
 /// Media autoplay policy for every WebView. WebKit's own default is
 /// ALLOW_WITHOUT_SOUND, which is why video sites autoplay muted: their
 /// unmuted-play probe is rejected, so they fall back to a muted player.
@@ -1019,7 +1045,11 @@ impl BrowserWindow {
         // user-agent.
         let this = self.clone();
         webview.connect_decide_policy(move |wv, decision, decision_type| {
-            if decision_type == webkit6::PolicyDecisionType::NavigationAction {
+            if matches!(
+                decision_type,
+                webkit6::PolicyDecisionType::NavigationAction
+                    | webkit6::PolicyDecisionType::NewWindowAction
+            ) {
                 let Some(navigation) =
                     decision.dynamic_cast_ref::<webkit6::NavigationPolicyDecision>()
                 else {
@@ -1028,6 +1058,35 @@ impl BrowserWindow {
                 let Some(mut action) = navigation.navigation_action() else {
                     return false;
                 };
+                let Some(uri) = action.request().and_then(|request| request.uri()) else {
+                    return false;
+                };
+
+                // Native-app links need explicit embedder handling. Only
+                // honor them during a user gesture, and only when the desktop
+                // has a registered handler for the scheme. This covers Zoom's
+                // `zoommtg:` join button without allowing pages to launch
+                // arbitrary programs on load.
+                if action.is_user_gesture()
+                    && external_uri_scheme(&uri).is_some_and(|scheme| {
+                        gtk::gio::AppInfo::default_for_uri_scheme(&scheme).is_some()
+                    })
+                {
+                    decision.ignore();
+                    if let Err(error) = gtk::gio::AppInfo::launch_default_for_uri(
+                        &uri,
+                        None::<&gtk::gio::AppLaunchContext>,
+                    ) {
+                        eprintln!("hwatud: could not open external URI: {error}");
+                        this.flash_bar("could not open external application", 4);
+                    }
+                    return true;
+                }
+
+                if decision_type == webkit6::PolicyDecisionType::NewWindowAction {
+                    return false;
+                }
+
                 if !is_ctrl_click_link(
                     action.navigation_type(),
                     action.mouse_button(),
@@ -1035,10 +1094,6 @@ impl BrowserWindow {
                 ) {
                     return false;
                 }
-                let Some(uri) = action.request().and_then(|request| request.uri()) else {
-                    return false;
-                };
-
                 decision.ignore();
                 Self::open(&this.daemon, Some(uri.to_string()), None, OpenMode::Normal);
                 return true;
@@ -2099,7 +2154,9 @@ impl BrowserWindow {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_ctrl_click_link, load_was_cancelled, parse_feature_overrides};
+    use super::{
+        external_uri_scheme, is_ctrl_click_link, load_was_cancelled, parse_feature_overrides,
+    };
 
     #[test]
     fn parses_on_off_pairs() {
@@ -2233,5 +2290,32 @@ mod tests {
             ctrl
         ));
         assert!(!is_ctrl_click_link(webkit6::NavigationType::Other, 1, ctrl));
+    }
+
+    #[test]
+    fn native_app_schemes_are_external_but_browser_schemes_are_not() {
+        assert_eq!(
+            external_uri_scheme("zoommtg://zoom.us/join"),
+            Some("zoommtg".into())
+        );
+        assert_eq!(
+            external_uri_scheme("mailto:person@example.com"),
+            Some("mailto".into())
+        );
+        assert_eq!(
+            external_uri_scheme("ZOOMMTG://zoom.us/join"),
+            Some("zoommtg".into())
+        );
+        assert_eq!(
+            external_uri_scheme("web+notes:42"),
+            Some("web+notes".into())
+        );
+
+        assert_eq!(external_uri_scheme("https://zoom.us/join"), None);
+        assert_eq!(external_uri_scheme("HTTP://example.com"), None);
+        assert_eq!(external_uri_scheme("javascript:alert(1)"), None);
+        assert_eq!(external_uri_scheme("hwatu://launcher"), None);
+        assert_eq!(external_uri_scheme("not a uri"), None);
+        assert_eq!(external_uri_scheme("1invalid:value"), None);
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -72,6 +72,19 @@ fn load_was_cancelled(error: &glib::Error) -> bool {
         || error.matches(gtk::gio::IOErrorEnum::Cancelled)
 }
 
+/// Whether a navigation action is a conventional Ctrl+click on a link.
+/// WebKit reports modifiers as GDK bits but leaves tab creation to the
+/// embedder, so without this check Ctrl+click navigates the current view.
+fn is_ctrl_click_link(
+    navigation_type: webkit6::NavigationType,
+    mouse_button: u32,
+    modifiers: u32,
+) -> bool {
+    navigation_type == webkit6::NavigationType::LinkClicked
+        && mouse_button == 1
+        && modifiers & gtk::gdk::ModifierType::CONTROL_MASK.bits() != 0
+}
+
 /// Media autoplay policy for every WebView. WebKit's own default is
 /// ALLOW_WITHOUT_SOUND, which is why video sites autoplay muted: their
 /// unmuted-play probe is rejected, so they fall back to a muted player.
@@ -997,12 +1010,39 @@ impl BrowserWindow {
             let this = self.clone();
             webview.connect_close(move |_| this.window.close());
         }
-        // Non-displayable responses (Content-Disposition: attachment,
-        // MIME types WebKit can't render) become downloads instead of
-        // dead ends. Main-document responses also pass through the
-        // per-site UA switcher (mobile UI for reels-style sites),
-        // which may restart the load under the right user-agent.
-        webview.connect_decide_policy(|wv, decision, decision_type| {
+        // Ctrl+click follows the same client-tab path as Ctrl+t instead of
+        // replacing the current page. Non-displayable responses
+        // (Content-Disposition: attachment, MIME types WebKit can't render)
+        // become downloads instead of dead ends. Main-document responses
+        // also pass through the per-site UA switcher (mobile UI for
+        // reels-style sites), which may restart the load under the right
+        // user-agent.
+        let this = self.clone();
+        webview.connect_decide_policy(move |wv, decision, decision_type| {
+            if decision_type == webkit6::PolicyDecisionType::NavigationAction {
+                let Some(navigation) =
+                    decision.dynamic_cast_ref::<webkit6::NavigationPolicyDecision>()
+                else {
+                    return false;
+                };
+                let Some(mut action) = navigation.navigation_action() else {
+                    return false;
+                };
+                if !is_ctrl_click_link(
+                    action.navigation_type(),
+                    action.mouse_button(),
+                    action.modifiers(),
+                ) {
+                    return false;
+                }
+                let Some(uri) = action.request().and_then(|request| request.uri()) else {
+                    return false;
+                };
+
+                decision.ignore();
+                Self::open(&this.daemon, Some(uri.to_string()), None, OpenMode::Normal);
+                return true;
+            }
             if decision_type != webkit6::PolicyDecisionType::Response {
                 return false; // default handling
             }
@@ -2059,7 +2099,7 @@ impl BrowserWindow {
 
 #[cfg(test)]
 mod tests {
-    use super::{load_was_cancelled, parse_feature_overrides};
+    use super::{is_ctrl_click_link, load_was_cancelled, parse_feature_overrides};
 
     #[test]
     fn parses_on_off_pairs() {
@@ -2165,5 +2205,33 @@ mod tests {
     fn genuine_network_error_remains_a_page_failure() {
         let error = glib::Error::new(webkit6::NetworkError::Failed, "Connection failed");
         assert!(!load_was_cancelled(&error));
+    }
+
+    #[test]
+    fn only_ctrl_primary_link_clicks_open_new_tabs() {
+        let ctrl = gtk::gdk::ModifierType::CONTROL_MASK.bits();
+        let shift = gtk::gdk::ModifierType::SHIFT_MASK.bits();
+
+        assert!(is_ctrl_click_link(
+            webkit6::NavigationType::LinkClicked,
+            1,
+            ctrl
+        ));
+        assert!(is_ctrl_click_link(
+            webkit6::NavigationType::LinkClicked,
+            1,
+            ctrl | shift
+        ));
+        assert!(!is_ctrl_click_link(
+            webkit6::NavigationType::LinkClicked,
+            1,
+            shift
+        ));
+        assert!(!is_ctrl_click_link(
+            webkit6::NavigationType::LinkClicked,
+            3,
+            ctrl
+        ));
+        assert!(!is_ctrl_click_link(webkit6::NavigationType::Other, 1, ctrl));
     }
 }

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -382,6 +382,15 @@ fn feature_overrides() -> Vec<(String, bool)> {
 /// correct pixels until the fixes ship in a stable WebKitGTK.
 const BASELINE_FEATURE_OVERRIDES: &[(&str, bool)] = &[("PropagateDamagingInformation", false)];
 
+/// `HWATU_MEDIA_STREAM=1|on|true` re-enables the MediaStream API
+/// (getUserMedia/enumerateDevices), which is off by default; see the
+/// wedge documented at the call site in `apply_view_settings`.
+fn media_stream_enabled() -> bool {
+    std::env::var("HWATU_MEDIA_STREAM")
+        .map(|v| matches!(v.trim(), "1" | "on" | "true"))
+        .unwrap_or(false)
+}
+
 fn parse_feature_overrides(raw: &str) -> Vec<(String, bool)> {
     raw.split(',')
         .filter_map(|entry| {
@@ -450,6 +459,27 @@ fn apply_view_settings(view: &webkit6::WebView) {
         // entirely so automation against such pages stays responsive.
         if std::env::var("HWATU_DISABLE_MEDIA").is_ok_and(|v| !v.is_empty() && v != "0") {
             settings.set_enable_media(false);
+        }
+
+        // MediaStream (getUserMedia/enumerateDevices) is off unless
+        // explicitly requested. On WebKitGTK 2.52.5 + GStreamer 1.28
+        // (pipewire provider), a page calling
+        // navigator.mediaDevices.enumerateDevices() wedges the web
+        // process main thread inside
+        // GStreamerVideoCaptureDeviceManager::computeCaptureDevices —
+        // a nested g_main_context_iteration loop that never completes,
+        // pinning one core at 100% and starving JS/paint/IPC for the
+        // life of the process (reproduced on example.com with a bare
+        // enumerateDevices() call; observed in the wild via
+        // doordash.com's fingerprinting SDK, which probes devices on
+        // every page). Chromium-family browsers answer the same probe
+        // in microseconds, which is why the same sites feel fine
+        // there. With the API disabled, navigator.mediaDevices is
+        // simply absent and such probes fall through their error
+        // paths instantly. HWATU_MEDIA_STREAM=1 re-enables for actual
+        // camera/mic use.
+        if !media_stream_enabled() {
+            settings.set_enable_media_stream(false);
         }
 
         // Scrolling must hit the GPU compositor path. The default
@@ -2180,6 +2210,24 @@ mod tests {
     #[test]
     fn empty_input_is_empty() {
         assert!(parse_feature_overrides("").is_empty());
+    }
+
+    /// MediaStream stays off unless the env opt-in is exact: the
+    /// default guards against the enumerateDevices() main-thread wedge
+    /// (see apply_view_settings), so a sloppy value must not enable it.
+    #[test]
+    fn media_stream_env_gate() {
+        std::env::remove_var("HWATU_MEDIA_STREAM");
+        assert!(!super::media_stream_enabled());
+        std::env::set_var("HWATU_MEDIA_STREAM", "1");
+        assert!(super::media_stream_enabled());
+        std::env::set_var("HWATU_MEDIA_STREAM", "on");
+        assert!(super::media_stream_enabled());
+        std::env::set_var("HWATU_MEDIA_STREAM", "0");
+        assert!(!super::media_stream_enabled());
+        std::env::set_var("HWATU_MEDIA_STREAM", "yes");
+        assert!(!super::media_stream_enabled());
+        std::env::remove_var("HWATU_MEDIA_STREAM");
     }
 
     #[test]

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -342,6 +342,25 @@ pub enum Request {
         #[serde(default)]
         timeout_ms: Option<u64>,
     },
+    /// Paste from the compositor clipboard into an element targeted like
+    /// [`Request::Click`]. Always uses trusted native input synthesis: the
+    /// daemon clicks/focuses the target, then asks `wtype` to press Ctrl+V
+    /// while the trusted input session owns compositor focus.
+    Paste {
+        #[serde(default)]
+        id: Option<u64>,
+        #[serde(default)]
+        selector: Option<String>,
+        #[serde(default)]
+        nth: Option<u32>,
+        #[serde(default)]
+        contains: Option<String>,
+        /// Interactable index from the last snapshot of this window.
+        #[serde(default)]
+        r#ref: Option<u32>,
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+    },
     /// Read the window's console/error/network capture buffer:
     /// console.* calls, uncaught exceptions, unhandled rejections,
     /// failed resource loads, and HTTP >= 400 responses. `clear`
@@ -571,6 +590,7 @@ impl Request {
             Request::Snapshot { .. } => "snapshot",
             Request::Click { .. } => "click",
             Request::Type { .. } => "type",
+            Request::Paste { .. } => "paste",
             Request::Console { .. } => "console",
             Request::Net { .. } => "net",
             Request::Motion { .. } => "motion",
@@ -611,6 +631,7 @@ impl Request {
                 | Request::Snapshot { .. }
                 | Request::Click { .. }
                 | Request::Type { .. }
+                | Request::Paste { .. }
                 | Request::Console { .. }
         ) || matches!(self, Request::Expect { watch: false, .. })
     }
@@ -1175,6 +1196,46 @@ mod tests {
         assert_eq!(id, Some(4));
         assert!(clear);
         assert_eq!(limit, Some(50));
+    }
+
+    #[test]
+    fn paste_roundtrips_with_selector_or_ref() {
+        let req = Request::Paste {
+            id: Some(9),
+            selector: Some("textarea".into()),
+            nth: Some(1),
+            contains: Some("Bio".into()),
+            r#ref: None,
+            timeout_ms: Some(2500),
+        };
+        let wire = serde_json::to_string(&req).unwrap();
+        assert!(wire.contains("\"cmd\":\"paste\""));
+        let Ok(Request::Paste {
+            id,
+            selector,
+            nth,
+            contains,
+            r#ref,
+            timeout_ms,
+        }) = serde_json::from_str::<Request>(&wire)
+        else {
+            panic!("paste failed to roundtrip");
+        };
+        assert_eq!(id, Some(9));
+        assert_eq!(selector.as_deref(), Some("textarea"));
+        assert_eq!(nth, Some(1));
+        assert_eq!(contains.as_deref(), Some("Bio"));
+        assert_eq!(r#ref, None);
+        assert_eq!(timeout_ms, Some(2500));
+
+        let Ok(Request::Paste {
+            selector, r#ref, ..
+        }) = serde_json::from_str::<Request>(r#"{"cmd":"paste","ref":7}"#)
+        else {
+            panic!("paste ref failed to parse");
+        };
+        assert!(selector.is_none());
+        assert_eq!(r#ref, Some(7));
     }
 
     /// Subscribe roundtrips with and without filters; a bare


### PR DESCRIPTION
Seven QoL and performance fixes for interactive browsing:

- **browser: open ctrl-clicked links in new tabs** — standard browser convention.
- **browser: open native app links via desktop handlers** — mailto/tel/etc. hand off to the desktop.
- **Add trusted native paste automation** — `hwatu paste` delivers real clipboard events.
- **Preserve focus isolation for headless automation** — headless windows no longer steal input focus.
- **Fix replacing contenteditable text** — typing into rich-text editors replaces instead of appending.
- **smoothwheel: scale discrete wheel deltas to Chromium's 120px/notch** — wheel scrolling covers the distance users expect.
- **Disable MediaStream API by default** — fixes sites feeling drastically slower than Chromium. On WebKitGTK 2.52.5 + GStreamer 1.28 (pipewire provider), `navigator.mediaDevices.enumerateDevices()` wedges the web process main thread inside `GStreamerVideoCaptureDeviceManager::computeCaptureDevices` (nested glib loop never completes, 100% CPU for the process lifetime). Reproduced with a bare `enumerateDevices()` on example.com; hit in the wild by doordash.com's fingerprinting SDK. With `enable-media-stream` off, `navigator.mediaDevices` is absent and probes fail fast. `HWATU_MEDIA_STREAM=1` re-enables for real camera/mic use. Verified live: DoorDash settles at ~1% CPU after the fix vs a permanent 100% spin before.

All workspace tests pass (rebased on current main).
