### PR TITLE
docs: document shipped D0+D1 features

### DIFF
--- a/docs/human.md
+++ b/docs/human.md
@@ -32,13 +32,34 @@ fraction? Set `"preferred_width"` in `~/.config/hwatu/config.json`
 (see [Configuration](#configuration)). The launcher deals a
 hanafuda card per window so windows are tellable apart at a glance.
 
-If you want history completion and password-manager integration,
-qutebrowser still does those better today (both are now on the
-[browser roadmap](roadmaps/browser.md)). What Hwatu offers instead: one
-warm engine for all windows (~56 MB per extra window), native ad
-blocking with no extension process, and the agent hand-off loop no
-other browser has. Portfolio scope and shared non-goals live in the
+If you want history completion and password-manager integration:
+both arrived in v0.8. Ctrl+L completes against your visit history
+(frecency-ranked, Tab/Down cycles), and alt+p fills logins from
+`pass` or Bitwarden's `bw` (hwatu integrates, never stores). What
+Hwatu offers beyond qutebrowser's versions: one warm engine for all
+windows (~56 MB per extra window), native ad blocking with no
+extension process, and the agent hand-off loop no other browser has.
+Portfolio scope and shared non-goals live in the
 [roadmap index](roadmap.md).
+
+### History, keywords, quickmarks
+
+Every page you visit (in normal or background windows; never agent
+headless runs) lands in a local SQLite history. Ctrl+L shows the top
+matches as you type; `hwatu history [query]` queries it from the
+shell and `hwatu history --clear` wipes it.
+
+`~/.config/hwatu/search.conf` takes keyword lines after the engine
+line, and `~/.config/hwatu/quickmarks.conf` maps names to URLs:
+
+```text
+# search.conf              # quickmarks.conf
+duckduckgo                 news https://news.ycombinator.com/
+w wikipedia-template...    mail https://mail.proton.me/
+```
+
+Then `w rust` searches Wikipedia and typing `news` alone opens HN.
+Both files are read per lookup; edits apply immediately.
 
 ## Keybindings
 
@@ -59,6 +80,9 @@ rebindable in `~/.config/hwatu/keys.conf`, one
 | `fullscreen` | `F11` | toggle fullscreen |
 | `mute` | `m` (bare key) | toggle page audio, preference sticks across videos on the page |
 | `print` | `ctrl+p` | print the page (system dialog; print-to-PDF included) |
+| `hint_follow` / `hint_new_window` | `f` / `F` (bare keys) | link hints: label visible links/controls, type the label to activate / open in a new window |
+| `hint_yank` | `ctrl+shift+y` | link hints: copy the picked link's URL |
+| `fill_password` | `alt+p` | fill login from your password manager (pass or Bitwarden CLI) |
 | `command_palette` | `ctrl+k`, `ctrl+shift+p` | fuzzy action search in the bar |
 
 Bare-key chords like `m` dispatch after the page declines the key, so
@@ -115,6 +139,7 @@ hwatu example.com          # open a URL
 hwatu how to exit vim      # non-URLs become a web search
 hwatu list                 # every window: id, url, title
 hwatu adblock update       # fetch + compile EasyList/EasyPrivacy
+hwatu history [query]      # frecency-ranked visit history (--clear wipes)
 hwatu update               # self-update
 hwatu quit                 # stop the daemon
 ```
@@ -136,6 +161,10 @@ hwatu quit                 # stop the daemon
     `"spell_check_languages": ["en_US", "de_DE"]` overrides the
     locale-derived language list (install matching hunspell
     dictionaries).
+  - `"password_backend": "pass"|"bitwarden"|"off"`: pin the alt+p
+    fill backend. Default auto-detects `pass`
+    (`~/.password-store`) first, then an unlocked Bitwarden vault
+    (`BW_SESSION`).
 - `~/.local/share/hwatud/site.json`: per-site memory (permission
   answers, zoom levels). Delete it (or an entry) to be re-asked;
   never written in ephemeral-profile mode.

--- a/docs/human.md
+++ b/docs/human.md
@@ -16,6 +16,15 @@ content-extension engine, zero JS in the request path), sane
 downloads, crash-restore sessions, TLS and permission prompts as
 one-line y/n bar prompts.
 
+Daily-driver basics all work: file uploads (`<input type=file>` opens
+a file dialog), printing (Ctrl+P, print-to-PDF included), PDF viewing
+(built-in pdf.js), spell check (locale-derived, Enchant), web
+notifications (forwarded to your desktop's notification daemon;
+clicking one focuses the page's window), and WebRTC calls
+(Meet/Discord/Zoom-web — needs your distro's gst-plugins-bad and
+`"media_stream": true`, see [Configuration](#configuration)).
+Permission answers and per-site zoom persist across restarts.
+
 New windows open at half the monitor width, matching the middle
 stop of niri's default 1/3, 1/2, 2/3 preset-width cycle and a
 comfortable reading width on 1080p-class monitors. Prefer a different
@@ -49,6 +58,7 @@ rebindable in `~/.config/hwatu/keys.conf`, one
 | `close` | `ctrl+w`, `ctrl+q` | close window |
 | `fullscreen` | `F11` | toggle fullscreen |
 | `mute` | `m` (bare key) | toggle page audio, preference sticks across videos on the page |
+| `print` | `ctrl+p` | print the page (system dialog; print-to-PDF included) |
 | `command_palette` | `ctrl+k`, `ctrl+shift+p` | fuzzy action search in the bar |
 
 Bare-key chords like `m` dispatch after the page declines the key, so
@@ -117,8 +127,29 @@ hwatu quit                 # stop the daemon
     but vanishes on daemon restart.
   - `"preferred_width": 0.25`: initial window width as a fraction of
     the monitor width, between 0 and 1. Default is one half.
+  - `"media_stream": true`: enable getUserMedia + WebRTC (mic, cam,
+    calls). Off by default because a WebKitGTK+pipewire device-probe
+    wedge lets fingerprinting SDKs freeze pages; turn it on if you
+    take calls in hwatu. `HWATU_MEDIA_STREAM=1` is the one-run env
+    equivalent.
+  - `"spell_check": false` disables spell check;
+    `"spell_check_languages": ["en_US", "de_DE"]` overrides the
+    locale-derived language list (install matching hunspell
+    dictionaries).
+- `~/.local/share/hwatud/site.json`: per-site memory (permission
+  answers, zoom levels). Delete it (or an entry) to be re-asked;
+  never written in ephemeral-profile mode.
 - Env-only gates, read at window creation: `HWATU_FOCUS_SHIELD=0`,
   `HWATU_BLUR_SHIELD=0`, `HWATU_DISABLE_MEDIA=1`.
+
+### Calls and video notes
+
+- WebRTC needs GStreamer's "bad" plugin set at runtime:
+  `gst-plugins-bad` (Arch) / `gstreamer1.0-plugins-bad` (Debian).
+- Hardware video decode (battery + shortform smoothness) arrives with
+  the same package's `va` plugin plus your GPU's VA-API driver
+  (`intel-media-driver` / `libva-mesa-driver`). `hwatu doctor`
+  reports whether it is active.
 
 ## Tiling WM setup
 

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -86,6 +86,22 @@ H8. **PDF viewing.** WebKitGTK ships pdf.js enabled by default;
 
 ### D1: category-defining features (what the audience switches for)
 
+**Shipped 2026-08-08** (all five items). Against the original scope
+below: H9 as history.rs (SQLite, frecency ranking: ln(1+visits) x
+recency bucket x match-quality; host-prefix beats word-boundary beats
+substring), bar completions in URL mode with Down/Tab cycling, and a
+`hwatu history` CLI/protocol verb with `--clear`; headless windows,
+launcher pages, and blanks never recorded, in-memory under ephemeral
+profiles. H10 as hints.rs (`f` follow, `F` new-window, ctrl+shift+y
+yank-to-GDK-clipboard; visibility + elementFromPoint candidate
+filtering, capture-phase key consumption, fail-open). H11 as
+passfill.rs (pass + Bitwarden CLIs, worker-thread lookup, framework-
+safe fill JS; integrate-never-store held). H12 had already shipped
+2026-08-05 as ctrl+shift+t with the 10-deep reopen stack. H13 as
+search.conf keyword lines + quickmarks.conf (per-lookup reads, no
+restart). Live checks: test-history.sh, test-hints.sh,
+test-passfill.sh, test-search-keywords.sh.
+
 Ordered by user-testimony criticality crossed with implementation
 cost. These reverse specific entries in the old not-planned list;
 the reversal is deliberate.

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -30,7 +30,22 @@ drivers.
 
 ### D0: silently broken or one-line-cheap (engine already does it)
 
-Each of these is small because WebKitGTK 2.52 already implements the
+**Shipped 2026-08-08** (all eight items, one pass; live checks in
+`scripts/test-d0.sh`). What shipped, against the original scope below:
+H1 file uploads via GTK FileDialog (MIME filter + multi-select
+honored); H2 WebRTC enabled behind the media-stream gate, which
+gained a persistent `"media_stream": true` config key; H3 as a
+`hwatu doctor` probe (gstreamer `va` plugin + render node) plus
+install docs; H4 via a direct D-Bus forwarder (notify.rs) with click
+routing to window focus and page-side close retraction; H5 as a
+write-through JSON site store (sitedata.rs) holding permission
+decisions and per-site zoom, applied on commit, RAM-only under
+ephemeral profiles; H6 with locale-derived language and
+`"spell_check"`/`"spell_check_languages"` keys; H7 on ctrl+p and the
+`print` signal (one dialog path for both); H8 verified live — the
+response policy handler already lets pdf.js render application/pdf.
+
+Each of these was small because WebKitGTK 2.52 already implements the
 hard part; hwatud just never connected the signal or flipped the
 setting.
 


### PR DESCRIPTION
Combined docs PR superseding #66 (its commits are merged into this branch).

**D0** (human.md + roadmap): uploads, print, PDF, spell check, notifications, WebRTC, per-site persistence; config keys `media_stream`, `spell_check`, `spell_check_languages`; site.json; gst-plugins-bad/VA-API notes.

**D1** (this branch):
- roadmap: D1 marked **Shipped 2026-08-08** with implementation summary (H9 history.rs, H10 hints.rs, H11 passfill.rs, H12 already shipped, H13 search keywords/quickmarks)
- human.md: history completion + alt+p fill paragraph replaces the 'qutebrowser still does those better' concession; keybinding rows for f/F/ctrl+shift+y/alt+p; History-keywords-quickmarks section with config examples; `hwatu history` in the commands block; `password_backend` config key.

Per repo policy: docs via branch + PR, review and merge is yours.