### PR TITLE
docs(roadmap): D4 niri-native integration tier (H28-H40)

### DIFF
--- a/crates/hwatud/examples/inject_scroll.rs
+++ b/crates/hwatud/examples/inject_scroll.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Justin Hong
+//! Inject real compositor-level touchpad scrolling for smoothwheel
+//! verification. Creates a wlr virtual pointer, moves it over the
+//! focused window, and streams finger-sourced axis events — the same
+//! event class a physical two-finger touchpad swipe produces — so the
+//! whole native pipeline (compositor -> GTK -> WebKit -> smoothwheel
+//! script) is exercised, not synthetic page-JS WheelEvents.
+//!
+//! Usage: cargo run --example inject_scroll -p hwatud -- <x> <y> <dy> <events> [dx]
+//! Not shipped; developer tool for scroll-path verification.
+
+use wayland_client::protocol::{wl_output, wl_pointer, wl_registry, wl_seat};
+use wayland_client::{
+    globals::{registry_queue_init, GlobalListContents},
+    Connection, Dispatch, QueueHandle,
+};
+use wayland_protocols_wlr::virtual_pointer::v1::client::{
+    zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1,
+    zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1,
+};
+
+struct S;
+impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for S {
+    fn event(
+        _: &mut Self,
+        _: &wl_registry::WlRegistry,
+        _: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_seat::WlSeat, ()> for S {
+    fn event(
+        _: &mut Self,
+        _: &wl_seat::WlSeat,
+        _: wl_seat::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_output::WlOutput, ()> for S {
+    fn event(
+        _: &mut Self,
+        _: &wl_output::WlOutput,
+        _: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<ZwlrVirtualPointerManagerV1, ()> for S {
+    fn event(
+        _: &mut Self,
+        _: &ZwlrVirtualPointerManagerV1,
+        _: <ZwlrVirtualPointerManagerV1 as wayland_client::Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<ZwlrVirtualPointerV1, ()> for S {
+    fn event(
+        _: &mut Self,
+        _: &ZwlrVirtualPointerV1,
+        _: <ZwlrVirtualPointerV1 as wayland_client::Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+fn now_ms() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u32
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let x: f64 = args[0].parse().unwrap();
+    let y: f64 = args[1].parse().unwrap();
+    let dy: f64 = args[2].parse().unwrap();
+    let n: usize = args[3].parse().unwrap();
+    let dx: f64 = args.get(4).map(|v| v.parse().unwrap()).unwrap_or(0.0);
+
+    let conn = Connection::connect_to_env().expect("wayland connect");
+    let (globals, mut queue) = registry_queue_init::<S>(&conn).expect("globals");
+    let qh = queue.handle();
+    let manager: ZwlrVirtualPointerManagerV1 = globals
+        .bind(&qh, 1..=2, ())
+        .expect("virtual pointer manager");
+    let seat: Option<wl_seat::WlSeat> = globals.bind(&qh, 1..=9, ()).ok();
+    let output: Option<wl_output::WlOutput> = globals.bind(&qh, 1..=4, ()).ok();
+    let ptr =
+        manager.create_virtual_pointer_with_output::<_, S>(seat.as_ref(), output.as_ref(), &qh, ());
+    conn.flush().unwrap();
+    let mut s = S;
+    let _ = queue.roundtrip(&mut s);
+
+    // Park the pointer over the target so the scroll hits the window.
+    ptr.motion_absolute(now_ms(), x as u32, y as u32, 1920, 1080);
+    ptr.frame();
+    conn.flush().unwrap();
+    let _ = queue.roundtrip(&mut s);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Finger-sourced continuous axis stream: what a two-finger
+    // touchpad swipe looks like on the wire. No axis_discrete, so
+    // GTK/WebKit treat it as precise deltas. Deltas vary per frame
+    // like a real finger (a perfectly uniform stream would look like
+    // a quantized hi-res wheel to delta-GCD detectors, which is not
+    // what a touchpad produces).
+    const JITTER: [f64; 8] = [1.0, 1.31, 0.83, 1.19, 0.91, 1.27, 0.77, 1.13];
+    for i in 0..n {
+        let t = now_ms();
+        let j = JITTER[i % JITTER.len()];
+        ptr.axis_source(wl_pointer::AxisSource::Finger);
+        if dy != 0.0 {
+            ptr.axis(t, wl_pointer::Axis::VerticalScroll, dy * j);
+        }
+        if dx != 0.0 {
+            ptr.axis(t, wl_pointer::Axis::HorizontalScroll, dx * j);
+        }
+        ptr.frame();
+        conn.flush().unwrap();
+        let _ = queue.roundtrip(&mut s);
+        std::thread::sleep(std::time::Duration::from_millis(12));
+    }
+    // Scroll stop, like libinput sends on finger lift.
+    let t = now_ms();
+    ptr.axis_source(wl_pointer::AxisSource::Finger);
+    ptr.axis_stop(t, wl_pointer::Axis::VerticalScroll);
+    if dx != 0.0 {
+        ptr.axis_stop(t, wl_pointer::Axis::HorizontalScroll);
+    }
+    ptr.frame();
+    conn.flush().unwrap();
+    let _ = queue.roundtrip(&mut s);
+    println!("injected {n} finger axis frames at {x},{y} dy={dy} dx={dx}");
+}

--- a/crates/hwatud/src/console.rs
+++ b/crates/hwatud/src/console.rs
@@ -48,15 +48,19 @@ pub struct Entry {
     pub page: Option<String>,
 }
 
-/// True when Cloudflare says its challenge cannot run in this browser.
+/// True when Cloudflare rejects or abandons its challenge in this browser.
 ///
 /// 110500 is the documented unsupported-browser error.  The 600 family is a
 /// generic execution rejection, and is what Turnstile currently emits after
-/// detecting WebKitGTK's deliberately generic WebGL fingerprint.
+/// detecting WebKitGTK's deliberately generic WebGL fingerprint. Managed
+/// challenges can also tear down the widget without emitting either code;
+/// their final signal is the "Cannot find Widget" cleanup warning.
 pub fn is_turnstile_compat_error(entry: &Entry) -> bool {
     entry.kind == "console"
-        && entry.text.contains("[Cloudflare Turnstile] Error:")
-        && (entry.text.contains("Error: 110500") || entry.text.contains("Error: 600"))
+        && ((entry.text.contains("[Cloudflare Turnstile] Error:")
+            && (entry.text.contains("Error: 110500") || entry.text.contains("Error: 600")))
+            || (entry.text.contains("[Cloudflare Turnstile]")
+                && entry.text.contains("Cannot find Widget")))
 }
 
 fn now_ms() -> u64 {
@@ -292,7 +296,11 @@ mod tests {
         assert!(is_turnstile_compat_error(&e));
         e.text = "[Cloudflare Turnstile] Error: 110500.".into();
         assert!(is_turnstile_compat_error(&e));
+        e.text = "[Cloudflare Turnstile] Cannot find Widget cf-chl-widget-r2uax, consider using turnstile.remove() to clean up a widget.".into();
+        assert!(is_turnstile_compat_error(&e));
         e.text = "unrelated API Error: 600010".into();
+        assert!(!is_turnstile_compat_error(&e));
+        e.text = "Cannot find Widget in unrelated code".into();
         assert!(!is_turnstile_compat_error(&e));
         e.text = "[Cloudflare Turnstile] Error: 200500.".into();
         assert!(!is_turnstile_compat_error(&e));

--- a/crates/hwatud/src/keys.rs
+++ b/crates/hwatud/src/keys.rs
@@ -54,6 +54,8 @@ pub enum Action {
     Fullscreen,
     /// Toggle page audio mute.
     Mute,
+    /// Reopen the most recently closed window (ctrl+shift+t).
+    ReopenClosed,
     /// Open the command palette (fuzzy action search in the bar).
     CommandPalette,
 }
@@ -80,6 +82,7 @@ impl Action {
         Action::ZoomReset,
         Action::Fullscreen,
         Action::Mute,
+        Action::ReopenClosed,
         Action::CommandPalette,
     ];
 
@@ -105,6 +108,7 @@ impl Action {
             Action::ZoomReset => "zoom_reset",
             Action::Fullscreen => "fullscreen",
             Action::Mute => "mute",
+            Action::ReopenClosed => "reopen_closed",
             Action::CommandPalette => "command_palette",
         }
     }
@@ -132,6 +136,7 @@ impl Action {
             Action::ZoomReset => "reset zoom",
             Action::Fullscreen => "toggle fullscreen",
             Action::Mute => "toggle video mute",
+            Action::ReopenClosed => "reopen last closed tab",
             Action::CommandPalette => "command palette",
         }
     }
@@ -170,6 +175,8 @@ impl Action {
             // Bare key, so it dispatches in the bubble phase: an `m`
             // typed into a page text box still reaches the page.
             Action::Mute => "m",
+            // The mainstream browser convention for "undo close tab".
+            Action::ReopenClosed => "ctrl+shift+t",
             // ctrl+shift+p mirrors VS Code; ctrl+k is unclaimed in
             // browsers and one chord shorter for daily use.
             Action::CommandPalette => "ctrl+k, ctrl+shift+p",
@@ -566,6 +573,12 @@ mod tests {
         // Bare m toggles mute; it must bubble so page inputs keep it.
         assert_eq!(map.lookup(Phase::Bubble, Key::m, NONE), Some(Action::Mute));
         assert_eq!(map.lookup(Phase::Capture, Key::m, NONE), None);
+        // Undo close tab, the chord everyone knows. Shift matters:
+        // bare ctrl+t opens a new window instead.
+        assert_eq!(
+            map.lookup(Phase::Capture, Key::T, CTRL | SHIFT),
+            Some(Action::ReopenClosed)
+        );
     }
 
     #[test]

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -369,6 +369,24 @@ fn main() -> glib::ExitCode {
     if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
+    // Keep GTK's scene-graph renderer on OpenGL. GTK 4.22 auto-picks
+    // its Vulkan renderer on "the best" Vulkan device, which on hybrid
+    // Intel+NVIDIA laptops is the discrete GPU — while WebKit's frames
+    // render on the integrated GPU the Wayland EGL platform selects.
+    // Every composited frame then crosses GPUs (or bounces through the
+    // CPU), and scrolling collapses to ~22fps: measured 45ms/frame
+    // scroll under GSK vulkan vs 12-17ms under GSK ngl on the same
+    // fixture (144Hz niri, i7-12650H + RTX 4050; stock MiniBrowser
+    // matches the ngl number). Vulkan is no faster even pinned to the
+    // iGPU (GDK_VULKAN_DEVICE=1: 48ms), so this is the renderer's
+    // upload path, not device selection. ngl follows the EGL platform,
+    // keeping composite on the same GPU WebKit paints with. Explicit
+    // user env always wins (GSK_RENDERER=vulkan restores GTK's pick).
+    // "gl" is the unified OpenGL renderer name on GTK 4.22+ (the
+    // 4.14-era split into gl/ngl is gone; ngl now warns and aliases).
+    if std::env::var_os("GSK_RENDERER").is_none() {
+        std::env::set_var("GSK_RENDERER", "gl");
+    }
     // Display-free operation (roadmap G4): with no usable
     // WAYLAND_DISPLAY/DISPLAY, spawn a managed headless child
     // compositor and point GTK at it. Must run before any GTK/GDK

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -76,6 +76,11 @@ pub struct Daemon {
     /// and none is focused, so an agent that opened or drove a window
     /// can keep addressing it without repeating `id`.
     pub last_target: RefCell<Option<u64>>,
+    /// Recently closed user windows, newest last, capped small.
+    /// `ctrl+shift+t` (Action::ReopenClosed) pops from here. Headless
+    /// windows (agent verification runs) and blank/launcher pages are
+    /// never recorded.
+    pub recently_closed: RefCell<Vec<session::SessionEntry>>,
     /// Idle headless windows kept for reuse by `hwatu check`, so
     /// back-to-back checks navigate a warm window instead of paying
     /// window construction + prewarm-refill per check. Entries carry
@@ -141,6 +146,7 @@ impl Daemon {
             prompt_memory: prompts::Memory::default(),
             keymap: keys::Keymap::load(),
             last_target: RefCell::new(None),
+            recently_closed: RefCell::new(Vec::new()),
             check_pool: RefCell::new(Vec::new()),
             prefetch_pool: RefCell::new(Vec::new()),
             session_save_timer: RefCell::new(None),

--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -54,7 +54,11 @@
 //! (or, on the synthetic-swipe path, as the old reel's audio playing
 //! over the transition). Deliberately no crossfade: the native apps
 //! hard-cut audio at gesture commit too, and overlapping reel audio
-//! is universally perceived as a bug.
+//! is universally perceived as a bug. Because the commit-time pick is
+//! a mid-transition guess, a settle-time reconcile runs after each
+//! page: only the front-and-center video may keep playing, everything
+//! else is paused — a wrong guess otherwise leaked an off-screen
+//! reel's audio under the watched one indefinitely.
 //!
 //! Keyboard scrolling (Arrow/Page/Space) goes through the same
 //! animator, because WebKit's keydown scroll has the identical
@@ -478,23 +482,34 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     if (!ownVolume.has(v)) ownVolume.set(v, v.volume);
     return ownVolume.get(v);
   }
+  // Videos the handoff itself paused, so settle-time reconciliation
+  // can tell "we silenced it" apart from "the user paused it" and only
+  // resume the former.
+  const handoffPaused = new WeakSet();
   function handoffPlayback(dir) {
     if (!shortformSite()) return;
-    // The incoming card is still ~one viewport away in the paging
-    // direction at commit time: nearest video at least 40% of a
-    // viewport from center. None found (virtualized card not mounted
-    // yet) fails open — the site's observer handles it as before.
+    // Pick the incoming card: nearest video ahead of center in the
+    // paging direction. On the synthetic-swipe path the feed has
+    // already been dragged ~65% of a viewport at pointerup, leaving
+    // the real incoming reel only ~35% from center — a 40% floor
+    // skipped it and started the reel AFTER it instead (next-next
+    // reel's audio under the one being watched). 15% still safely
+    // excludes the outgoing reel: its center sits behind mid in the
+    // paging direction (d <= 0) throughout the transition. None found
+    // (virtualized card not mounted yet) fails open — the site's
+    // observer handles it as before.
     const mid = innerHeight / 2;
     let inc = null, best = Infinity;
     for (const v of document.querySelectorAll('video')) {
       const r = v.getBoundingClientRect();
       if (r.width < 1 || r.height < 1) continue;
       const d = ((r.top + r.bottom) / 2 - mid) * dir;
-      if (d < innerHeight * 0.4) continue;
+      if (d < innerHeight * 0.15) continue;
       if (d < best) { best = d; inc = v; }
     }
     if (inc) {
       const iv = ownVol(inc);
+      handoffPaused.delete(inc);
       if (inc.paused) {
         try { inc.volume = 0; } catch (_) {}
         const p = inc.play();
@@ -516,8 +531,41 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
         // Restore the element's own volume after the pause so a
         // scroll-back (or the site recycling the element) never
         // inherits a silenced video.
-        try { v.pause(); v.volume = ov; ownVolume.delete(v); } catch (_) {}
+        try { handoffPaused.add(v); v.pause(); v.volume = ov; ownVolume.delete(v); } catch (_) {}
       });
+    }
+  }
+  // Settle-time reconciliation: the commit-time handoff guesses the
+  // incoming card mid-transition. When the guess was wrong (the feed
+  // rubber-banded back, or the mounted-cards geometry mid-drag fooled
+  // the pick), a reel that is NOT on screen keeps playing audio under
+  // the one being watched — indefinitely, because the site's observer
+  // never pauses a video it didn't start. Once the transition has
+  // settled, the front-and-center video is the only one allowed to
+  // play: every other playing video ramps out and pauses, and a video
+  // the handoff itself paused is resumed if it ended up active (a
+  // snapped-back swipe must not leave the current reel frozen).
+  function reconcilePlayback() {
+    if (!shortformSite()) return;
+    // A newer swipe in flight owns playback: its own settle-time
+    // reconcile is already scheduled, and running now would judge
+    // mid-transition geometry.
+    if (performance.now() < swipeUntil) return;
+    const active = activeShortformVideo();
+    for (const v of document.querySelectorAll('video')) {
+      if (v === active || v.paused || rampTarget(v) === 0) continue;
+      const ov = ownVol(v);
+      rampVolume(v, 0, RAMP_OUT_MS, () => {
+        try { handoffPaused.add(v); v.pause(); v.volume = ov; ownVolume.delete(v); } catch (_) {}
+      });
+    }
+    if (active && active.paused && handoffPaused.has(active)) {
+      handoffPaused.delete(active);
+      const iv = ownVol(active);
+      try { active.volume = 0; } catch (_) {}
+      const p = active.play();
+      if (p && p.catch) p.catch(() => {});
+      rampVolume(active, iv, RAMP_IN_MS, () => ownVolume.delete(active));
     }
   }
 
@@ -577,6 +625,11 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
           // Gesture commit: start the incoming reel's playback now
           // instead of waiting out IG's settle + observer.
           handoffPlayback(dir);
+          // And reconcile once IG's own snap animation has settled:
+          // the commit-time pick is a mid-transition guess, and a
+          // wrong guess leaks an off-screen reel's audio forever.
+          // (+50ms so this fires past its own swipeUntil guard.)
+          setTimeout(reconcilePlayback, SWIPE_ABSORB_MS + 50);
         }
       } catch (_) {
         clearInterval(iv);
@@ -673,8 +726,12 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     if (target == null) return true;
     animateTo(el, horiz, target);
     // Page commit on a snap/card feed: same handoff as the swipe
-    // path. handoffPlayback gates itself to shortform sites.
-    if (!horiz) handoffPlayback(dir);
+    // path. handoffPlayback gates itself to shortform sites; the
+    // settle-time reconcile corrects a wrong mid-transition pick.
+    if (!horiz) {
+      handoffPlayback(dir);
+      setTimeout(reconcilePlayback, SNAP_DUR + 150);
+    }
     return true;
   }
 
@@ -1423,10 +1480,17 @@ mod tests {
         assert!(body.contains("if (!shortformSite()) return;"));
         // Outgoing: every other playing video ramps to zero, pauses,
         // then restores its own volume so scroll-back never inherits
-        // a silenced video.
+        // a silenced video. The pause is marked so settle-time
+        // reconciliation can resume a wrongly-paused active reel.
         assert!(body.contains("if (v === inc || v.paused || rampTarget(v) === 0) continue;"));
         assert!(body.contains("rampVolume(v, 0, RAMP_OUT_MS"));
-        assert!(body.contains("v.pause(); v.volume = ov; ownVolume.delete(v);"));
+        assert!(body.contains("handoffPaused.add(v); v.pause(); v.volume = ov; ownVolume.delete(v);"));
+        // Incoming pick floor: 15% of a viewport ahead of center. The
+        // old 40% floor overshot on the synthetic-swipe path (feed
+        // already dragged ~65% at pointerup) and started the reel
+        // AFTER the incoming one — its audio then played under the
+        // reel being watched.
+        assert!(body.contains("innerHeight * 0.15"));
         // Incoming: starts muted-by-volume and ramps in; the play()
         // rejection is swallowed (autoplay policy).
         assert!(body.contains("inc.volume = 0;"));
@@ -1439,6 +1503,34 @@ mod tests {
         let ps = SMOOTH_WHEEL_JS.split("function pageSnap").nth(1).unwrap();
         let ps_body = ps.split("function animateBy").next().unwrap();
         assert!(ps_body.contains("handoffPlayback(dir)"));
+    }
+
+    /// After the transition settles, only the front-and-center video
+    /// may keep playing: a wrong commit-time pick otherwise leaks an
+    /// off-screen reel's audio under the watched one indefinitely.
+    /// Both commit paths schedule the reconcile past their settle
+    /// window, it skips while a newer swipe is in flight, and it
+    /// resumes only videos the handoff itself paused.
+    #[test]
+    fn settle_time_reconcile_shape() {
+        assert!(SMOOTH_WHEEL_JS.contains("function reconcilePlayback"));
+        let body = SMOOTH_WHEEL_JS
+            .split("function reconcilePlayback")
+            .nth(1)
+            .unwrap();
+        let body = body.split("function swipeFeed").next().unwrap();
+        // Gated to shortform sites, and defers to a newer in-flight swipe.
+        assert!(body.contains("if (!shortformSite()) return;"));
+        assert!(body.contains("if (performance.now() < swipeUntil) return;"));
+        // Only the active video keeps playing; others ramp out + pause.
+        assert!(body.contains("activeShortformVideo()"));
+        assert!(body.contains("rampVolume(v, 0, RAMP_OUT_MS"));
+        // Resumes the active video only when the handoff paused it —
+        // a user pause stays a pause.
+        assert!(body.contains("handoffPaused.has(active)"));
+        // Scheduled on both commit paths, past each settle window.
+        assert!(SMOOTH_WHEEL_JS.contains("setTimeout(reconcilePlayback, SWIPE_ABSORB_MS + 50)"));
+        assert!(SMOOTH_WHEEL_JS.contains("setTimeout(reconcilePlayback, SNAP_DUR + 150)"));
     }
 
     /// Precise touchpad deltas on the Instagram gesture feed must be

--- a/crates/hwatud/src/smoothwheel.rs
+++ b/crates/hwatud/src/smoothwheel.rs
@@ -122,6 +122,24 @@
 //! Baseten can then appear not to scroll at all. Keyboard enhancements
 //! remain installed; only wheel input returns to the engine-native path.
 //!
+//! Precise rescue: on some driver stacks (observed on NVIDIA+Wayland
+//! and Intel+NVIDIA hybrid laptops) that synchronous routing kills the
+//! engine's precise path outright — two-finger touchpad scrolling
+//! moves nothing anywhere while discrete wheel ticks (claimed by the
+//! animator) still work. The per-site skip list can't cover "every
+//! page on this GPU stack", so the handler self-heals: it watches
+//! unclaimed precise bursts, and when a burst has accumulated real
+//! travel and the target scroller provably hasn't moved a pixel by
+//! the deferred check, the page flips to rescue mode — precise deltas
+//! are claimed and drive the scroller directly (1:1 finger tracking,
+//! like the native path), with a short velocity fling on release
+//! through the same animator (the engine's kinetic scroll is as dead
+//! as its precise path). A healthy engine moves the scroller within a
+//! frame or two, so the check never trips it. This also restores
+//! two-finger panning (both axes) of a pinch-zoomed page: the pinch
+//! commits as page scale, growing the root scroller's extent, and the
+//! rescue pans it like any other scroller.
+//!
 //! `HWATU_SMOOTH_WHEEL=0` disables the whole thing.
 
 /// See module docs. Constants mirror Chromium
@@ -781,6 +799,75 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
     return host === 'baseten.co' || host.endsWith('.baseten.co');
   }
 
+  // Precise rescue (see module docs): on some driver stacks the
+  // engine's precise touchpad path is dead inside the synchronous
+  // wheel region — unclaimed precise deltas move nothing anywhere,
+  // while discrete ticks (claimed by the animator) still work. Probe
+  // unclaimed bursts: real accumulated travel with a provably unmoved
+  // scroller flips the page into rescue mode for the rest of its
+  // life. Claimed deltas then track the finger 1:1 on BOTH axes (a
+  // pinch-zoomed page pans diagonally, exactly like the native path)
+  // and a release fling runs through the animator (the engine's
+  // kinetic scroll is as dead as its precise path). A healthy engine
+  // moves the scroller well within the probe window, so the probe
+  // never trips it.
+  const RESCUE_PROBE_MS = 150, RESCUE_MIN_TRAVEL = 48,
+        RESCUE_BURST_GAP_MS = 250, RESCUE_IDLE_MS = 120,
+        RESCUE_FLING_SCALE = 180, RESCUE_MIN_FLING_V = 0.4;
+  let rescued = false;
+  let probe = null;
+  let flingSamples = [], flingTimer = 0;
+  function rescueFling(el) {
+    const samples = flingSamples;
+    flingSamples = [];
+    if (samples.length < 3) return;
+    const span = samples[samples.length - 1].t - samples[0].t;
+    if (span <= 0) return;
+    let sx = 0, sy = 0;
+    for (const s of samples) { sx += s.dx; sy += s.dy; }
+    const horiz = Math.abs(sx) > Math.abs(sy);
+    const v = (horiz ? sx : sy) / span; // px/ms at release
+    if (Math.abs(v) < RESCUE_MIN_FLING_V) return;
+    animateBy(el, horiz, v * RESCUE_FLING_SCALE);
+  }
+  function rescueScroll(e) {
+    let dx = e.deltaX, dy = e.deltaY;
+    if (e.shiftKey && !dx) { dx = dy; dy = 0; }
+    if (!dx && !dy) return rescued; // scroll-stop: absorb once claimed
+    const horiz = Math.abs(dx) > Math.abs(dy);
+    const el = scrollTarget(e.target, horiz, (horiz ? dx : dy) > 0 ? 1 : -1);
+    if (!el) return false;
+    const now = performance.now();
+    if (!rescued) {
+      // Feed (or start) the dead-path probe; this event stays native.
+      // The token closure keeps a stale timer from judging a newer
+      // burst's probe.
+      if (!probe || probe.el !== el || now - probe.last > RESCUE_BURST_GAP_MS) {
+        const p = { el, horiz, pos: getPos(el, horiz), travel: 0, last: now };
+        probe = p;
+        setTimeout(() => {
+          if (probe !== p) return;
+          probe = null;
+          if (!rescued && p.travel >= RESCUE_MIN_TRAVEL && p.el.isConnected
+              && Math.abs(getPos(p.el, p.horiz) - p.pos) < 1) rescued = true;
+        }, RESCUE_PROBE_MS);
+      }
+      probe.travel += Math.abs(horiz ? dx : dy);
+      probe.last = now;
+      return false;
+    }
+    // 1:1 finger tracking on both axes; the fling arms on idle. A
+    // stale glide must not fight the finger.
+    const a = anims.get(el);
+    if (a) endAnim(el, a);
+    el.scrollBy({ left: dx, top: dy, behavior: 'instant' });
+    flingSamples.push({ t: now, dx, dy });
+    if (flingSamples.length > 8) flingSamples.shift();
+    clearTimeout(flingTimer);
+    flingTimer = setTimeout(() => rescueFling(el), RESCUE_IDLE_MS);
+    return true;
+  }
+
   function installWheelHandler() {
     addEventListener('wheel', e => {
       try {
@@ -791,7 +878,10 @@ const SMOOTH_WHEEL_JS: &str = r#"(() => {
           // IG gesture feed native pixels desync the reel state: claim
           // and translate them into synthetic swipes.
           if (!e.shiftKey && e.deltaY
-              && preciseFeedScroll(e.target, e.deltaY)) e.preventDefault();
+              && preciseFeedScroll(e.target, e.deltaY)) { e.preventDefault(); return; }
+          // Elsewhere they stay native unless the engine's precise
+          // path is provably dead (see rescueScroll).
+          if (rescueScroll(e)) e.preventDefault();
           return;
         }
 
@@ -1484,7 +1574,9 @@ mod tests {
         // reconciliation can resume a wrongly-paused active reel.
         assert!(body.contains("if (v === inc || v.paused || rampTarget(v) === 0) continue;"));
         assert!(body.contains("rampVolume(v, 0, RAMP_OUT_MS"));
-        assert!(body.contains("handoffPaused.add(v); v.pause(); v.volume = ov; ownVolume.delete(v);"));
+        assert!(
+            body.contains("handoffPaused.add(v); v.pause(); v.volume = ov; ownVolume.delete(v);")
+        );
         // Incoming pick floor: 15% of a viewport ahead of center. The
         // old 40% floor overshot on the synthetic-swipe path (feed
         // already dragged ~65% at pointerup) and started the reel
@@ -1558,7 +1650,58 @@ mod tests {
             .unwrap();
         let arm = handler.split("let dx = e.deltaX").next().unwrap();
         assert!(arm.contains("!isDiscrete(e)"));
-        assert!(arm.contains("preciseFeedScroll(e.target, e.deltaY)) e.preventDefault()"));
+        assert!(
+            arm.contains("preciseFeedScroll(e.target, e.deltaY)) { e.preventDefault(); return; }")
+        );
+    }
+
+    /// Precise deltas everywhere else must stay engine-native unless
+    /// the engine's precise path is provably dead: the rescue only
+    /// claims after an unclaimed burst accumulated real travel AND the
+    /// target scroller did not move a pixel by the deferred check. It
+    /// must never trip on a healthy engine, and once tripped it must
+    /// track the finger on both axes (zoomed-page side pan) and fling
+    /// through the animator on release.
+    #[test]
+    fn precise_rescue_shape() {
+        assert!(SMOOTH_WHEEL_JS.contains("function rescueScroll"));
+        assert!(SMOOTH_WHEEL_JS.contains("function rescueFling"));
+        let body = SMOOTH_WHEEL_JS
+            .split("function rescueScroll")
+            .nth(1)
+            .unwrap();
+        let body = body.split("function installWheelHandler").next().unwrap();
+        // The probe is evidence-gated: travel floor + unmoved scroller,
+        // judged on a deferred timer, and a stale timer cannot judge a
+        // newer burst.
+        assert!(SMOOTH_WHEEL_JS.contains("RESCUE_MIN_TRAVEL"));
+        assert!(body.contains("p.travel >= RESCUE_MIN_TRAVEL"));
+        assert!(body.contains("Math.abs(getPos(p.el, p.horiz) - p.pos) < 1"));
+        assert!(body.contains("if (probe !== p) return;"));
+        // Unrescued events stay native (return false before any claim).
+        assert!(body.contains("return false;"));
+        // Claimed deltas pan both axes 1:1 — this is what makes a
+        // pinch-zoomed page side-pannable.
+        assert!(body.contains("el.scrollBy({ left: dx, top: dy, behavior: 'instant' })"));
+        // Release fling reuses the Chromium-curve animator.
+        let fling = SMOOTH_WHEEL_JS
+            .split("function rescueFling")
+            .nth(1)
+            .unwrap()
+            .split("function rescueScroll")
+            .next()
+            .unwrap();
+        assert!(fling.contains("animateBy(el, horiz,"));
+        // The wheel handler consults the rescue inside the precise arm,
+        // after the IG feed guard, and preventDefaults claimed events.
+        let handler = SMOOTH_WHEEL_JS
+            .split("addEventListener('wheel'")
+            .nth(1)
+            .unwrap();
+        let arm = handler.split("let dx = e.deltaX").next().unwrap();
+        let feed = arm.find("preciseFeedScroll").unwrap();
+        let rescue = arm.find("rescueScroll(e)) e.preventDefault()").unwrap();
+        assert!(feed < rescue);
     }
 
     /// Hi-res wheels (MX Master-style) emit sub-notch deltas that are

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -906,6 +906,32 @@ impl BrowserWindow {
             let this = this.clone();
             window.connect_close_request(move |_| {
                 this.cancel_discard_timer();
+                // Remember the page for ctrl+shift+t before the window
+                // leaves the registry. Headless windows belong to an
+                // agent's verification run, and blank/launcher pages
+                // are not worth resurrecting.
+                {
+                    let info = this.info();
+                    if info.mode != OpenMode::Headless
+                        && !info.url.is_empty()
+                        && info.url != "about:blank"
+                        && !crate::launcher::is_launcher(&info.url)
+                    {
+                        let mut closed = daemon.recently_closed.borrow_mut();
+                        closed.push(crate::session::SessionEntry {
+                            url: info.url,
+                            title: info.title,
+                            app_id: info.app_id,
+                            mode: info.mode,
+                        });
+                        // Cap the stack: 10 reopens deep matches what
+                        // mainstream browsers keep reachable by key.
+                        let overflow = closed.len().saturating_sub(10);
+                        if overflow > 0 {
+                            closed.drain(..overflow);
+                        }
+                    }
+                }
                 // The GTK toplevel dying does not kill the web process:
                 // WebKit caches it for reuse, and a cached process keeps
                 // running its page — an autoplaying video's audio audibly
@@ -1841,6 +1867,7 @@ impl BrowserWindow {
                 }
             }
             Action::Mute => self.toggle_mute(),
+            Action::ReopenClosed => self.reopen_closed(),
             Action::CommandPalette => self.open_palette(),
         }
         glib::Propagation::Stop
@@ -1977,6 +2004,24 @@ impl BrowserWindow {
         };
         webview.set_zoom_level(1.0);
         self.flash_bar("zoom 100%", 1);
+    }
+
+    /// Reopen the most recently closed window (ctrl+shift+t), popping
+    /// the daemon's recently-closed stack. Reopened windows always
+    /// take focus regardless of how the original was opened: the user
+    /// pressed a key asking for the page back.
+    fn reopen_closed(self: &Rc<Self>) {
+        let entry = self.daemon.recently_closed.borrow_mut().pop();
+        let Some(entry) = entry else {
+            self.flash_bar("nothing to reopen", 1);
+            return;
+        };
+        Self::open(
+            &self.daemon,
+            Some(entry.url),
+            entry.app_id,
+            OpenMode::Normal,
+        );
     }
 
     /// Back/forward through this window's history. Restores a

--- a/crates/hwatud/src/window.rs
+++ b/crates/hwatud/src/window.rs
@@ -452,6 +452,31 @@ fn parse_feature_overrides(raw: &str) -> Vec<(String, bool)> {
         .collect()
 }
 
+/// Push a closing window onto the reopen stack (ctrl+shift+t), capped
+/// at 10 like mainstream browsers keep reachable by key. Headless
+/// windows belong to an agent's verification run, and blank/launcher
+/// pages are not worth resurrecting; none are recorded.
+fn remember_recently_closed(stack: &RefCell<Vec<crate::session::SessionEntry>>, info: WindowInfo) {
+    if info.mode == OpenMode::Headless
+        || info.url.is_empty()
+        || info.url == "about:blank"
+        || crate::launcher::is_launcher(&info.url)
+    {
+        return;
+    }
+    let mut closed = stack.borrow_mut();
+    closed.push(crate::session::SessionEntry {
+        url: info.url,
+        title: info.title,
+        app_id: info.app_id,
+        mode: info.mode,
+    });
+    let overflow = closed.len().saturating_sub(10);
+    if overflow > 0 {
+        closed.drain(..overflow);
+    }
+}
+
 /// Set the Wayland xdg_toplevel app_id for one window, overriding the
 /// GTK-derived application id. No-op on X11 (WM_CLASS stays global to
 /// the GTK app; per-window class on X11 is not worth the unsafe Xlib).
@@ -907,31 +932,8 @@ impl BrowserWindow {
             window.connect_close_request(move |_| {
                 this.cancel_discard_timer();
                 // Remember the page for ctrl+shift+t before the window
-                // leaves the registry. Headless windows belong to an
-                // agent's verification run, and blank/launcher pages
-                // are not worth resurrecting.
-                {
-                    let info = this.info();
-                    if info.mode != OpenMode::Headless
-                        && !info.url.is_empty()
-                        && info.url != "about:blank"
-                        && !crate::launcher::is_launcher(&info.url)
-                    {
-                        let mut closed = daemon.recently_closed.borrow_mut();
-                        closed.push(crate::session::SessionEntry {
-                            url: info.url,
-                            title: info.title,
-                            app_id: info.app_id,
-                            mode: info.mode,
-                        });
-                        // Cap the stack: 10 reopens deep matches what
-                        // mainstream browsers keep reachable by key.
-                        let overflow = closed.len().saturating_sub(10);
-                        if overflow > 0 {
-                            closed.drain(..overflow);
-                        }
-                    }
-                }
+                // leaves the registry.
+                remember_recently_closed(&daemon.recently_closed, this.info());
                 // The GTK toplevel dying does not kill the web process:
                 // WebKit caches it for reuse, and a cached process keeps
                 // running its page — an autoplaying video's audio audibly
@@ -2365,8 +2367,56 @@ impl BrowserWindow {
 mod tests {
     use super::{
         external_uri_scheme, is_ctrl_click_link, load_was_cancelled, parse_feature_overrides,
-        recovery_url, termination_info,
+        recovery_url, remember_recently_closed, termination_info,
     };
+
+    /// The reopen stack (ctrl+shift+t) records user windows newest
+    /// last, skips headless/blank/launcher pages, and caps at 10 so
+    /// the key can't dredge up the whole session's history.
+    #[test]
+    fn reopen_stack_records_user_windows_and_caps() {
+        use hwatu_ipc::{OpenMode, WindowInfo};
+        let info = |url: &str, mode| WindowInfo {
+            id: 1,
+            url: url.into(),
+            title: "t".into(),
+            focused: false,
+            suspended: false,
+            app_id: None,
+            mode,
+            web_process_terminated: None,
+        };
+        let stack = std::cell::RefCell::new(Vec::new());
+        // Recorded: a normal page, and a background window too (the
+        // reopen key should bring back agent-opened pages the user
+        // closed by hand).
+        remember_recently_closed(&stack, info("https://a.example/", OpenMode::Normal));
+        remember_recently_closed(&stack, info("https://b.example/", OpenMode::Background));
+        // Skipped: headless, blank, launcher.
+        remember_recently_closed(&stack, info("https://c.example/", OpenMode::Headless));
+        remember_recently_closed(&stack, info("", OpenMode::Normal));
+        remember_recently_closed(&stack, info("about:blank", OpenMode::Normal));
+        remember_recently_closed(&stack, info(crate::launcher::URI, OpenMode::Normal));
+        {
+            let closed = stack.borrow();
+            assert_eq!(closed.len(), 2);
+            // Newest last: pop() must return the most recent close.
+            assert_eq!(closed[0].url, "https://a.example/");
+            assert_eq!(closed[1].url, "https://b.example/");
+        }
+        // Cap at 10, evicting oldest first: 2 seeds + 12 pushes = 14,
+        // so a/b and n0/n1 fall off and n2 is the oldest survivor.
+        for i in 0..12 {
+            remember_recently_closed(
+                &stack,
+                info(&format!("https://n{i}.example/"), OpenMode::Normal),
+            );
+        }
+        let closed = stack.borrow();
+        assert_eq!(closed.len(), 10);
+        assert_eq!(closed[0].url, "https://n2.example/");
+        assert_eq!(closed[9].url, "https://n11.example/");
+    }
 
     #[test]
     fn baseline_enables_the_complete_opfs_feature_bundle() {

--- a/docs/research-input-lag.md
+++ b/docs/research-input-lag.md
@@ -240,3 +240,49 @@ path. Revisit when WebKitGTK's vblank monitor learns to follow the
 real display rate (or exposes a refresh-rate override): the DMA-BUF
 path is the better architecture and should win again once its pacing
 is fixed.
+
+## Addendum 2: the GSK Vulkan cross-GPU collapse (found and fixed)
+
+Symptom rediscovered while chasing "scroll paint should never lag":
+on the same 144Hz niri laptop (i7-12650H iGPU + RTX 4050 dGPU,
+NVIDIA 610 driver, GTK 4.22), every hwatu scroll frame took ~45ms
+(~22fps) while idle rAF sat at 7ms (144fps) — but stock MiniBrowser
+on the identical fixture scrolled at 14ms/frame. Same engine, same
+env, so the delta had to be in what surrounds the engine.
+
+Bisection (self-driving fixture writes its result into
+`document.title`, `~/.jcode/scratch/hwatu-scroll-bench/`):
+
+| config | scroll ms/frame |
+|---|---|
+| hwatu default (GSK auto → vulkan) | 44-46 |
+| hwatu, adblock/smoothwheel/shields off | 45 (not the scripts) |
+| hwatu, `LIBGL_ALWAYS_SOFTWARE=1` | 44 (not GL raster) |
+| hwatu at 1024x768 | 19 (pixel-volume bound) |
+| hwatu `GSK_RENDERER=vulkan` explicit | 46 |
+| hwatu `GSK_RENDERER=vulkan` + `GDK_VULKAN_DEVICE=1` (iGPU) | 48 |
+| hwatu `GSK_RENDERER=ngl`/`gl` | 12-17 |
+| hwatu `GSK_RENDERER=cairo` | 17 |
+| MiniBrowser (GSK gl default via its own path) | 14 |
+
+Root cause: GTK 4.22's renderer auto-selection picks the Vulkan
+renderer, and `GDK_DEBUG=vulkan` shows it lands on the **discrete
+NVIDIA GPU** ("Using Vulkan device 0: NVIDIA GeForce RTX 4050"),
+while WebKit paints its frames through the Wayland EGL platform on
+the **Intel iGPU** (eglinfo: Wayland platform → Mesa Intel ADL GT2).
+Every composited frame crosses the GPU boundary. Vulkan pinned to
+the iGPU is equally slow, so the texture-upload path of the Vulkan
+renderer is implicated too, not just device mismatch. The GL
+renderer follows the same EGL platform WebKit uses and composites
+on the iGPU: 3x faster, and it matches MiniBrowser.
+
+Fix: hwatud exports `GSK_RENDERER=gl` by default (`main.rs`), next
+to the existing DMA-BUF opt-out. Explicit user env always wins
+(`GSK_RENDERER=vulkan hwatud` restores GTK's pick). Verified after
+the change: fixture scroll 14-16ms, Wikipedia scroll median 14ms
+p95 17ms (was 44-46ms), WebGL2 still hardware-backed, screenshot
+pixel-clean, all 173 hwatud tests pass.
+
+Revisit when GTK's Vulkan renderer either follows the compositor's
+main device or gets dmabuf import fast paths on NVIDIA — Vulkan is
+GTK's strategic renderer and will eventually be the right answer.

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -191,6 +191,81 @@ audio (WM focus loss never pauses playback), and the compositing path
 is measured solid (142.9fps). No crossfade will be added — native
 does not have one either.
 
+### D4: niri-native integration (the WM is the browser chrome)
+
+Adopted 2026-08-08. Thesis: what makes macOS-Safari feel native is the
+browser treating the OS as its UI toolkit. The tiling-WM equivalent is
+treating compositor IPC (niri first, since it has the richest IPC),
+XDG portals, and desktop services as first-class surfaces. Nobody else
+can do "the WM is the tab manager" well because no other browser
+speaks niri IPC. Phone-connectivity features (Handoff analogs, KDE
+Connect push) were considered and rejected: out of scope, no
+constituency here.
+
+#### Niri IPC as the tab model
+
+H28. **Columns as tab groups.** "Open link in stack" places the new
+    window in the current niri column (niri's tabbed column display
+    renders it as a tab). Safari tab groups, except the groups are
+    real WM objects the user already knows how to manipulate.
+    Background-open = spawn in the column to the right, unfocused,
+    via `niri msg action`.
+H29. **`hwatu jump <query>`.** Fuzzy match over open windows + global
+    history (H9), then `niri msg action focus-window` to the winner
+    or a new window on a miss. Bindable from niri config, so any app
+    is one chord from "Spotlight for the web".
+H30. **Semantic app-ids.** Per-profile and per-site app_id
+    (`hwatu.work`, `hwatu.youtube`) so niri window rules do
+    auto-placement, floating, workspace pinning, and opacity without
+    hwatu growing its own rule engine. Profiles (separate cookie
+    stores) fall out of the same mechanism.
+H31. **Workspace-aware session restore.** Extends H19: restore
+    windows to *named* niri workspaces, and route deep links by rule
+    ("github.com/work-org opens on workspace work"). Uses the H30
+    identity conventions.
+
+#### Windows as system objects
+
+H32. **PiP as a niri float.** "Pop out video" spawns a small
+    always-on-float window (distinct app_id so a niri rule floats
+    it); the page keeps scrolling underneath. Reuses the shortform
+    verb machinery (H24) to find the active video.
+H33. **Quick Look for links.** "Peek" a hinted link (H10) in a
+    transient floating window: Esc dismisses, Enter promotes it to a
+    real tiled window. Cheap once H10 and H32's float plumbing exist.
+
+#### System-services analogs
+
+H34. **Reader mode.** Safari's signature feature: extraction JS
+    (readability-class) injected on demand, rendered with the user's
+    fonts and the H15 color scheme. Pairs with edit-in-$EDITOR (H18).
+H35. **libsecret as Keychain.** Store per-site credentials in
+    gnome-keyring/KWallet via libsecret as the zero-config tier
+    beneath H11's pass/KeePassXC/Bitwarden integration. Integrate,
+    never store our own — H11's principle unchanged; libsecret is
+    the system's store, not ours.
+H36. **Share sheet.** Current page or selection → palette "share"
+    submenu: mpv (H17), yt-dlp, wl-copy, wallabag, email, translate,
+    define. User-extensible via a `share.conf` of commands, same
+    format family as search.conf.
+
+#### Polish that reads as native
+
+H37. **Theme continuity.** Follow the XDG portal color-scheme (and
+    darkman) for prefers-color-scheme, and read niri's focus-ring
+    color to tint the bar and hanafuda accent, so the browser looks
+    like part of the rig, not a guest on it.
+H38. **Touchpad gestures.** Two-finger horizontal swipe = back /
+    forward with a rubber-band preview; pinch = zoom. The single
+    biggest contributor to Safari's laptop feel; the smoothwheel
+    infra already owns precise-delta events.
+H39. **Hotkey overlay parity.** A `Super+?`-style cheatsheet overlay
+    matching niri's own hotkey overlay in look and dismissal, so
+    muscle memory transfers between compositor and browser.
+H40. **Battery-aware mode.** Safari's efficiency pitch, translated:
+    on battery (upower D-Bus), tighten discard thresholds (H27),
+    drop reelwarm prefetch (H22), and cap shortform framerate.
+
 ### Engine-bound gaps (documented honestly, not planned)
 
 - **Widevine/DRM:** WebKitGTK has ClearKey only; no distro ships

--- a/scripts/bench-scroll/bench-one.sh
+++ b/scripts/bench-scroll/bench-one.sh
@@ -17,7 +17,7 @@ id=$(echo "$out" | grep -oP 'window \K[0-9]+' | head -1)
 run wait-load --id "$id" --until settled >/dev/null
 sleep 1
 
-result=$(run eval --id "$id" --timeout-ms 20000 '
+result=$(run eval --id "$id" --timeout-ms 60000 '
 (async () => {
   const stats = arr => {
     const d = arr.slice().sort((a,b)=>a-b);


### PR DESCRIPTION
Adds a D4 tier to the browser roadmap: thirteen features aimed at making hwatu+niri as native a combo as macOS+Safari.

**Niri IPC as the tab model**
- H28 columns as tab groups (open-in-stack via niri tabbed columns)
- H29 `hwatu jump` — fuzzy window+history jump, bindable from niri
- H30 semantic app-ids for niri window rules + profiles
- H31 workspace-aware session restore / deep-link routing

**Windows as system objects**
- H32 PiP as a niri float
- H33 Quick Look-style link peek

**System-services analogs**
- H34 reader mode
- H35 libsecret as the zero-config credential tier under H11
- H36 share sheet (share.conf)

**Polish**
- H37 theme continuity (portal color-scheme + niri accent)
- H38 touchpad gestures (swipe back/forward, pinch zoom)
- H39 hotkey overlay parity with niri
- H40 battery-aware mode

Phone-connectivity Handoff analogs were considered and explicitly rejected (documented in the tier intro).

Per repo policy: docs change via branch + PR, review and merge is yours.