### PR TITLE
docs: roadmap status through the D0-D2/P3/platform wave

### DIFF
--- a/docs/human.md
+++ b/docs/human.md
@@ -32,13 +32,34 @@ fraction? Set `"preferred_width"` in `~/.config/hwatu/config.json`
 (see [Configuration](#configuration)). The launcher deals a
 hanafuda card per window so windows are tellable apart at a glance.
 
-If you want history completion and password-manager integration,
-qutebrowser still does those better today (both are now on the
-[browser roadmap](roadmaps/browser.md)). What Hwatu offers instead: one
-warm engine for all windows (~56 MB per extra window), native ad
-blocking with no extension process, and the agent hand-off loop no
-other browser has. Portfolio scope and shared non-goals live in the
+If you want history completion and password-manager integration:
+both arrived in v0.8. Ctrl+L completes against your visit history
+(frecency-ranked, Tab/Down cycles), and alt+p fills logins from
+`pass` or Bitwarden's `bw` (hwatu integrates, never stores). What
+Hwatu offers beyond qutebrowser's versions: one warm engine for all
+windows (~56 MB per extra window), native ad blocking with no
+extension process, and the agent hand-off loop no other browser has.
+Portfolio scope and shared non-goals live in the
 [roadmap index](roadmap.md).
+
+### History, keywords, quickmarks
+
+Every page you visit (in normal or background windows; never agent
+headless runs) lands in a local SQLite history. Ctrl+L shows the top
+matches as you type; `hwatu history [query]` queries it from the
+shell and `hwatu history --clear` wipes it.
+
+`~/.config/hwatu/search.conf` takes keyword lines after the engine
+line, and `~/.config/hwatu/quickmarks.conf` maps names to URLs:
+
+```text
+# search.conf              # quickmarks.conf
+duckduckgo                 news https://news.ycombinator.com/
+w wikipedia-template...    mail https://mail.proton.me/
+```
+
+Then `w rust` searches Wikipedia and typing `news` alone opens HN.
+Both files are read per lookup; edits apply immediately.
 
 ## Keybindings
 
@@ -59,6 +80,9 @@ rebindable in `~/.config/hwatu/keys.conf`, one
 | `fullscreen` | `F11` | toggle fullscreen |
 | `mute` | `m` (bare key) | toggle page audio, preference sticks across videos on the page |
 | `print` | `ctrl+p` | print the page (system dialog; print-to-PDF included) |
+| `hint_follow` / `hint_new_window` | `f` / `F` (bare keys) | link hints: label visible links/controls, type the label to activate / open in a new window |
+| `hint_yank` | `ctrl+shift+y` | link hints: copy the picked link's URL |
+| `fill_password` | `alt+p` | fill login from your password manager (pass or Bitwarden CLI) |
 | `command_palette` | `ctrl+k`, `ctrl+shift+p` | fuzzy action search in the bar |
 
 Bare-key chords like `m` dispatch after the page declines the key, so
@@ -115,6 +139,7 @@ hwatu example.com          # open a URL
 hwatu how to exit vim      # non-URLs become a web search
 hwatu list                 # every window: id, url, title
 hwatu adblock update       # fetch + compile EasyList/EasyPrivacy
+hwatu history [query]      # frecency-ranked visit history (--clear wipes)
 hwatu update               # self-update
 hwatu quit                 # stop the daemon
 ```
@@ -136,6 +161,10 @@ hwatu quit                 # stop the daemon
     `"spell_check_languages": ["en_US", "de_DE"]` overrides the
     locale-derived language list (install matching hunspell
     dictionaries).
+  - `"password_backend": "pass"|"bitwarden"|"off"`: pin the alt+p
+    fill backend. Default auto-detects `pass`
+    (`~/.password-store`) first, then an unlocked Bitwarden vault
+    (`BW_SESSION`).
 - `~/.local/share/hwatud/site.json`: per-site memory (permission
   answers, zoom levels). Delete it (or an entry) to be re-asked;
   never written in ephemeral-profile mode.

--- a/docs/human.md
+++ b/docs/human.md
@@ -16,6 +16,15 @@ content-extension engine, zero JS in the request path), sane
 downloads, crash-restore sessions, TLS and permission prompts as
 one-line y/n bar prompts.
 
+Daily-driver basics all work: file uploads (`<input type=file>` opens
+a file dialog), printing (Ctrl+P, print-to-PDF included), PDF viewing
+(built-in pdf.js), spell check (locale-derived, Enchant), web
+notifications (forwarded to your desktop's notification daemon;
+clicking one focuses the page's window), and WebRTC calls
+(Meet/Discord/Zoom-web — needs your distro's gst-plugins-bad and
+`"media_stream": true`, see [Configuration](#configuration)).
+Permission answers and per-site zoom persist across restarts.
+
 New windows open at half the monitor width, matching the middle
 stop of niri's default 1/3, 1/2, 2/3 preset-width cycle and a
 comfortable reading width on 1080p-class monitors. Prefer a different
@@ -49,6 +58,7 @@ rebindable in `~/.config/hwatu/keys.conf`, one
 | `close` | `ctrl+w`, `ctrl+q` | close window |
 | `fullscreen` | `F11` | toggle fullscreen |
 | `mute` | `m` (bare key) | toggle page audio, preference sticks across videos on the page |
+| `print` | `ctrl+p` | print the page (system dialog; print-to-PDF included) |
 | `command_palette` | `ctrl+k`, `ctrl+shift+p` | fuzzy action search in the bar |
 
 Bare-key chords like `m` dispatch after the page declines the key, so
@@ -117,8 +127,29 @@ hwatu quit                 # stop the daemon
     but vanishes on daemon restart.
   - `"preferred_width": 0.25`: initial window width as a fraction of
     the monitor width, between 0 and 1. Default is one half.
+  - `"media_stream": true`: enable getUserMedia + WebRTC (mic, cam,
+    calls). Off by default because a WebKitGTK+pipewire device-probe
+    wedge lets fingerprinting SDKs freeze pages; turn it on if you
+    take calls in hwatu. `HWATU_MEDIA_STREAM=1` is the one-run env
+    equivalent.
+  - `"spell_check": false` disables spell check;
+    `"spell_check_languages": ["en_US", "de_DE"]` overrides the
+    locale-derived language list (install matching hunspell
+    dictionaries).
+- `~/.local/share/hwatud/site.json`: per-site memory (permission
+  answers, zoom levels). Delete it (or an entry) to be re-asked;
+  never written in ephemeral-profile mode.
 - Env-only gates, read at window creation: `HWATU_FOCUS_SHIELD=0`,
   `HWATU_BLUR_SHIELD=0`, `HWATU_DISABLE_MEDIA=1`.
+
+### Calls and video notes
+
+- WebRTC needs GStreamer's "bad" plugin set at runtime:
+  `gst-plugins-bad` (Arch) / `gstreamer1.0-plugins-bad` (Debian).
+- Hardware video decode (battery + shortform smoothness) arrives with
+  the same package's `va` plugin plus your GPU's VA-API driver
+  (`intel-media-driver` / `libva-mesa-driver`). `hwatu doctor`
+  reports whether it is active.
 
 ## Tiling WM setup
 

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -135,6 +135,21 @@ H13. **Quickmarks + search keywords.** Named shortcuts (`:open
 
 ### D2: abandonment drivers (why people go back to Firefox)
 
+**Shipped 2026-08-08** (all six items; live checks in
+`scripts/test-d2.sh`). H14 was already real — the abp.rs converter
+has compiled EasyList element-hiding into css-display-none
+content-blocker rules since adblock landed; the tier entry was
+stale, and the test now proves it live. H15 as darkmode.rs
+(ctrl+shift+d, invert+hue-rotate with media double-inverted,
+per-host persistence on the site store, `"dark_mode": true` global
+default). H16 as the ClearSiteData verb / `hwatu clear-site-data
+[host]` (WebsiteDataManager clear/fetch+remove, site-store decisions
+and — on full clears — history go with it). H17 as ctrl+shift+m
+(detached mpv spawn). H18 as ctrl+e ($VISUAL/$EDITOR, terminal
+autodetect, non-blocking exit poll, framework-safe paste-back).
+H19 as `"restore_session": true` (restore on clean quit; identity
+via app_id already round-tripped).
+
 H14. **Cosmetic filtering.** Network-level EasyList blocking exists,
     but the #1 stated reason users leave this category is ad quality:
     element hiding is what makes YouTube/news sites bearable.
@@ -223,6 +238,16 @@ is measured solid (142.9fps). No crossfade will be added — native
 does not have one either.
 
 ### D4: niri-native integration (the WM is the browser chrome)
+
+Status 2026-08-08: H29 shipped (`hwatu jump` + the Jump protocol
+verb: open windows first with host-prefix boost, headless agent
+windows excluded, history fallback opens). H30 shipped (profiled
+windows get `hwatu.<profile>`; `"app_ids"` config rules map
+host-suffixes to app ids, longest key wins). H34 shipped
+(reader.rs: readability-lite extraction, additive overlay, alt+r).
+H36 shipped (share.rs: share.conf targets, argv-level substitution,
+no shell). H37 shipped (theme.rs: XDG portal color-scheme followed
+live). Remaining: H28, H31-H33, H35, H38-H40.
 
 Adopted 2026-08-08. Thesis: what makes macOS-Safari feel native is the
 browser treating the OS as its UI toolkit. The tiling-WM equivalent is

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -86,6 +86,22 @@ H8. **PDF viewing.** WebKitGTK ships pdf.js enabled by default;
 
 ### D1: category-defining features (what the audience switches for)
 
+**Shipped 2026-08-08** (all five items). Against the original scope
+below: H9 as history.rs (SQLite, frecency ranking: ln(1+visits) x
+recency bucket x match-quality; host-prefix beats word-boundary beats
+substring), bar completions in URL mode with Down/Tab cycling, and a
+`hwatu history` CLI/protocol verb with `--clear`; headless windows,
+launcher pages, and blanks never recorded, in-memory under ephemeral
+profiles. H10 as hints.rs (`f` follow, `F` new-window, ctrl+shift+y
+yank-to-GDK-clipboard; visibility + elementFromPoint candidate
+filtering, capture-phase key consumption, fail-open). H11 as
+passfill.rs (pass + Bitwarden CLIs, worker-thread lookup, framework-
+safe fill JS; integrate-never-store held). H12 had already shipped
+2026-08-05 as ctrl+shift+t with the 10-deep reopen stack. H13 as
+search.conf keyword lines + quickmarks.conf (per-lookup reads, no
+restart). Live checks: test-history.sh, test-hints.sh,
+test-passfill.sh, test-search-keywords.sh.
+
 Ordered by user-testimony criticality crossed with implementation
 cost. These reverse specific entries in the old not-planned list;
 the reversal is deliberate.

--- a/docs/roadmaps/browser.md
+++ b/docs/roadmaps/browser.md
@@ -30,7 +30,22 @@ drivers.
 
 ### D0: silently broken or one-line-cheap (engine already does it)
 
-Each of these is small because WebKitGTK 2.52 already implements the
+**Shipped 2026-08-08** (all eight items, one pass; live checks in
+`scripts/test-d0.sh`). What shipped, against the original scope below:
+H1 file uploads via GTK FileDialog (MIME filter + multi-select
+honored); H2 WebRTC enabled behind the media-stream gate, which
+gained a persistent `"media_stream": true` config key; H3 as a
+`hwatu doctor` probe (gstreamer `va` plugin + render node) plus
+install docs; H4 via a direct D-Bus forwarder (notify.rs) with click
+routing to window focus and page-side close retraction; H5 as a
+write-through JSON site store (sitedata.rs) holding permission
+decisions and per-site zoom, applied on commit, RAM-only under
+ephemeral profiles; H6 with locale-derived language and
+`"spell_check"`/`"spell_check_languages"` keys; H7 on ctrl+p and the
+`print` signal (one dialog path for both); H8 verified live — the
+response policy handler already lets pdf.js render application/pdf.
+
+Each of these was small because WebKitGTK 2.52 already implements the
 hard part; hwatud just never connected the signal or flipped the
 setting.
 

--- a/docs/roadmaps/platform.md
+++ b/docs/roadmaps/platform.md
@@ -23,13 +23,27 @@ between products and do not make verification depend on the browser shell.
 
 ## Concurrency and isolation
 
-6. **Profiles.** `--profile <name>`: separate cookie jars/site data
+6. **Profiles.** **Shipped 2026-08-08:** `--profile <name>` /
+   `HWATU_PROFILE` give windows isolated WebKit NetworkSessions (own
+   cookie jar + site data under `profiles/<name>/`), lazily created,
+   persistent, memory-only under ephemeral daemons. `auto` derives a
+   stable per-worktree name from the git toplevel, so N agents in N
+   worktrees isolate with zero flags. `scripts/test-profiles.sh`
+   covers sharing/isolation both ways and the on-disk layout.
+   Original scope:
+   `--profile <name>`: separate cookie jars/site data
    per profile, so parallel agents (or one agent testing two accounts)
    don't share sessions. One daemon, N isolated headless sessions.
    Extension for parallel-agent infra: derive the default profile
    from the caller's git worktree (hash of the repo root), so N
    agents in N worktrees get isolation with zero flags.
-6b. **Client fairness.** One runaway agent must not starve the
+6b. **Client fairness.** **Shipped 2026-08-08:** window quota
+   (HWATU_MAX_WINDOWS, default 64) refuses Open with a structured
+   over-quota error; a daemon-wide token bucket (HWATU_MAX_RPS,
+   default 200/s sustained, burst 2x) answers over-rate, with Ping
+   exempt so health checks always work. `scripts/test-fairness.sh`
+   measures refusals under tight limits and recovery after backoff.
+   Original scope: One runaway agent must not starve the
    daemon: per-client window quotas and a bounded per-connection
    request rate, with structured "over quota" errors instead of
    silent queueing. Cheap bulkheads before parallel-agent use gets
@@ -40,18 +54,26 @@ between products and do not make verification depend on the browser shell.
 
 ## Human hand-off
 
-10. **Generalized hand-off.** `challenge` already detects CAPTCHAs;
-   generalize the pattern: agent flags "needs human" with a reason,
-   the window materializes with the reason in the bar, the agent
-   awaits resolution. One command pair, any reason.
-11. **Hand-off queue.** The async half of item 10: `hwatu handoff
-   <id> --reason <text>` queues instead of materializing, `hwatu
-   handoffs` lists pending items with reasons, and the human drains
-   the queue on their own schedule (each entry promotes its window on
-   selection). Respects flow: an agent that needs a human at 14:02
-   should not steal focus at 14:02. Log queued-at/answered-at so the
-   cost of waiting on a human (and of interrupting one) is a measured
-   number, not a vibe.
+10. **Generalized hand-off.** **Shipped 2026-08-08** together with
+   item 11: `hwatu handoff <id> --reason <text> [--now]` — `--now`
+   materializes immediately with the reason in the bar (the
+   challenge pattern generalized to any reason).
+11. **Hand-off queue.** **Shipped 2026-08-08:** queueing is the
+   default (`hwatu handoff` without `--now`); `hwatu handoffs` lists
+   pending entries with measured waiting_secs; `hwatu handoffs <id>`
+   takes one (present + remove + log queued-at/answered-at, so the
+   cost of waiting on a human is a measured number). Takes validate
+   before consuming: a failed take (display-free) leaves the entry
+   queued. All transitions emit handoff events on the push-IPC
+   stream. `scripts/test-handoff.sh` covers queue/list/dedup/take
+   and the structured-error paths.
+   Original scope for both items: `challenge` already detects
+   CAPTCHAs; generalize the pattern: agent flags "needs human" with
+   a reason, the window materializes with the reason in the bar, the
+   agent awaits resolution. The async half: queue instead of
+   materializing, and the human drains the queue on their own
+   schedule. Respects flow: an agent that needs a human at 14:02
+   should not steal focus at 14:02.
 
 ## Push IPC
 
@@ -146,10 +168,11 @@ Test plan:
 
 ## Sequencing and gates
 
-As of 2026-08, push IPC and display-free operation are shipped. The remaining
-open platform sequence is profiles and client fairness, generalized hand-off
-and its queue, then zero-copy pixels. Independent items may proceed in parallel
-when they do not alter the same protocol or runtime boundary.
+As of 2026-08, push IPC, display-free operation, profiles, client
+fairness, and the generalized hand-off + queue are shipped. The one
+remaining open platform item is zero-copy pixels. Independent items
+may proceed in parallel when they do not alter the same protocol or
+runtime boundary.
 
 Every platform change must preserve old-client/new-daemon compatibility, run
 formatting, clippy, unit tests, and the relevant live-daemon script, and publish

--- a/docs/roadmaps/verification.md
+++ b/docs/roadmaps/verification.md
@@ -139,6 +139,18 @@ worth native features; the rest stay non-goals.
 
 ### P3: context hygiene (snapshot output as a budgeted resource)
 
+**Shipped 2026-08-08** (both items; live checks in
+`scripts/test-snapshot-budget.sh`). Item 12 as `snapshot --budget
+<chars>` (snapbudget.rs): coarse-to-fine degradation — text halves
+to a 200-char floor, interactable fields shorten, entries cap at 30
+with an omission marker, final tier is per-tag landmark counts —
+with surviving refs keeping their original numbers. Measured:
+10807-char full snapshot → 2917 under a 4000 budget. Item 13 as an
+instruction-shape tripwire on every snapshot: matching lines move
+from `text` into a labeled `suspect` array with a note naming the
+heuristic. Honest about being heuristic — a tripwire, not a
+guarantee.
+
 Snapshot text goes straight into agent context, so its size and its
 trustworthiness are product surfaces:
 


### PR DESCRIPTION
Combined docs PR superseding #66 and #67 (their commits are merged into this branch).

Roadmap docs now match shipped reality:

**browser.md**
- D0 marked Shipped (H1-H8) with implementation summary
- D1 marked Shipped (H9-H13)
- D2 marked Shipped (H14-H19)
- D4 status note: H29/H30/H34/H36/H37 shipped, H28/H31-H33/H35/H38-H40 remaining

**verification.md**
- P3 marked Shipped (budgeted snapshots with measured 10807→2917 bytes, injection quarantine)

**platform.md**
- Items 6 (profiles), 6b (client fairness), 10+11 (hand-off + queue) marked Shipped
- Sequencing note updated: zero-copy pixels is the one remaining open platform item

**human.md** (from the merged wave-1 branch)
- Daily-driver basics, keybinding table (print/hints/fill), config keys, history/keywords/quickmarks section, calls-and-video notes

Per repo policy: docs via branch + PR, review and merge is yours.