### PR TITLE
feat: IPC over TCP — remote daemon, auth, inline payloads, MCP screenshots

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,42 @@ hwatud --no-eval --ephemeral-profile
 - `--ephemeral-profile` avoids normal persistent browser/session/profile writes for the daemon. It does not make visited sites private from the network, the compositor, the kernel, or other same-user local observation.
 - Secrets visible in page pixels or DOM text may still be exposed by screenshot/snapshot tools even when eval is disabled.
 
+## TCP listener security
+
+When `hwatud --listen` is used, the daemon accepts TCP connections in
+addition to the Unix socket. TCP changes the threat model:
+
+- **Token required for non-loopback.** `--listen 0.0.0.0:8741` or
+  `--listen [::]:8741` requires `--token` (or `HWATU_TOKEN`). The
+  daemon refuses to start without a token on non-loopback binds.
+- **Loopback without token is allowed but weaker.** Any local process
+  can connect (weaker than the 0700 Unix socket). A warning is printed
+  at startup.
+- **Token comparison is constant-time** (FNV-1a hash + u64 equality)
+  to mitigate timing attacks over the network.
+- **Max 64 TCP connections** to prevent fd/queue exhaustion.
+- **Max 32 MiB per frame** to prevent memory exhaustion.
+- **No TLS/encryption.** Use `ssh -L`, WireGuard, or similar for
+  confidentiality. The token authenticates; it is not a transport.
+
+### Attack surface
+
+A successful TCP connection (with valid token) has the same privileges
+as a Unix socket client:
+
+- **eval (RCE):** arbitrary JavaScript in any loaded page
+- **Screenshots:** data exfiltration of visible content
+- **upload/click/type:** drive the user's authenticated browser
+- **quit:** kill the daemon (and potentially the user's session)
+
+### Recommendations
+
+- Always use `--token` for TCP, even on loopback
+- Prefer `ssh -L` tunnels over direct exposure
+- Use `--ephemeral-profile` for untrusted agent workflows
+- Use `--no-eval` if the agent only needs navigation/screenshot
+
+## Reporting security issues
 ## Reporting security issues
 
 Please report suspected vulnerabilities privately when possible. If GitHub private vulnerability reporting is enabled for this repository, use it. Otherwise contact the maintainer listed on the GitHub repository profile, or open a minimal public issue that describes the impact without publishing exploit details. Include your hwatu version, WebKitGTK version, operating system, session type, the daemon startup line, and whether `--no-eval` or `--ephemeral-profile` was in use.

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -150,14 +150,15 @@ impl Opts {
 /// One request, one reply, one connection (the daemon protocol is
 /// one-shot per connection for everything except Subscribe).
 fn call(req: &Request) -> Result<Response, String> {
-    let mut stream = crate::connect_or_spawn().map_err(|e| format!("cannot reach daemon: {e}"))?;
+    let mut reader = crate::connect_or_spawn().map_err(|e| format!("cannot reach daemon: {e}"))?;
     let mut payload = serde_json::to_vec(req).expect("serialize request");
     payload.push(b'\n');
-    stream
+    reader
+        .get_mut()
         .write_all(&payload)
         .map_err(|e| format!("write: {e}"))?;
     let mut line = String::new();
-    BufReader::new(stream)
+    reader
         .read_line(&mut line)
         .map_err(|e| format!("read: {e}"))?;
     serde_json::from_str::<Response>(line.trim()).map_err(|e| format!("bad response: {e}"))

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -543,6 +543,7 @@ fn crop_blank_canvases(cap: &serde_json::Value, live: u64, out: &Path) -> Result
             id: Some(live),
             path: Some(shot.to_string_lossy().into_owned()),
             full: false,
+            data: false,
         })?
         else {
             unreachable!()
@@ -1750,6 +1751,7 @@ fn verify_with(opts: &Opts, live: u64, clone_win: u64) -> Result<serde_json::Val
             id: live,
             other: Some(clone_win),
             baseline: None,
+            baseline_data: None,
             tolerance: opts.tolerance,
             heatmap: None,
             full: false,

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -32,6 +32,25 @@ pub(crate) fn resolve_path(path: Option<String>) -> Option<String> {
     })
 }
 
+/// Read a local file into an inline base64 payload (`--baseline-data`,
+/// `upload --file`). These fields carry file bytes to a *remote*
+/// daemon that cannot see this host's filesystem; the size cap
+/// (`INLINE_MAX_BYTES`) is checked here so a too-big file fails fast
+/// client-side instead of being rejected by the daemon.
+pub(crate) fn read_inline_file(path: &str, flag: &str) -> Result<String, String> {
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("{flag}: cannot read {path}: {e}"))?;
+    if bytes.len() > hwatu_ipc::INLINE_MAX_BYTES {
+        return Err(format!(
+            "{flag}: {path} is {} bytes; the inline cap is {} (24 MiB) \
+             — copy it to the daemon host and pass a path instead",
+            bytes.len(),
+            hwatu_ipc::INLINE_MAX_BYTES
+        ));
+    }
+    Ok(hwatu_ipc::base64::encode(&bytes))
+}
+
 pub(crate) fn normalize_request_paths(request: &mut Request) {
     match request {
         Request::Screenshot { path, .. } => *path = resolve_path(path.take()),
@@ -130,6 +149,7 @@ fn main() {
             adblock,
             value,
             path,
+            data,
         }) => {
             if let Some(w) = window {
                 if json {
@@ -190,6 +210,12 @@ fn main() {
             }
             if let Some(p) = path {
                 println!("{p}");
+            }
+            if let Some(d) = data {
+                // `hwatu shot --stdout`: raw base64 PNG on stdout, for
+                // `hwatu shot --stdout | base64 -d > x.png`. Only the
+                // screenshot command produces `data` today.
+                println!("{d}");
             }
         }
         Ok(Response::Err { message }) => {
@@ -366,6 +392,10 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
     let mut eval_js: Option<String> = None;
     let mut shot = false;
     let mut shot_path: Option<String> = None;
+    let mut shot_data = false;
+    let mut baseline_data: Option<String> = None;
+    let mut upload_file: Option<String> = None;
+    let mut to_stdout = false;
     let mut keep = false;
     let mut diff = false;
     let mut rect = false;
@@ -517,6 +547,28 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                     .ok_or("usage: --baseline <png-path>")?
                     .clone(),
             );
+        } else if arg == "--baseline-data" {
+            let file = it
+                .next()
+                .filter(|v| !v.is_empty())
+                .ok_or("usage: --baseline-data <file>")?;
+            baseline_data = Some(read_inline_file(file, "--baseline-data")?);
+        } else if let Some(v) = arg.strip_prefix("--baseline-data=") {
+            if v.trim().is_empty() {
+                return Err("usage: --baseline-data=<file>".into());
+            }
+            baseline_data = Some(read_inline_file(v, "--baseline-data")?);
+        } else if arg == "--file" {
+            let file = it
+                .next()
+                .filter(|v| !v.is_empty())
+                .ok_or("usage: --file <path>")?;
+            upload_file = Some(file.clone());
+        } else if arg == "--shot-data" {
+            shot_data = true;
+            shot = true;
+        } else if arg == "--stdout" {
+            to_stdout = true;
         } else if arg == "--base" {
             base = Some(
                 it.next()
@@ -695,6 +747,7 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
             id,
             path: rest.get(1).map(|s| s.to_string()),
             full,
+            data: to_stdout,
         }),
         Some("wait-load") => Ok(Request::WaitLoad {
             id,
@@ -758,6 +811,13 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                         .into(),
                 );
             }
+            if baseline.is_some() && baseline_data.is_some() {
+                return Err(
+                    "--baseline and --baseline-data are mutually exclusive \
+                     (baseline-data sends the PNG inline from your filesystem)"
+                        .into(),
+                );
+            }
             Ok(Request::Check {
                 url: Some(url),
                 render: None,
@@ -766,7 +826,9 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                 shot,
                 shot_path,
                 full,
+                shot_data,
                 baseline,
+                baseline_data,
                 tolerance,
                 heatmap,
                 until: until.unwrap_or_default(),
@@ -817,6 +879,13 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                     hwatu_ipc::RENDER_MAX_BYTES
                 ));
             }
+            if baseline.is_some() && baseline_data.is_some() {
+                return Err(
+                    "--baseline and --baseline-data are mutually exclusive \
+                     (baseline-data sends the PNG inline from your filesystem)"
+                        .into(),
+                );
+            }
             Ok(Request::Check {
                 url: None,
                 render: Some(html),
@@ -825,7 +894,9 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                 shot,
                 shot_path,
                 full,
+                shot_data,
                 baseline,
+                baseline_data,
                 tolerance,
                 heatmap,
                 until: until.unwrap_or_default(),
@@ -863,16 +934,30 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
         Some("upload") => {
             let selector = rest
                 .get(1)
-                .ok_or("usage: hwatu upload [--id <id>] <selector> <path>")?
+                .ok_or("usage: hwatu upload [--id <id>] <selector> (--file <path> | <path>)")?
                 .to_string();
-            let path = rest
-                .get(2)
-                .ok_or("usage: hwatu upload [--id <id>] <selector> <path>")?
-                .to_string();
+            let path = match (&upload_file, rest.get(2)) {
+                // --file <path>: the file lives on *our* filesystem;
+                // it is sent inline as base64 (`data`); `path` is
+                // kept as a label the daemon ignores.
+                (Some(file), _) => file.clone(),
+                (None, Some(path)) => path.to_string(),
+                (None, None) => {
+                    return Err(
+                        "usage: hwatu upload [--id <id>] <selector> (--file <path> | <path>)"
+                            .into(),
+                    )
+                }
+            };
+            let data = match upload_file {
+                Some(file) => Some(read_inline_file(&file, "--file")?),
+                None => None,
+            };
             Ok(Request::Upload {
                 id,
                 selector,
                 path,
+                data,
                 timeout_ms,
             })
         }
@@ -959,15 +1044,25 @@ fn parse_with_default_mode(args: &[String], default_mode: OpenMode) -> Result<Re
                 timeout_ms,
             })
         }
-        Some("diff") => Ok(Request::Diff {
-            id: id.ok_or("usage: hwatu diff --id <id> (--other <id> | --baseline <png>) [--tolerance <n>] [--heatmap <png>] [--full]")?,
-            other,
-            baseline,
-            tolerance,
-            heatmap,
-            full,
-            timeout_ms,
-        }),
+        Some("diff") => {
+            if baseline.is_some() && baseline_data.is_some() {
+                return Err(
+                    "--baseline and --baseline-data are mutually exclusive \
+                     (baseline-data sends the PNG inline from your filesystem)"
+                        .into(),
+                );
+            }
+            Ok(Request::Diff {
+                id: id.ok_or("usage: hwatu diff --id <id> (--other <id> | --baseline <png> | --baseline-data <file>) [--tolerance <n>] [--heatmap <png>] [--full]")?,
+                other,
+                baseline,
+                baseline_data,
+                tolerance,
+                heatmap,
+                full,
+                timeout_ms,
+            })
+        }
         Some("click") => {
             let selector = rest.get(1).map(|s| s.to_string());
             if selector.is_none() && r#ref.is_none() {

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -11,7 +11,7 @@ mod onboarding;
 mod update;
 
 use hwatu_ipc::{AdblockCmd, ClockAction, LoadStage, OpenMode, Request, Response, Viewport};
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -120,8 +120,8 @@ fn main() {
     }
 
     let started = Instant::now();
-    let mut stream = match connect_or_spawn() {
-        Ok(s) => s,
+    let mut reader = match connect_or_spawn() {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("hwatu: cannot reach daemon: {e}");
             std::process::exit(1);
@@ -130,13 +130,12 @@ fn main() {
 
     let mut payload = serde_json::to_vec(&request).expect("serialize request");
     payload.push(b'\n');
-    if let Err(e) = stream.write_all(&payload) {
+    if let Err(e) = reader.get_mut().write_all(&payload) {
         eprintln!("hwatu: write failed: {e}");
         std::process::exit(1);
     }
 
     let mut line = String::new();
-    let mut reader = BufReader::new(stream);
     if let Err(e) = reader.read_line(&mut line) {
         eprintln!("hwatu: read failed: {e}");
         std::process::exit(1);
@@ -1357,8 +1356,8 @@ fn watch(args: &[String]) -> i32 {
         }
     }
 
-    let mut stream = match connect_or_spawn() {
-        Ok(s) => s,
+    let mut reader = match connect_or_spawn() {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("hwatu: cannot reach daemon: {e}");
             return 1;
@@ -1367,11 +1366,10 @@ fn watch(args: &[String]) -> i32 {
     let request = Request::Subscribe { kinds, window };
     let mut payload = serde_json::to_vec(&request).expect("serialize request");
     payload.push(b'\n');
-    if let Err(e) = stream.write_all(&payload) {
+    if let Err(e) = reader.get_mut().write_all(&payload) {
         eprintln!("hwatu: write failed: {e}");
         return 1;
     }
-    let reader = BufReader::new(stream);
     for line in reader.lines() {
         match line {
             Ok(l) if !l.trim().is_empty() => {
@@ -1404,8 +1402,8 @@ fn expect_watch(request: Request) -> i32 {
         Request::Expect { id, .. } => *id,
         _ => None,
     };
-    let mut stream = match connect_or_spawn() {
-        Ok(s) => s,
+    let mut reader = match connect_or_spawn() {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("hwatu: cannot reach daemon: {e}");
             return 1;
@@ -1417,12 +1415,11 @@ fn expect_watch(request: Request) -> i32 {
     };
     let mut payload = serde_json::to_vec(&sub).expect("serialize request");
     payload.push(b'\n');
-    if let Err(e) = stream.write_all(&payload) {
+    if let Err(e) = reader.get_mut().write_all(&payload) {
         eprintln!("hwatu: write failed: {e}");
         return 1;
     }
 
-    let mut reader = BufReader::new(stream);
     let mut first = String::new();
     if let Err(e) = reader.read_line(&mut first) {
         eprintln!("hwatu: read failed: {e}");
@@ -1436,7 +1433,7 @@ fn expect_watch(request: Request) -> i32 {
     let _ = std::io::stdout().flush();
 
     let mut install = match connect_or_spawn() {
-        Ok(s) => s,
+        Ok(r) => r,
         Err(e) => {
             eprintln!("hwatu: cannot reach daemon: {e}");
             return 1;
@@ -1444,13 +1441,12 @@ fn expect_watch(request: Request) -> i32 {
     };
     let mut payload = serde_json::to_vec(&request).expect("serialize request");
     payload.push(b'\n');
-    if let Err(e) = install.write_all(&payload) {
+    if let Err(e) = install.get_mut().write_all(&payload) {
         eprintln!("hwatu: write failed: {e}");
         return 1;
     }
     let mut install_line = String::new();
-    let mut install_reader = BufReader::new(install);
-    if let Err(e) = install_reader.read_line(&mut install_line) {
+    if let Err(e) = install.read_line(&mut install_line) {
         eprintln!("hwatu: read failed: {e}");
         return 1;
     }
@@ -1517,12 +1513,16 @@ impl std::io::Write for Connection {
     }
 }
 
-pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
+/// Connect to the daemon and return a BufReader-wrapped connection.
+/// The BufReader is created here so TCP connections can do the auth
+/// handshake with read_line (stops at '\n'), preserving any residual
+/// data that arrived with the auth reply (Nagle coalescing on remote).
+pub(crate) fn connect_or_spawn() -> std::io::Result<BufReader<Connection>> {
     match hwatu_ipc::endpoint() {
         hwatu_ipc::Endpoint::Unix(path) => {
             // Existing behavior: connect or spawn daemon.
             if let Ok(s) = UnixStream::connect(&path) {
-                return Ok(Connection::Unix(s));
+                return Ok(BufReader::new(Connection::Unix(s)));
             }
 
             // No daemon: spawn hwatud (sibling binary or PATH) and poll.
@@ -1539,7 +1539,7 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
             let deadline = Instant::now() + Duration::from_secs(10);
             loop {
                 if let Ok(s) = UnixStream::connect(&path) {
-                    return Ok(Connection::Unix(s));
+                    return Ok(BufReader::new(Connection::Unix(s)));
                 }
                 if Instant::now() > deadline {
                     return Err(std::io::Error::new(
@@ -1553,7 +1553,7 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
         hwatu_ipc::Endpoint::Tcp(addr) => {
             // TCP: connect with timeout, set nodelay, do auth handshake.
             // Never spawn — the daemon lives on the laptop.
-            let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+            let stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(5))
                 .map_err(|e| {
                     std::io::Error::new(
                         std::io::ErrorKind::ConnectionRefused,
@@ -1565,31 +1565,31 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
                 })?;
             stream.set_nodelay(true)?;
 
-            // Auth handshake: send token, wait for reply.
+            // Auth handshake: wrap in BufReader and use read_line so we
+            // stop exactly at '\n'. Any residual data (e.g. the first
+            // response coalesced with the auth reply by Nagle) stays in
+            // the BufReader buffer and is available for the caller's
+            // subsequent read_line of the actual response.
+            let conn = Connection::Tcp(stream);
+            let mut reader = BufReader::new(conn);
+
             let token = std::env::var("HWATU_TOKEN").unwrap_or_default();
             let auth_req = hwatu_ipc::AuthRequest { auth: token };
             let auth_line = serde_json::to_string(&auth_req).unwrap() + "\n";
-            stream.write_all(auth_line.as_bytes())?;
+            reader.get_mut().write_all(auth_line.as_bytes())?;
 
-            // Read reply line.
-            let mut reply_buf = Vec::new();
-            let mut buf = [0u8; 4096];
-            loop {
-                let n = stream.read(&mut buf)?;
-                if n == 0 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        "daemon closed connection during auth",
-                    ));
-                }
-                reply_buf.extend_from_slice(&buf[..n]);
-                if reply_buf.contains(&b'\n') {
-                    break;
-                }
+            let mut reply_line = String::new();
+            let n = reader.read_line(&mut reply_line).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e)
+            })?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "daemon closed connection during auth",
+                ));
             }
-            let reply_str = std::str::from_utf8(&reply_buf).unwrap_or("");
             let reply: hwatu_ipc::AuthReply =
-                serde_json::from_str(reply_str.trim()).map_err(|e| {
+                serde_json::from_str(reply_line.trim()).map_err(|e| {
                     std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!("bad auth reply: {e}"),
@@ -1605,7 +1605,7 @@ pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
                 }
             }
 
-            Ok(Connection::Tcp(stream))
+            Ok(reader)
         }
     }
 }

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -11,7 +11,7 @@ mod onboarding;
 mod update;
 
 use hwatu_ipc::{AdblockCmd, ClockAction, LoadStage, OpenMode, Request, Response, Viewport};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -1486,35 +1486,127 @@ fn expect_event_is_terminal_navigation(line: &str) -> bool {
             == Some(true)
 }
 
-pub(crate) fn connect_or_spawn() -> std::io::Result<UnixStream> {
-    let path = hwatu_ipc::socket_path();
-    if let Ok(s) = UnixStream::connect(&path) {
-        return Ok(s);
+/// IPC connection: Unix socket (local) or TCP (remote daemon).
+pub(crate) enum Connection {
+    Unix(UnixStream),
+    Tcp(std::net::TcpStream),
+}
+
+impl std::io::Read for Connection {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Connection::Unix(s) => s.read(buf),
+            Connection::Tcp(s) => s.read(buf),
+        }
+    }
+}
+
+impl std::io::Write for Connection {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Connection::Unix(s) => s.write(buf),
+            Connection::Tcp(s) => s.write(buf),
+        }
     }
 
-    // No daemon: spawn hwatud (sibling binary or PATH) and poll the socket.
-    let daemon = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("hwatud")))
-        .filter(|p| p.exists())
-        .unwrap_or_else(|| "hwatud".into());
-    Command::new(daemon)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Connection::Unix(s) => s.flush(),
+            Connection::Tcp(s) => s.flush(),
+        }
+    }
+}
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        if let Ok(s) = UnixStream::connect(&path) {
-            return Ok(s);
+pub(crate) fn connect_or_spawn() -> std::io::Result<Connection> {
+    match hwatu_ipc::endpoint() {
+        hwatu_ipc::Endpoint::Unix(path) => {
+            // Existing behavior: connect or spawn daemon.
+            if let Ok(s) = UnixStream::connect(&path) {
+                return Ok(Connection::Unix(s));
+            }
+
+            // No daemon: spawn hwatud (sibling binary or PATH) and poll.
+            let daemon = std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|d| d.join("hwatud")))
+                .filter(|p| p.exists())
+                .unwrap_or_else(|| "hwatud".into());
+            Command::new(daemon)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()?;
+
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                if let Ok(s) = UnixStream::connect(&path) {
+                    return Ok(Connection::Unix(s));
+                }
+                if Instant::now() > deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "daemon did not come up within 10s",
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(15));
+            }
         }
-        if Instant::now() > deadline {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "daemon did not come up within 10s",
-            ));
+        hwatu_ipc::Endpoint::Tcp(addr) => {
+            // TCP: connect with timeout, set nodelay, do auth handshake.
+            // Never spawn — the daemon lives on the laptop.
+            let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        format!(
+                            "cannot reach daemon at tcp://{addr}: {e}\n\
+                             is the daemon listening (hwatud --listen …) and is the tunnel up?"
+                        ),
+                    )
+                })?;
+            stream.set_nodelay(true)?;
+
+            // Auth handshake: send token, wait for reply.
+            let token = std::env::var("HWATU_TOKEN").unwrap_or_default();
+            let auth_req = hwatu_ipc::AuthRequest { auth: token };
+            let auth_line = serde_json::to_string(&auth_req).unwrap() + "\n";
+            stream.write_all(auth_line.as_bytes())?;
+
+            // Read reply line.
+            let mut reply_buf = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = stream.read(&mut buf)?;
+                if n == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "daemon closed connection during auth",
+                    ));
+                }
+                reply_buf.extend_from_slice(&buf[..n]);
+                if reply_buf.contains(&b'\n') {
+                    break;
+                }
+            }
+            let reply_str = std::str::from_utf8(&reply_buf).unwrap_or("");
+            let reply: hwatu_ipc::AuthReply =
+                serde_json::from_str(reply_str.trim()).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("bad auth reply: {e}"),
+                    )
+                })?;
+            match reply {
+                hwatu_ipc::AuthReply::Ok => {}
+                hwatu_ipc::AuthReply::Err { message } => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        format!("daemon auth rejected: {message}"),
+                    ));
+                }
+            }
+
+            Ok(Connection::Tcp(stream))
         }
-        std::thread::sleep(Duration::from_millis(15));
     }
 }
 

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -147,16 +147,16 @@ fn subscribe_events(args: &Value) -> Result<String, String> {
             .collect::<Vec<_>>()
     });
     let window = opt_u64(args, "window");
-    let mut stream =
+    let mut reader =
         crate::connect_or_spawn().map_err(|e| format!("cannot reach hwatu daemon: {e}"))?;
     let request = Request::Subscribe { kinds, window };
     let mut payload = serde_json::to_vec(&request).map_err(|e| e.to_string())?;
     payload.push(b'\n');
-    stream
+    reader
+        .get_mut()
         .write_all(&payload)
         .map_err(|e| format!("write failed: {e}"))?;
     std::thread::spawn(move || {
-        let reader = std::io::BufReader::new(stream);
         for line in reader.lines() {
             let Ok(line) = line else { break };
             let Ok(event) = serde_json::from_str::<Value>(&line) else {
@@ -176,15 +176,16 @@ fn subscribe_events(args: &Value) -> Result<String, String> {
 
 /// One request per connection, like the CLI.
 fn transact(request: &Request) -> Result<Response, String> {
-    let mut stream =
+    let mut reader =
         crate::connect_or_spawn().map_err(|e| format!("cannot reach hwatu daemon: {e}"))?;
     let mut payload = serde_json::to_vec(request).map_err(|e| e.to_string())?;
     payload.push(b'\n');
-    stream
+    reader
+        .get_mut()
         .write_all(&payload)
         .map_err(|e| format!("write failed: {e}"))?;
     let mut line = String::new();
-    std::io::BufReader::new(stream)
+    reader
         .read_line(&mut line)
         .map_err(|e| format!("read failed: {e}"))?;
     serde_json::from_str(line.trim()).map_err(|e| format!("bad daemon response: {e} ({line:?})"))

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -258,13 +258,6 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             until: parse_until(args)?,
             timeout_ms,
         }),
-        "goto" => Ok(Request::Navigate {
-            id,
-            url: req_str(args, "url")?,
-            wait: opt_bool(args, "wait").unwrap_or(true),
-            until: parse_until(args)?,
-            timeout_ms,
-        }),
         "prefetch" => Ok(Request::Prefetch {
             url: req_str(args, "url")?,
         }),
@@ -443,11 +436,6 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             to_y: opt_f64(args, "to_y"),
             by_pages: opt_f64(args, "by_pages"),
             timeout_ms,
-        }),
-        "console" => Ok(Request::Console {
-            id,
-            clear: opt_bool(args, "clear").unwrap_or(false),
-            limit: opt_u64(args, "limit").map(|v| v as usize),
         }),
         "console" => Ok(Request::Console {
             id,

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -344,9 +344,6 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             until: parse_until(args)?,
             timeout_ms,
         }),
-        "prefetch" => Ok(Request::Prefetch {
-            url: req_str(args, "url")?,
-        }),
         "eval" => Ok(Request::Eval {
             id,
             js: req_str(args, "js")?,
@@ -528,24 +525,31 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             clear: opt_bool(args, "clear").unwrap_or(false),
             limit: opt_u64(args, "limit").map(|v| v as usize),
         }),
-        "snapshot" => Ok(Request::Snapshot {
-            id,
-            diff: opt_bool(args, "diff").unwrap_or(false),
-            rect: opt_bool(args, "rect").unwrap_or(false),
-            timeout_ms,
-        }),
         "net" => Ok(Request::Net {
             id,
             clear: opt_bool(args, "clear").unwrap_or(false),
             limit: opt_u64(args, "limit").map(|v| v as usize),
         }),
-        "upload" => Ok(Request::Upload {
-            id,
-            selector: req_str(args, "selector")?,
-            path: req_str(args, "path")?,
-            data: opt_str(args, "data"),
-            timeout_ms,
-        }),
+        "upload" => {
+            let selector = req_str(args, "selector")?;
+            let path = req_str(args, "path")?;
+            let data = if is_tcp_endpoint() {
+                let bytes = std::fs::read(&path).map_err(|e| format!("cannot read upload file '{path}': {e}"))?;
+                if bytes.len() > hwatu_ipc::INLINE_MAX_BYTES {
+                    return Err(format!("upload file '{path}' exceeds {} byte limit", hwatu_ipc::INLINE_MAX_BYTES));
+                }
+                Some(hwatu_ipc::base64::encode(&bytes))
+            } else {
+                opt_str(args, "data")
+            };
+            Ok(Request::Upload {
+                id,
+                selector,
+                path,
+                data,
+                timeout_ms,
+            })
+        }
         "challenge" => Ok(Request::Challenge {
             id,
             wait: opt_bool(args, "wait").unwrap_or(false),

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -267,6 +267,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             id,
             path: opt_str(args, "path"),
             full: opt_bool(args, "full").unwrap_or(false),
+            data: opt_bool(args, "data").unwrap_or(false),
         }),
         "wait_load" => Ok(Request::WaitLoad {
             id,
@@ -307,7 +308,9 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
                 shot: opt_bool(args, "shot").unwrap_or(false),
                 shot_path: opt_str(args, "shot_path"),
                 full: opt_bool(args, "full").unwrap_or(false),
+                shot_data: opt_bool(args, "shot_data").unwrap_or(false),
                 baseline: opt_str(args, "baseline"),
+                baseline_data: opt_str(args, "baseline_data"),
                 tolerance: opt_u64(args, "tolerance").map(|v| v.min(255) as u8),
                 heatmap: opt_str(args, "heatmap"),
                 until: parse_until(args)?,
@@ -339,7 +342,9 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
                 shot: opt_bool(args, "shot").unwrap_or(false),
                 shot_path: opt_str(args, "shot_path"),
                 full: opt_bool(args, "full").unwrap_or(false),
+                shot_data: opt_bool(args, "shot_data").unwrap_or(false),
                 baseline: opt_str(args, "baseline"),
+                baseline_data: opt_str(args, "baseline_data"),
                 tolerance: opt_u64(args, "tolerance").map(|v| v.min(255) as u8),
                 heatmap: opt_str(args, "heatmap"),
                 until: parse_until(args)?,
@@ -443,6 +448,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             id,
             selector: req_str(args, "selector")?,
             path: req_str(args, "path")?,
+            data: opt_str(args, "data"),
             timeout_ms,
         }),
         "challenge" => Ok(Request::Challenge {
@@ -504,13 +510,18 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
         "diff" => {
             let other = opt_u64(args, "other");
             let baseline = opt_str(args, "baseline");
-            if other.is_none() && baseline.is_none() {
-                return Err("diff needs `other` (window id) or `baseline` (PNG path)".into());
+            let baseline_data = opt_str(args, "baseline_data");
+            if other.is_none() && baseline.is_none() && baseline_data.is_none() {
+                return Err(
+                    "diff needs `other` (window id), `baseline` (PNG path), or `baseline_data` (PNG inline)"
+                        .into(),
+                );
             }
             Ok(Request::Diff {
                 id: opt_u64(args, "id").ok_or("missing required argument: id")?,
                 other,
                 baseline,
+                baseline_data,
                 tolerance: opt_u64(args, "tolerance").map(|v| v.min(255) as u8),
                 heatmap: opt_str(args, "heatmap"),
                 full: opt_bool(args, "full").unwrap_or(false),

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -15,9 +15,10 @@
 use hwatu_ipc::{ClockAction, Endpoint, LoadStage, OpenMode, Request, Response, Viewport};
 use serde_json::{json, Value};
 use std::io::{BufRead, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 static EVENT_THREAD: AtomicBool = AtomicBool::new(false);
+static SHOT_SEQ: AtomicU64 = AtomicU64::new(0);
 
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
@@ -117,61 +118,69 @@ fn is_tcp_endpoint() -> bool {
     matches!(hwatu_ipc::endpoint(), Endpoint::Tcp(_))
 }
 
-/// Transform `shot_data` fields in a check/render response value into
-/// MCP image blocks. Walks the top-level object and any `viewports`
-/// array, converting `"shot_data": "<base64>"` to
-/// `"shot_image": { "type": "image", "data": "...", "mimeType": "image/png" }`.
-fn format_response_value(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => {
-            let mut new_map = map.clone();
-            if let Some(shot_data) = new_map.remove("shot_data") {
-                new_map.insert(
-                    "shot_image".to_string(),
-                    json!({
-                        "type": "image",
-                        "data": shot_data,
-                        "mimeType": "image/png",
-                    }),
-                );
-            }
-            if let Some(Value::Array(ref viewports)) = new_map.get("viewports") {
-                let transformed: Vec<Value> = viewports
-                    .iter()
-                    .map(format_response_value)
-                    .collect();
-                new_map.insert("viewports".to_string(), Value::Array(transformed));
-            }
-            Value::Object(new_map)
+/// Decode a base64 PNG, write it to a local temp file, return the path.
+/// Named `/tmp/hwatu-mcp-<pid>-<seq>.png` (bounded, orphaned on exit).
+fn write_shot(data: &str) -> Result<String, String> {
+    let bytes = hwatu_ipc::base64::decode(data)
+        .map_err(|e| format!("invalid shot data: {e}"))?;
+    let seq = SHOT_SEQ.fetch_add(1, Ordering::Relaxed);
+    let path = format!("/tmp/hwatu-mcp-{}-{}.png", std::process::id(), seq);
+    std::fs::write(&path, &bytes)
+        .map_err(|e| format!("cannot write shot to {path}: {e}"))?;
+    Ok(path)
+}
+
+/// Transform `shot_data` fields in a check/render response into local
+/// file paths. Decodes base64, writes temp file, replaces `shot` with
+/// the local path and removes `shot_data`. Walks `viewports` arrays
+/// recursively for multi-viewport sweeps.
+fn format_shot_data(text: &str) -> String {
+    let Ok(mut v) = serde_json::from_str::<Value>(text) else {
+        return text.to_string();
+    };
+    transform_shot_data(&mut v);
+    serde_json::to_string(&v).unwrap_or(text.to_string())
+}
+
+fn transform_shot_data(value: &mut Value) {
+    let Value::Object(map) = value else { return };
+    if let Some(shot_data) = map.get("shot_data").and_then(Value::as_str) {
+        if let Ok(path) = write_shot(shot_data) {
+            map.insert("shot".to_string(), json!(path));
+            map.remove("shot_data");
         }
-        _ => value.clone(),
+    }
+    if let Some(Value::Array(viewports)) = map.get_mut("viewports") {
+        for vp in viewports {
+            transform_shot_data(vp);
+        }
     }
 }
 
-/// Format a tool response as MCP content blocks.
-/// When the response carries `data` (screenshot base64), returns an
-/// image block + optional metadata text. Otherwise returns text.
+/// Format a tool response as MCP content.
+/// Over TCP: decodes inline `data` (base64 screenshot), writes a local
+/// temp file, and replaces `data` with `path` so the agent sees a
+/// readable file path (identical to the Unix socket flow).
+/// Over Unix: returns the text unchanged.
 fn tool_content(text: &str, is_error: bool) -> Value {
-    // Try to parse as Response::Ok with a `data` field.
-    if let Ok(Response::Ok {
+    let Ok(Response::Ok {
         data: Some(ref data),
-        window,
         ..
-    }) = serde_json::from_str::<Response>(text) {
-        let mut content = vec![json!({
-            "type": "image",
-            "data": data,
-            "mimeType": "image/png",
-        })];
-        if let Some(w) = window {
-            content.push(json!({
-                "type": "text",
-                "text": serde_json::to_string(&w).unwrap_or_default(),
-            }));
-        }
-        return json!({ "content": content, "isError": is_error });
+    }) = serde_json::from_str::<Response>(text) else {
+        return tool_text(text, is_error);
+    };
+    // Decode base64, write local temp file, replace data with path.
+    let Ok(path) = write_shot(data) else {
+        return tool_text(text, is_error);
+    };
+    let Ok(mut v) = serde_json::from_str::<Value>(text) else {
+        return tool_text(text, is_error);
+    };
+    if let Value::Object(map) = &mut v {
+        map.remove("data");
+        map.insert("path".to_string(), json!(path));
     }
-    tool_text(text, is_error)
+    tool_text(&serde_json::to_string(&v).unwrap_or(text.to_string()), is_error)
 }
 
 /// `tools/call` -> daemon roundtrip -> response text.
@@ -195,12 +204,7 @@ fn handle_tool_call(params: &Value) -> Result<Value, Value> {
         ok => serde_json::to_string(&ok).map_err(|e| tool_text(&e.to_string(), true))?,
     };
     let transformed = if is_tcp_endpoint() {
-        if let Ok(mut v) = serde_json::from_str::<Value>(&text) {
-            v = format_response_value(&v);
-            serde_json::to_string(&v).unwrap_or(text)
-        } else {
-            text
-        }
+        format_shot_data(&text)
     } else {
         text
     };

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -150,10 +150,15 @@ fn transform_shot_data(value: &mut Value) {
             map.remove("shot_data");
         }
     }
+    // Descend into nested objects that may carry shot_data:
+    // `value` (check/render result) and `viewports` (per-size entries).
     if let Some(Value::Array(viewports)) = map.get_mut("viewports") {
         for vp in viewports {
             transform_shot_data(vp);
         }
+    }
+    if let Some(nested) = map.get_mut("value") {
+        transform_shot_data(nested);
     }
 }
 

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -258,6 +258,16 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             until: parse_until(args)?,
             timeout_ms,
         }),
+        "goto" => Ok(Request::Navigate {
+            id,
+            url: req_str(args, "url")?,
+            wait: opt_bool(args, "wait").unwrap_or(true),
+            until: parse_until(args)?,
+            timeout_ms,
+        }),
+        "prefetch" => Ok(Request::Prefetch {
+            url: req_str(args, "url")?,
+        }),
         "eval" => Ok(Request::Eval {
             id,
             js: req_str(args, "js")?,
@@ -438,6 +448,17 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             id,
             clear: opt_bool(args, "clear").unwrap_or(false),
             limit: opt_u64(args, "limit").map(|v| v as usize),
+        }),
+        "console" => Ok(Request::Console {
+            id,
+            clear: opt_bool(args, "clear").unwrap_or(false),
+            limit: opt_u64(args, "limit").map(|v| v as usize),
+        }),
+        "snapshot" => Ok(Request::Snapshot {
+            id,
+            diff: opt_bool(args, "diff").unwrap_or(false),
+            rect: opt_bool(args, "rect").unwrap_or(false),
+            timeout_ms,
         }),
         "net" => Ok(Request::Net {
             id,

--- a/crates/hwatu/src/mcp.rs
+++ b/crates/hwatu/src/mcp.rs
@@ -12,7 +12,7 @@
 //! The daemon is autostarted on the first tool call, like every other
 //! `hwatu` invocation.
 
-use hwatu_ipc::{ClockAction, LoadStage, OpenMode, Request, Response, Viewport};
+use hwatu_ipc::{ClockAction, Endpoint, LoadStage, OpenMode, Request, Response, Viewport};
 use serde_json::{json, Value};
 use std::io::{BufRead, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -52,8 +52,8 @@ pub fn run() -> i32 {
             "ping" => jsonrpc_result(id, json!({})),
             "tools/list" => jsonrpc_result(id, json!({ "tools": tool_definitions() })),
             "tools/call" => match handle_tool_call(&params) {
-                Ok(text) => jsonrpc_result(id, tool_text(&text, false)),
-                Err(text) => jsonrpc_result(id, tool_text(&text, true)),
+                Ok(content) => jsonrpc_result(id, content),
+                Err(content) => jsonrpc_result(id, content),
             },
             // Optional capabilities we don't provide.
             "resources/list" => jsonrpc_result(id, json!({ "resources": [] })),
@@ -112,23 +112,99 @@ fn tool_text(text: &str, is_error: bool) -> Value {
     })
 }
 
+/// True when the IPC endpoint is TCP (remote daemon).
+fn is_tcp_endpoint() -> bool {
+    matches!(hwatu_ipc::endpoint(), Endpoint::Tcp(_))
+}
+
+/// Transform `shot_data` fields in a check/render response value into
+/// MCP image blocks. Walks the top-level object and any `viewports`
+/// array, converting `"shot_data": "<base64>"` to
+/// `"shot_image": { "type": "image", "data": "...", "mimeType": "image/png" }`.
+fn format_response_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut new_map = map.clone();
+            if let Some(shot_data) = new_map.remove("shot_data") {
+                new_map.insert(
+                    "shot_image".to_string(),
+                    json!({
+                        "type": "image",
+                        "data": shot_data,
+                        "mimeType": "image/png",
+                    }),
+                );
+            }
+            if let Some(Value::Array(ref viewports)) = new_map.get("viewports") {
+                let transformed: Vec<Value> = viewports
+                    .iter()
+                    .map(format_response_value)
+                    .collect();
+                new_map.insert("viewports".to_string(), Value::Array(transformed));
+            }
+            Value::Object(new_map)
+        }
+        _ => value.clone(),
+    }
+}
+
+/// Format a tool response as MCP content blocks.
+/// When the response carries `data` (screenshot base64), returns an
+/// image block + optional metadata text. Otherwise returns text.
+fn tool_content(text: &str, is_error: bool) -> Value {
+    // Try to parse as Response::Ok with a `data` field.
+    if let Ok(Response::Ok {
+        data: Some(ref data),
+        window,
+        ..
+    }) = serde_json::from_str::<Response>(text) {
+        let mut content = vec![json!({
+            "type": "image",
+            "data": data,
+            "mimeType": "image/png",
+        })];
+        if let Some(w) = window {
+            content.push(json!({
+                "type": "text",
+                "text": serde_json::to_string(&w).unwrap_or_default(),
+            }));
+        }
+        return json!({ "content": content, "isError": is_error });
+    }
+    tool_text(text, is_error)
+}
+
 /// `tools/call` -> daemon roundtrip -> response text.
-fn handle_tool_call(params: &Value) -> Result<String, String> {
+fn handle_tool_call(params: &Value) -> Result<Value, Value> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
         .ok_or("missing tool name")?;
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
     if name == "subscribe_events" {
-        return subscribe_events(&args);
+        return match subscribe_events(&args) {
+            Ok(text) => Ok(tool_text(&text, false)),
+            Err(text) => Err(tool_text(&text, true)),
+        };
     }
     let mut request = build_request(name, &args)?;
     crate::normalize_request_paths(&mut request);
     let response = transact(&request)?;
-    match response {
-        Response::Err { message } => Err(message),
-        ok => serde_json::to_string(&ok).map_err(|e| e.to_string()),
-    }
+    let text = match response {
+        Response::Err { message } => return Err(tool_text(&message, true)),
+        ok => serde_json::to_string(&ok).map_err(|e| tool_text(&e.to_string(), true))?,
+    };
+    let transformed = if is_tcp_endpoint() {
+        if let Ok(mut v) = serde_json::from_str::<Value>(&text) {
+            v = format_response_value(&v);
+            serde_json::to_string(&v).unwrap_or(text)
+        } else {
+            text
+        }
+    } else {
+        text
+    };
+    Ok(tool_content(&transformed, false))
 }
 
 /// Start (once) a background thread that holds a subscribed
@@ -271,7 +347,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
             id,
             path: opt_str(args, "path"),
             full: opt_bool(args, "full").unwrap_or(false),
-            data: opt_bool(args, "data").unwrap_or(false),
+            data: is_tcp_endpoint() || opt_bool(args, "data").unwrap_or(false),
         }),
         "wait_load" => Ok(Request::WaitLoad {
             id,
@@ -312,7 +388,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
                 shot: opt_bool(args, "shot").unwrap_or(false),
                 shot_path: opt_str(args, "shot_path"),
                 full: opt_bool(args, "full").unwrap_or(false),
-                shot_data: opt_bool(args, "shot_data").unwrap_or(false),
+                shot_data: is_tcp_endpoint() || opt_bool(args, "shot_data").unwrap_or(false),
                 baseline: opt_str(args, "baseline"),
                 baseline_data: opt_str(args, "baseline_data"),
                 tolerance: opt_u64(args, "tolerance").map(|v| v.min(255) as u8),
@@ -346,7 +422,7 @@ pub(crate) fn build_request(name: &str, args: &Value) -> Result<Request, String>
                 shot: opt_bool(args, "shot").unwrap_or(false),
                 shot_path: opt_str(args, "shot_path"),
                 full: opt_bool(args, "full").unwrap_or(false),
-                shot_data: opt_bool(args, "shot_data").unwrap_or(false),
+                shot_data: is_tcp_endpoint() || opt_bool(args, "shot_data").unwrap_or(false),
                 baseline: opt_str(args, "baseline"),
                 baseline_data: opt_str(args, "baseline_data"),
                 tolerance: opt_u64(args, "tolerance").map(|v| v.min(255) as u8),
@@ -643,6 +719,7 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
                 "eval": prop("string", "JS to run once loaded (expression or function body)."),
                 "shot": prop("boolean", "Take a screenshot to a temp file."),
                 "shot_path": prop("string", "Screenshot destination (implies shot)."),
+                "shot_data": prop("boolean", "Return screenshot as base64 image content (default true over TCP)."),
                 "full": prop("boolean", "Screenshot/diff the full document, not just the viewport."),
                 "baseline": prop("string", "Baseline PNG path: pixel-diff the loaded page against it and include match_percent + mismatch regions in the reply."),
                 "tolerance": prop("integer", "Per-channel diff tolerance 0-255 (default 8; only with baseline)."),
@@ -670,6 +747,7 @@ pub(crate) fn tool_definitions() -> Vec<Value> {
                 "eval": prop("string", "JS to run once loaded (expression or function body)."),
                 "shot": prop("boolean", "Take a screenshot to a temp file."),
                 "shot_path": prop("string", "Screenshot destination (implies shot)."),
+                "shot_data": prop("boolean", "Return screenshot as base64 image content (default true over TCP)."),
                 "full": prop("boolean", "Screenshot/diff the full document, not just the viewport."),
                 "baseline": prop("string", "Baseline PNG path: pixel-diff the rendered page against it."),
                 "tolerance": prop("integer", "Per-channel diff tolerance 0-255 (default 8; only with baseline)."),

--- a/crates/hwatu/src/onboarding.rs
+++ b/crates/hwatu/src/onboarding.rs
@@ -210,6 +210,7 @@ fn smoke_test() -> Result<String, String> {
             id: Some(id),
             path: Some(shot.to_string_lossy().into_owned()),
             full: false,
+            data: false,
         }) {
             Ok(Response::Ok { .. }) => match fs::metadata(&shot) {
                 Ok(meta) if meta.len() > 0 => {
@@ -686,6 +687,7 @@ fn demo(args: &[String]) -> i32 {
         id: Some(id),
         path: None,
         full: false,
+        data: false,
     }) {
         Ok(Response::Ok { path: Some(p), .. }) => println!("demo: screenshot -> {p}"),
         other => {

--- a/crates/hwatu/src/onboarding.rs
+++ b/crates/hwatu/src/onboarding.rs
@@ -717,13 +717,13 @@ fn demo(args: &[String]) -> i32 {
 // ===================================================================
 
 fn send(request: &Request) -> Result<Response, String> {
-    use std::io::{BufRead, BufReader, Write};
-    let mut stream = crate::connect_or_spawn().map_err(|e| e.to_string())?;
+    use std::io::{BufRead, Write};
+    let mut reader = crate::connect_or_spawn().map_err(|e| e.to_string())?;
     let mut payload = serde_json::to_vec(request).expect("serialize request");
     payload.push(b'\n');
-    stream.write_all(&payload).map_err(|e| e.to_string())?;
+    reader.get_mut().write_all(&payload).map_err(|e| e.to_string())?;
     let mut line = String::new();
-    BufReader::new(stream)
+    reader
         .read_line(&mut line)
         .map_err(|e| e.to_string())?;
     serde_json::from_str(line.trim()).map_err(|e| format!("bad response: {e}"))

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -747,7 +747,9 @@ pub fn check(
     shot: bool,
     shot_path: Option<String>,
     full: bool,
+    shot_data: bool,
     baseline: Option<String>,
+    baseline_data: Option<String>,
     tolerance: Option<u8>,
     heatmap: Option<String>,
     until: LoadStage,
@@ -773,10 +775,32 @@ pub fn check(
     if baseline_dir.is_some() && viewports.is_empty() {
         return reply.send(Response::err("`baseline_dir` requires `viewports`"));
     }
+    if baseline_data.is_some() && !viewports.is_empty() {
+        return reply.send(Response::err(
+            "pass `baseline_dir` (per-size baselines), not `baseline_data`, with `viewports`",
+        ));
+    }
     if baseline.is_some() && !viewports.is_empty() {
         return reply.send(Response::err(
             "pass `baseline_dir` (per-size baselines), not `baseline`, with `viewports`",
         ));
+    }
+    // Baseline inputs are mutually exclusive: a path baseline lives
+    // on the daemon host, an inline one on the client's filesystem.
+    if baseline.is_some() && baseline_data.is_some() {
+        return reply.send(Response::err(
+            "`baseline` and `baseline_data` are mutually exclusive",
+        ));
+    }
+    if let Some(b64) = &baseline_data {
+        // The client checks INLINE_MAX_BYTES; check again because
+        // clients are not trusted.
+        if b64.len() > hwatu_ipc::INLINE_MAX_BYTES * 4 / 3 + 4 {
+            return reply.send(Response::err(format!(
+                "baseline_data is too large (cap {} decoded bytes)",
+                hwatu_ipc::INLINE_MAX_BYTES
+            )));
+        }
     }
     if let Some(html) = &render {
         if html.len() > hwatu_ipc::RENDER_MAX_BYTES {
@@ -870,8 +894,9 @@ pub fn check(
                 win_id,
                 viewports: viewports.clone(),
                 eval_js: eval_js.clone(),
-                shot: shot || shot_path.is_some(),
+                shot: shot || shot_path.is_some() || shot_data,
                 shot_path: shot_path.clone(),
+                shot_data,
                 full,
                 baseline_dir: baseline_dir.clone(),
                 tolerance,
@@ -964,19 +989,26 @@ pub fn check(
                 }),
             );
         }
-        if shot || shot_path.is_some() {
+        if shot || shot_path.is_some() || shot_data {
             pending.set(pending.get() + 1);
             let finish = finish.clone();
             let result = result.clone();
+            // shot_data captures to memory and returns base64 for a
+            // remote client; `path` (and the `shot` reply field) keep
+            // their local meaning when the caller asked for a file.
             screenshot(
                 &daemon,
                 Some(win_id),
                 shot_path,
                 full,
+                shot_data,
                 Box::new(move |resp| {
                     match resp {
                         Response::Ok { path: Some(p), .. } => {
                             result.borrow_mut()["shot"] = serde_json::json!(p);
+                        }
+                        Response::Ok { data: Some(b64), .. } => {
+                            result.borrow_mut()["shot_data"] = serde_json::json!(b64);
                         }
                         Response::Err { message } => {
                             result.borrow_mut()["shot"] = serde_json::json!({ "error": message });
@@ -996,7 +1028,27 @@ pub fn check(
                 win_id,
                 png,
                 tolerance,
-                heatmap,
+                heatmap.clone(),
+                full,
+                Box::new(move |value| {
+                    result.borrow_mut()["diff"] = match value {
+                        Ok(v) => v,
+                        Err(e) => serde_json::json!({ "error": e }),
+                    };
+                    finish();
+                }),
+            );
+        }
+        if let Some(b64) = baseline_data {
+            pending.set(pending.get() + 1);
+            let finish = finish.clone();
+            let result = result.clone();
+            crate::verify::diff_against_baseline_data(
+                &daemon,
+                win_id,
+                b64,
+                tolerance,
+                heatmap.clone(),
                 full,
                 Box::new(move |value| {
                     result.borrow_mut()["diff"] = match value {
@@ -1055,6 +1107,7 @@ struct Sweep {
     eval_js: Option<String>,
     shot: bool,
     shot_path: Option<String>,
+    shot_data: bool,
     full: bool,
     baseline_dir: Option<String>,
     tolerance: Option<u8>,
@@ -1164,10 +1217,14 @@ fn sweep_pass(sweep: Rc<Sweep>, i: usize) {
                     Some(sweep.win_id),
                     path,
                     sweep.full,
+                    sweep.shot_data,
                     Box::new(move |resp| {
                         match resp {
                             Response::Ok { path: Some(p), .. } => {
                                 entry.borrow_mut()["shot"] = serde_json::json!(p);
+                            }
+                            Response::Ok { data: Some(b64), .. } => {
+                                entry.borrow_mut()["shot_data"] = serde_json::json!(b64);
                             }
                             Response::Err { message } => {
                                 entry.borrow_mut()["shot"] =
@@ -1546,6 +1603,7 @@ pub fn screenshot(
     id: Option<u64>,
     path: Option<String>,
     full: bool,
+    data: bool,
     reply: Reply,
 ) {
     let reply = OnceReply::new(reply);
@@ -1589,16 +1647,24 @@ pub fn screenshot(
                 let width = texture.width() as u32;
                 let height = texture.height() as u32;
                 glib::spawn_future_local(async move {
-                    let path = target.clone();
+                    let target_path = target.clone();
                     let encoded = gio::spawn_blocking(move || {
-                        write_png(&path, &bytes, stride, width, height)
+                        if data {
+                            encode_png(&bytes, stride, width, height)
+                        } else {
+                            write_png(&target, &bytes, stride, width, height)?;
+                            Ok(Vec::new())
+                        }
                     })
                     .await;
                     match encoded {
-                        Ok(Ok(())) => reply.send(Response::path(target.to_string_lossy())),
+                        Ok(Ok(png)) if data => {
+                            reply.send(Response::data(hwatu_ipc::base64::encode(&png)))
+                        }
+                        Ok(Ok(_)) => reply.send(Response::path(target_path.to_string_lossy())),
                         Ok(Err(e)) => reply.send(Response::err(format!(
                             "screenshot write to {} failed: {e}",
-                            target.display()
+                            target_path.display()
                         ))),
                         Err(_) => reply.send(Response::err("screenshot encode panicked")),
                     }
@@ -1609,18 +1675,18 @@ pub fn screenshot(
     );
 }
 
-/// Encode RGBA rows (possibly padded to `stride`) as a PNG. Fast
+/// Encode RGBA rows (possibly padded to `stride`) as PNG bytes. Fast
 /// compression + Sub filtering: screenshots are verification
 /// artifacts, so encode speed beats squeezing out the last few KB.
-fn write_png(
-    path: &std::path::Path,
+/// Shared by the file-writing path and the inline `data` path.
+fn encode_png(
     rgba: &[u8],
     stride: usize,
     width: u32,
     height: u32,
-) -> Result<(), String> {
-    let file = std::fs::File::create(path).map_err(|e| e.to_string())?;
-    let mut encoder = png::Encoder::new(std::io::BufWriter::new(file), width, height);
+) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(width as usize * height as usize * 4 / 2 + 64);
+    let mut encoder = png::Encoder::new(&mut out, width, height);
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     encoder.set_compression(png::Compression::Fast);
@@ -1636,36 +1702,62 @@ fn write_png(
         }
         writer.write_image_data(&tight).map_err(|e| e.to_string())?;
     }
-    writer.finish().map_err(|e| e.to_string())
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(out)
 }
 
-/// Set a file input's files from a path on disk. The bytes travel
-/// into the page as base64 inside a JS snippet, are decoded to a
-/// `File`, and assigned through `DataTransfer`, the same technique
-/// every automation harness uses, since engines allow assigning
-/// `input.files` but not opening the OS picker programmatically.
+/// Encode to PNG bytes and write them to `path`.
+fn write_png(
+    path: &std::path::Path,
+    rgba: &[u8],
+    stride: usize,
+    width: u32,
+    height: u32,
+) -> Result<(), String> {
+    let png = encode_png(rgba, stride, width, height)?;
+    std::fs::write(path, png).map_err(|e| e.to_string())
+}
+
+/// Set a file input's files from a path on disk (or inline bytes).
+/// The bytes travel into the page as base64 inside a JS snippet, are
+/// decoded to a `File`, and assigned through `DataTransfer`, the
+/// same technique every automation harness uses, since engines allow
+/// assigning `input.files` but not opening the OS picker
+/// programmatically.
 pub fn upload(
     daemon: &Rc<Daemon>,
     id: Option<u64>,
     selector: String,
     path: String,
+    data: Option<String>,
     timeout_ms: Option<u64>,
     reply: Reply,
 ) {
-    let bytes = match std::fs::read(&path) {
-        Ok(b) => b,
-        Err(e) => {
-            return OnceReply::new(reply).send(Response::err(format!("cannot read {path}: {e}")));
-        }
+    // `data` (inline base64 from a remote client) wins over `path`:
+    // the client cannot read the daemon host's filesystem. The
+    // client checks INLINE_MAX_BYTES before sending; check again
+    // here because clients are not trusted.
+    let bytes = match data {
+        Some(b64) => match hwatu_ipc::base64::decode(&b64) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                return OnceReply::new(reply)
+                    .send(Response::err(format!("upload: bad inline data: {e}")));
+            }
+        },
+        None => match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) => {
+                return OnceReply::new(reply)
+                    .send(Response::err(format!("cannot read {path}: {e}")));
+            }
+        },
     };
-    // Keep IPC and JS-source sizes sane: 32 MiB of payload is ~43 MiB
-    // of base64 in a script string. Enough for fixtures and documents;
-    // bulk uploads should not go through a JS harness anyway.
-    const MAX: usize = 32 * 1024 * 1024;
-    if bytes.len() > MAX {
+    if bytes.len() > hwatu_ipc::INLINE_MAX_BYTES {
         return OnceReply::new(reply).send(Response::err(format!(
-            "{path} is {} bytes; upload supports at most {MAX} (32 MiB)",
-            bytes.len()
+            "{path} is {} bytes; upload supports at most {} (24 MiB)",
+            bytes.len(),
+            hwatu_ipc::INLINE_MAX_BYTES
         )));
     }
     let name = std::path::Path::new(&path)

--- a/crates/hwatud/src/automation.rs
+++ b/crates/hwatud/src/automation.rs
@@ -2480,6 +2480,7 @@ return {
                     windows,
                     adblock,
                     path,
+                    data,
                 } => {
                     let value = match budget {
                         Some(budget) => crate::snapbudget::apply(value, budget),
@@ -2491,6 +2492,7 @@ return {
                         windows,
                         adblock,
                         path,
+                        data,
                     }
                 }
                 other => other,

--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -11,7 +11,15 @@ use hwatu_ipc::{AdblockCmd, BatchResult, BatchStepResult, BatchStepStatus, Reque
 use std::cell::RefCell;
 use std::rc::Rc;
 
-pub fn start(daemon: Rc<Daemon>) -> std::io::Result<()> {
+/// Max bytes per frame (line) on the wire. Covers the 8 MiB render
+/// cap and ~24 MiB of inline base64 payloads. Oversize → close.
+const MAX_FRAME_BYTES: usize = 32 * 1024 * 1024;
+
+/// Max concurrent TCP connections. Prevents fd/queue exhaustion.
+/// Unix socket connections are uncapped (same-user trust).
+const MAX_TCP_CONNS: u32 = 64;
+
+pub fn start(daemon: Rc<Daemon>, tcp_listen: Option<&str>) -> std::io::Result<()> {
     let path = hwatu_ipc::socket_path();
     // Stale socket from a dead daemon: remove and rebind.
     let _ = std::fs::remove_file(&path);
@@ -27,24 +35,166 @@ pub fn start(daemon: Rc<Daemon>) -> std::io::Result<()> {
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
+    // Add TCP listener if configured.
+    if let Some(tcp_addr) = tcp_listen {
+        let inet_addr = parse_tcp_listen_addr(tcp_addr)?;
+        listener
+            .add_address(
+                &inet_addr,
+                gio::SocketType::Stream,
+                gio::SocketProtocol::Tcp,
+                glib::Object::NONE,
+            )
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+    }
+
     accept_next(listener, daemon);
     Ok(())
 }
+
+/// Parse `[host:]port` into a gio InetSocketAddress.
+fn parse_tcp_listen_addr(addr: &str) -> std::io::Result<gio::InetSocketAddress> {
+    // gio::InetSocketAddress::from_string parses "host:port" but
+    // the port param is additive (0 = use port from string).
+    if let Some(inet_addr) = gio::InetSocketAddress::from_string(addr, 0) {
+        return Ok(inet_addr);
+    }
+    // Manual parse: split on last colon.
+    let parts: Vec<&str> = addr.rsplitn(2, ':').collect();
+    let (host, port_str) = if parts.len() == 2 {
+        (parts[1], parts[0])
+    } else {
+        ("127.0.0.1", addr)
+    };
+    let port: u16 = port_str.parse().map_err(|_| {
+        std::io::Error::other(format!("invalid TCP port in {addr}: {port_str}"))
+    })?;
+    let inet_addr = gio::InetAddress::from_string(host)
+        .ok_or_else(|| std::io::Error::other(format!("cannot resolve host: {host}")))?;
+    Ok(gio::InetSocketAddress::new(&inet_addr, port))
+}
+
+/// Shared TCP connection counter (incremented on accept, decremented on close).
+static TCP_CONN_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 fn accept_next(listener: gio::SocketListener, daemon: Rc<Daemon>) {
     listener
         .clone()
         .accept_async(gio::Cancellable::NONE, move |res| {
-            if let Ok((conn, _)) = res {
-                handle_conn(conn, daemon.clone());
+            let (conn, _) = match res {
+                Ok(r) => r,
+                Err(_) => {
+                    accept_next(listener, daemon);
+                    return;
+                }
+            };
+            // Check if this is a TCP connection (not Unix socket).
+            let is_tcp = is_tcp_connection(&conn);
+            if is_tcp {
+                // Enforce max TCP connections.
+                let count = TCP_CONN_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if count >= MAX_TCP_CONNS {
+                    TCP_CONN_COUNT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                    // Close immediately — over capacity.
+                    return;
+                }
+                // Set TCP_NODELAY for low-latency IPC.
+                // IPPROTO_TCP = 6, TCP_NODELAY = 1 on Linux.
+                let _ = conn.socket().set_option(6, 1, 1);
             }
+            handle_conn(conn, daemon.clone(), is_tcp);
             accept_next(listener, daemon);
         });
 }
 
-fn handle_conn(conn: gio::SocketConnection, daemon: Rc<Daemon>) {
+/// Check if a connection is TCP (not Unix socket) by inspecting the socket family.
+fn is_tcp_connection(conn: &gio::SocketConnection) -> bool {
+    matches!(
+        conn.socket().family(),
+        gio::SocketFamily::Ipv4 | gio::SocketFamily::Ipv6
+    )
+}
+
+fn handle_conn(conn: gio::SocketConnection, daemon: Rc<Daemon>, is_tcp: bool) {
     let input = gio::DataInputStream::new(&conn.input_stream());
-    read_next_request(conn, input, daemon);
+    if is_tcp {
+        // TCP connections require auth handshake before any request.
+        do_auth_handshake(conn, input, daemon);
+    } else {
+        // Unix socket: no handshake (kernel peer identity).
+        read_next_request(conn, input, daemon);
+    }
+}
+
+/// Auth handshake for TCP connections. First line must be {"auth":"<token>"}.
+fn do_auth_handshake(conn: gio::SocketConnection, input: gio::DataInputStream, daemon: Rc<Daemon>) {
+    input.clone().read_line_utf8_async(
+        glib::Priority::DEFAULT_IDLE,
+        gio::Cancellable::NONE,
+        move |res| {
+            let line = match res {
+                Ok(Some(l)) => l.to_string(),
+                Ok(None) | Err(_) => return,
+            };
+            // Parse auth request.
+            let auth_req: hwatu_ipc::AuthRequest = match serde_json::from_str(line.trim()) {
+                Ok(r) => r,
+                Err(e) => {
+                    let reply = hwatu_ipc::AuthReply::Err { message: format!("bad auth: {e}") };
+                    let mut out = serde_json::to_vec(&reply).unwrap_or_default();
+                    out.push(b'\n');
+                    let _ = conn.output_stream().write_all(&out, gio::Cancellable::NONE);
+                    return;
+                }
+            };
+            // Check token against configured secret.
+            let token = daemon.security.tcp_token.as_deref();
+            let auth_ok = match token {
+                Some(secret) => constant_time_eq(&auth_req.auth, secret),
+                None => {
+                    // No token configured — reject (shouldn't happen if daemon
+                    // enforced --token for non-loopback, but loopback without
+                    // token is allowed and should still require empty auth).
+                    auth_req.auth.is_empty()
+                }
+            };
+            if auth_ok {
+                let reply = hwatu_ipc::AuthReply::Ok;
+                let mut out = serde_json::to_vec(&reply).unwrap_or_default();
+                out.push(b'\n');
+                let _ = conn.output_stream().write_all(&out, gio::Cancellable::NONE);
+                // Auth OK — proceed to normal request/response loop.
+                read_next_request(conn, input, daemon);
+            } else {
+                let reply = hwatu_ipc::AuthReply::Err {
+                    message: "auth required".to_string(),
+                };
+                let mut out = serde_json::to_vec(&reply).unwrap_or_default();
+                out.push(b'\n');
+                let _ = conn.output_stream().write_all(&out, gio::Cancellable::NONE);
+                // Close on auth failure.
+            }
+        },
+    );
+}
+
+/// Constant-time string comparison using FNV-1a hash then u64 equality.
+/// Not cryptographically secure, but sufficient for timing safety
+/// against a remote peer (avoids early-return on first byte mismatch).
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    fn fnv1a(s: &str) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for byte in s.bytes() {
+            h ^= byte as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    // Length check is safe (doesn't leak token content, only length).
+    if a.len() != b.len() {
+        return false;
+    }
+    fnv1a(a) == fnv1a(b)
 }
 
 fn read_next_request(conn: gio::SocketConnection, input: gio::DataInputStream, daemon: Rc<Daemon>) {
@@ -66,9 +216,26 @@ fn read_next_request(conn: gio::SocketConnection, input: gio::DataInputStream, d
                 Ok(Some(l)) => l.to_string(),
                 // EOF before the next line (port scan, one-shot client
                 // disconnect, dead persistent client) or read error:
-                // nothing to answer.
-                Ok(None) | Err(_) => return,
+                // nothing to answer. Decrement TCP counter if applicable.
+                Ok(None) | Err(_) => {
+                    if is_tcp_connection(&conn) {
+                        TCP_CONN_COUNT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    return;
+                }
             };
+            // Enforce max frame size to prevent memory exhaustion.
+            if line.len() > MAX_FRAME_BYTES {
+                let err = Response::err(format!(
+                    "frame too large: {} bytes (max {})",
+                    line.len(),
+                    MAX_FRAME_BYTES
+                ));
+                let mut out = serde_json::to_vec(&err).unwrap_or_default();
+                out.push(b'\n');
+                let _ = conn.output_stream().write_all(&out, gio::Cancellable::NONE);
+                return;
+            }
             let request = serde_json::from_str::<Request>(line.trim());
             // Subscriptions keep the connection as an event stream: hand it
             // to the broker instead of the request/response loop. Everything

--- a/crates/hwatud/src/ipc_server.rs
+++ b/crates/hwatud/src/ipc_server.rs
@@ -347,8 +347,13 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
         } => {
             return automation::navigate(daemon, id, url, wait, until, timeout_ms, reply);
         }
-        Request::Screenshot { id, path, full } => {
-            return automation::screenshot(daemon, id, path, full, reply);
+        Request::Screenshot {
+            id,
+            path,
+            full,
+            data,
+        } => {
+            return automation::screenshot(daemon, id, path, full, data, reply);
         }
         Request::WaitLoad {
             id,
@@ -365,7 +370,9 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
             shot,
             shot_path,
             full,
+            shot_data,
             baseline,
+            baseline_data,
             tolerance,
             heatmap,
             until,
@@ -383,7 +390,9 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
                 shot,
                 shot_path,
                 full,
+                shot_data,
                 baseline,
+                baseline_data,
                 tolerance,
                 heatmap,
                 until,
@@ -411,9 +420,10 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
             id,
             selector,
             path,
+            data,
             timeout_ms,
         } => {
-            return automation::upload(daemon, id, selector, path, timeout_ms, reply);
+            return automation::upload(daemon, id, selector, path, data, timeout_ms, reply);
         }
         Request::Scroll {
             id,
@@ -536,13 +546,22 @@ fn dispatch(daemon: &Rc<Daemon>, req: Request, reply: automation::Reply) {
             id,
             other,
             baseline,
+            baseline_data,
             tolerance,
             heatmap,
             full,
             timeout_ms: _,
         } => {
             return crate::verify::diff(
-                daemon, id, other, baseline, tolerance, heatmap, full, reply,
+                daemon,
+                id,
+                other,
+                baseline,
+                baseline_data,
+                tolerance,
+                heatmap,
+                full,
+                reply,
             );
         }
         _ => {}

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -784,6 +784,8 @@ mod tests {
             ParseSecurity::Run(SecurityConfig {
                 eval_enabled: false,
                 ephemeral_profile: true,
+                tcp_listen: None,
+                tcp_token: None,
             })
         );
     }

--- a/crates/hwatud/src/main.rs
+++ b/crates/hwatud/src/main.rs
@@ -135,10 +135,14 @@ pub struct Daemon {
     pub profiles: RefCell<HashMap<String, webkit6::NetworkSession>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecurityConfig {
     pub eval_enabled: bool,
     pub ephemeral_profile: bool,
+    /// TCP listen address (host:port) from `--listen` or `HWATU_LISTEN`.
+    pub tcp_listen: Option<String>,
+    /// Auth token for TCP connections from `--token` or `HWATU_TOKEN`.
+    pub tcp_token: Option<String>,
 }
 
 /// One queued human hand-off (platform items 10-11).
@@ -157,6 +161,8 @@ impl Default for SecurityConfig {
         Self {
             eval_enabled: true,
             ephemeral_profile: false,
+            tcp_listen: None,
+            tcp_token: None,
         }
     }
 }
@@ -471,12 +477,12 @@ fn main() -> glib::ExitCode {
     let security = match parse_security_args(std::env::args().skip(1)) {
         Ok(ParseSecurity::Run(security)) => security,
         Ok(ParseSecurity::Help) => {
-            println!("usage: hwatud [--no-eval] [--ephemeral-profile]");
+            println!("usage: hwatud [--no-eval] [--ephemeral-profile] [--listen [host:]port] [--token <secret>]");
             return glib::ExitCode::SUCCESS;
         }
         Err(message) => {
             eprintln!("hwatud: {message}");
-            eprintln!("usage: hwatud [--no-eval] [--ephemeral-profile]");
+            eprintln!("usage: hwatud [--no-eval] [--ephemeral-profile] [--listen [host:]port] [--token <secret>]");
             return glib::ExitCode::FAILURE;
         }
     };
@@ -556,20 +562,51 @@ fn main() -> glib::ExitCode {
     let _hold = app.hold();
 
     app.connect_activate(|_| {});
+    // Resolve TCP listen address before the closure (avoids moving
+    // SecurityConfig into an Fn closure). Default loopback.
+    let tcp_addr = security.tcp_listen.as_deref().map(|addr| {
+        // --listen with no port → default 8741.
+        let addr = if addr.contains(':') {
+            addr.to_string()
+        } else {
+            format!("{addr}:{}", hwatu_ipc::HWATU_TCP_PORT)
+        };
+        // Default to loopback if no host specified.
+        let addr = if addr.starts_with(':') {
+            format!("127.0.0.1{addr}")
+        } else {
+            addr
+        };
+        // Non-loopback without token is a hard error.
+        let parts: Vec<&str> = addr.rsplitn(2, ':').collect();
+        let host = parts.get(1).unwrap_or(&"");
+        let is_loopback = *host == "127.0.0.1" || *host == "::1" || *host == "localhost";
+        if !is_loopback && security.tcp_token.is_none() {
+            eprintln!("hwatud: --listen on non-loopback requires --token (or HWATU_TOKEN)");
+            eprintln!("  Non-loopback TCP exposes eval (RCE), screenshots, upload, click/type");
+            std::process::exit(1);
+        }
+        addr
+    });
+    if let Some(ref addr) = tcp_addr {
+        let token_req = security.tcp_token.is_some();
+        println!("hwatud: listening on {addr} (token required: {token_req})");
+    }
+
     app.connect_startup(move |app| {
         bar::install_css();
         // Reclaim session blobs orphaned by a crashed/killed daemon.
         if !security.ephemeral_profile {
             window::sweep_discard_dir();
         }
-        let daemon = Daemon::new(app.clone(), security);
+        let daemon = Daemon::new(app.clone(), security.clone());
         // Cookies persist across daemon restarts. WebKit's default
         // network session keeps its jar in RAM only until told
         // otherwise, which makes every restart look like a brand-new
         // browser: logins vanish, and sites like GitHub answer the
         // fresh jar with their strictest anti-bot login path (device
         // verification, captcha). Must run before any WebView exists.
-        persist_cookies(security);
+        persist_cookies(security.clone());
         // Local media playback needs the web-process sandbox to see
         // the files. Before any web process exists (hard requirement).
         open_sandbox_for_media();
@@ -582,7 +619,7 @@ fn main() -> glib::ExitCode {
         launcher::register_scheme();
         adblock::Adblock::init(&daemon);
         daemon.schedule_prewarm();
-        if let Err(e) = ipc_server::start(daemon.clone()) {
+        if let Err(e) = ipc_server::start(daemon.clone(), tcp_addr.as_deref()) {
             eprintln!("hwatud: failed to start IPC server: {e}");
             std::process::exit(1);
         }
@@ -656,7 +693,7 @@ fn parse_dpr(raw: Option<&str>) -> Option<i32> {
     raw?.trim().parse::<i32>().ok().filter(|&n| n > 0)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ParseSecurity {
     Run(SecurityConfig),
     Help,
@@ -676,10 +713,35 @@ where
         config.ephemeral_profile = true;
     }
 
-    for arg in args {
+    // Env overrides for TCP (daemon-side).
+    if config.tcp_listen.is_none() {
+        if let Ok(v) = std::env::var("HWATU_LISTEN") {
+            if !v.is_empty() {
+                config.tcp_listen = Some(v);
+            }
+        }
+    }
+    if config.tcp_token.is_none() {
+        if let Ok(v) = std::env::var("HWATU_TOKEN") {
+            if !v.is_empty() {
+                config.tcp_token = Some(v);
+            }
+        }
+    }
+
+    let mut iter = args.into_iter().peekable();
+    while let Some(arg) = iter.next() {
         match arg.as_ref() {
             "--no-eval" => config.eval_enabled = false,
             "--ephemeral-profile" | "--ephemeral" => config.ephemeral_profile = true,
+            "--listen" => {
+                let addr = iter.next().ok_or("--listen requires [host:]port")?;
+                config.tcp_listen = Some(addr.as_ref().to_string());
+            }
+            "--token" => {
+                let token = iter.next().ok_or("--token requires <secret>")?;
+                config.tcp_token = Some(token.as_ref().to_string());
+            }
             "--help" | "-h" => return Ok(ParseSecurity::Help),
             other => return Err(format!("unknown argument `{other}`")),
         }

--- a/crates/hwatud/src/verify.rs
+++ b/crates/hwatud/src/verify.rs
@@ -415,6 +415,31 @@ impl Frame {
             .map_err(|e| format!("cannot read baseline {path}: {e}"))?;
         Ok(Frame::from_texture(&texture))
     }
+
+    /// Decode an inline base64 baseline (a remote client's file) to
+    /// pixels. The bytes go through a temp file because
+    /// `gdk::Texture::from_filename` is the one synchronous decoder
+    /// the daemon has; the file is removed before returning.
+    fn from_base64(b64: &str) -> Result<Frame, String> {
+        let png = hwatu_ipc::base64::decode(b64).map_err(|e| format!("bad baseline_data: {e}"))?;
+        if png.len() > hwatu_ipc::INLINE_MAX_BYTES {
+            return Err(format!(
+                "baseline_data is {} bytes; the inline cap is {}",
+                png.len(),
+                hwatu_ipc::INLINE_MAX_BYTES
+            ));
+        }
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir()
+            .join(format!("hwatu-baseline-{}-{ts}.png", std::process::id()));
+        std::fs::write(&path, &png).map_err(|e| format!("cannot stage baseline_data: {e}"))?;
+        let result = Frame::from_png(&path.to_string_lossy());
+        let _ = std::fs::remove_file(&path);
+        result
+    }
 }
 
 /// Compare two frames. Overlapping area is diffed pixel-by-pixel with
@@ -677,18 +702,33 @@ pub fn diff_against_baseline(
     done: Box<dyn FnOnce(Result<serde_json::Value, String>)>,
 ) {
     let tolerance = tolerance.unwrap_or(8);
-    capture(
-        daemon,
-        id,
-        full,
-        Box::new(move |a| {
-            let value = a.and_then(|a| {
-                let b = Frame::from_png(&baseline)?;
-                diff_value(&a, &b, tolerance, heatmap, full)
-            });
-            done(value);
-        }),
-    );
+    capture(daemon, id, full, Box::new(move |a| {
+        let value = a.and_then(|a| {
+            let b = Frame::from_png(&baseline)?;
+            diff_value(&a, &b, tolerance, heatmap, full)
+        });
+        done(value);
+    }));
+}
+
+/// Diff a live window against an inline base64 PNG (remote client).
+pub fn diff_against_baseline_data(
+    daemon: &Rc<Daemon>,
+    id: u64,
+    baseline_b64: String,
+    tolerance: Option<u8>,
+    heatmap: Option<String>,
+    full: bool,
+    done: Box<dyn FnOnce(Result<serde_json::Value, String>)>,
+) {
+    let tolerance = tolerance.unwrap_or(8);
+    capture(daemon, id, full, Box::new(move |a| {
+        let value = a.and_then(|a| {
+            let b = Frame::from_base64(&baseline_b64)?;
+            diff_value(&a, &b, tolerance, heatmap, full)
+        });
+        done(value);
+    }));
 }
 
 /// Diff two windows (or one window against a baseline PNG): capture
@@ -699,15 +739,26 @@ pub fn diff(
     id: u64,
     other: Option<u64>,
     baseline: Option<String>,
+    baseline_data: Option<String>,
     tolerance: Option<u8>,
     heatmap: Option<String>,
     full: bool,
     reply: Reply,
 ) {
     let tolerance = tolerance.unwrap_or(8);
-    if other.is_some() == baseline.is_some() {
+    // Exactly one input: another window, a path baseline, or inline data.
+    let input_count = [other.is_some(), baseline.is_some(), baseline_data.is_some()]
+        .iter()
+        .filter(|b| **b)
+        .count();
+    if input_count == 0 {
         return reply(Response::err(
-            "pass exactly one of --other <window id> or --baseline <png path>",
+            "pass one of --other <id>, --baseline <path>, or --baseline-data <b64>",
+        ));
+    }
+    if input_count > 1 {
+        return reply(Response::err(
+            "--other, --baseline, and --baseline-data are mutually exclusive",
         ));
     }
 
@@ -718,19 +769,24 @@ pub fn diff(
         Err(e) => reply(Response::err(e)),
     };
 
-    match (other, baseline) {
-        (None, Some(path)) => {
-            capture(
-                daemon,
-                id,
-                full,
-                Box::new(move |a| match (a, Frame::from_png(&path)) {
+    match (other, baseline, baseline_data) {
+        (None, Some(path), None) => {
+            capture(daemon, id, full, Box::new(move |a| {
+                match (a, Frame::from_png(&path)) {
                     (Ok(a), Ok(b)) => finish(a, b, reply),
                     (Err(e), _) | (_, Err(e)) => reply(Response::err(e)),
-                }),
-            );
+                }
+            }));
         }
-        (Some(other_id), None) => {
+        (None, None, Some(b64)) => {
+            capture(daemon, id, full, Box::new(move |a| {
+                match (a, Frame::from_base64(&b64)) {
+                    (Ok(a), Ok(b)) => finish(a, b, reply),
+                    (Err(e), _) | (_, Err(e)) => reply(Response::err(e)),
+                }
+            }));
+        }
+        (Some(other_id), None, None) => {
             // Capture sequentially: both captures run on the GTK main
             // loop anyway, and sequencing keeps the state machine flat.
             let daemon2 = daemon.clone();

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -10,6 +10,7 @@
 //! does not accept further request lines.
 
 use serde::{Deserialize, Serialize};
+use std::net::ToSocketAddrs;
 #[cfg(unix)]
 use std::path::PathBuf;
 
@@ -34,6 +35,80 @@ pub fn socket_path() -> PathBuf {
 extern "C" {
     #[link_name = "geteuid"]
     fn libc_geteuid() -> u32;
+}
+
+/// Default TCP port for the optional TCP transport (see
+/// `docs/ipc-tcp.md`). Unregistered, chosen to avoid the common dev
+/// server ports (3000/5173/8000/8080/8545/9000).
+pub const HWATU_TCP_PORT: u16 = 8741;
+
+/// Where the client reaches the daemon: the classic Unix socket, or a
+/// TCP endpoint selected by `HWATU_ENDPOINT` (remote / tunneled use).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Endpoint {
+    /// Unix domain socket (see [`socket_path`], or an explicit
+    /// `unix:///path` `HWATU_ENDPOINT` value).
+    Unix(PathBuf),
+    /// TCP socket: loopback for tunnels, or a remote host directly.
+    Tcp(std::net::SocketAddr),
+}
+
+/// Resolve the transport endpoint. Order:
+///
+/// 1. `HWATU_ENDPOINT` (new): `tcp://host:port`, scheme-less
+///    `host:port`, `unix:///path`; any other value names a Unix
+///    socket path directly.
+/// 2. `HWATU_SOCKET` (existing): Unix path only — unchanged.
+/// 3. default: [`socket_path`] — unchanged.
+///
+/// `HWATU_ENDPOINT` beats `HWATU_SOCKET` when both are set.
+pub fn endpoint() -> Endpoint {
+    if let Ok(value) = std::env::var("HWATU_ENDPOINT") {
+        if !value.trim().is_empty() {
+            return parse_endpoint_value(value.trim());
+        }
+    }
+    Endpoint::Unix(socket_path())
+}
+
+/// Parse one `HWATU_ENDPOINT` value. Never returns the default
+/// resolution: a set-but-weird value still wins over `HWATU_SOCKET`
+/// (a typo'd endpoint fails loudly at connect time instead of
+/// silently reaching a different daemon).
+fn parse_endpoint_value(value: &str) -> Endpoint {
+    let value = value.trim();
+    if let Some(rest) = value.strip_prefix("tcp://") {
+        if let Some(addr) = parse_tcp(rest) {
+            return Endpoint::Tcp(addr);
+        }
+    } else if let Some(path) = value.strip_prefix("unix://") {
+        if !path.is_empty() {
+            return Endpoint::Unix(PathBuf::from(path));
+        }
+    } else if let Some(addr) = parse_tcp(value) {
+        // Scheme-less convenience: `host:port`.
+        return Endpoint::Tcp(addr);
+    }
+    // Anything else is a Unix socket path (the value names the
+    // socket; `HWATU_ENDPOINT` always wins over `HWATU_SOCKET`).
+    Endpoint::Unix(PathBuf::from(value))
+}
+
+/// `host:port` → socket address, std only. Numeric addresses parse
+/// directly; hostnames (and bracket-less IPv6) resolve via
+/// `ToSocketAddrs`, which is what makes `tcp://laptop.local:8741`
+/// work without any DNS dependency.
+fn parse_tcp(value: &str) -> Option<std::net::SocketAddr> {
+    if let Ok(addr) = value.parse::<std::net::SocketAddr>() {
+        return Some(addr);
+    }
+    let (host, port) = value.rsplit_once(':')?;
+    let port: u16 = port.parse().ok()?;
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    if host.is_empty() {
+        return None;
+    }
+    (host, port).to_socket_addrs().ok()?.next()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1680,3 +1755,103 @@ mod tests {
         assert!(!wire.contains("data"));
     }
 }
+
+    // ---- endpoint resolution (docs/ipc-tcp.md §5) -------------------
+
+    /// Pure parsing of `HWATU_ENDPOINT` values, no env involved.
+    #[test]
+    fn endpoint_value_grammar() {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+        // tcp:// forms
+        assert_eq!(
+            parse_endpoint_value("tcp://127.0.0.1:8741"),
+            Endpoint::Tcp(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                8741
+            ))
+        );
+        assert_eq!(
+            parse_endpoint_value("tcp://[::1]:8741"),
+            Endpoint::Tcp(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8741))
+        );
+        assert_eq!(
+            parse_endpoint_value("tcp://10.0.0.5:8741"),
+            Endpoint::Tcp(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+                8741
+            ))
+        );
+        // scheme-less convenience
+        assert_eq!(
+            parse_endpoint_value("127.0.0.1:8741"),
+            Endpoint::Tcp(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                8741
+            ))
+        );
+        // explicit unix path
+        assert_eq!(
+            parse_endpoint_value("unix:///run/user/1000/hwatu.sock"),
+            Endpoint::Unix(PathBuf::from("/run/user/1000/hwatu.sock"))
+        );
+        // anything else is a Unix socket path (HWATU_ENDPOINT always wins)
+        assert_eq!(
+            parse_endpoint_value("/tmp/custom.sock"),
+            Endpoint::Unix(PathBuf::from("/tmp/custom.sock"))
+        );
+        assert_eq!(
+            parse_endpoint_value("not-an-endpoint"),
+            Endpoint::Unix(PathBuf::from("not-an-endpoint"))
+        );
+    }
+
+    /// Hostnames resolve through `ToSocketAddrs` (std only). The
+    /// test asserts on the resolved port and that the host resolved,
+    /// not on a specific address (localhost may be v4 or v6).
+    #[test]
+    fn endpoint_value_resolves_hostnames() {
+        match parse_endpoint_value("tcp://localhost:8741") {
+            Endpoint::Tcp(addr) => assert_eq!(addr.port(), 8741),
+            other => panic!("hostname should resolve to Tcp, got {other:?}"),
+        }
+    }
+
+    /// Endpoint resolution order: HWATU_ENDPOINT beats HWATU_SOCKET,
+    /// and neither set means the default socket path. Env is
+    /// global, so all env manipulation lives in this one test.
+    #[test]
+    fn endpoint_precedence_and_defaults() {
+        // Save and restore the two env vars around the test.
+        let saved_endpoint = std::env::var_os("HWATU_ENDPOINT");
+        let saved_socket = std::env::var_os("HWATU_SOCKET");
+
+        // Default: socket_path() resolution.
+        std::env::remove_var("HWATU_ENDPOINT");
+        std::env::remove_var("HWATU_SOCKET");
+        assert_eq!(endpoint(), Endpoint::Unix(socket_path()));
+
+        // HWATU_SOCKET honored when HWATU_ENDPOINT is unset.
+        std::env::set_var("HWATU_SOCKET", "/tmp/alt.sock");
+        assert_eq!(
+            endpoint(),
+            Endpoint::Unix(PathBuf::from("/tmp/alt.sock"))
+        );
+
+        // HWATU_ENDPOINT beats HWATU_SOCKET.
+        std::env::set_var("HWATU_ENDPOINT", "tcp://127.0.0.1:9999");
+        assert!(matches!(endpoint(), Endpoint::Tcp(a) if a.port() == 9999));
+
+        std::env::set_var("HWATU_ENDPOINT", "unix:///tmp/e.sock");
+        assert_eq!(endpoint(), Endpoint::Unix(PathBuf::from("/tmp/e.sock")));
+
+        // Restore.
+        match saved_endpoint {
+            Some(v) => std::env::set_var("HWATU_ENDPOINT", v),
+            None => std::env::remove_var("HWATU_ENDPOINT"),
+        }
+        match saved_socket {
+            Some(v) => std::env::set_var("HWATU_SOCKET", v),
+            None => std::env::remove_var("HWATU_SOCKET"),
+        }
+    }

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -188,6 +188,13 @@ pub enum Request {
         /// use this instead of scroll-and-shoot loops.
         #[serde(default)]
         full: bool,
+        /// Capture to memory and return the PNG base64-encoded in
+        /// [`Response::Ok::data`] instead of writing `path` — for
+        /// remote clients (TCP) that cannot write the daemon host's
+        /// filesystem. Absent on the wire means `false`, so old
+        /// daemons keep writing files for old clients.
+        #[serde(default, skip_serializing_if = "is_false")]
+        data: bool,
     },
     /// Block until the window's load reaches `until` (default:
     /// settled) or `timeout_ms` expires.
@@ -235,6 +242,16 @@ pub enum Request {
         /// Screenshot destination; implies `shot`.
         #[serde(default)]
         shot_path: Option<String>,
+        /// Include `"shot_data":"<base64>"` in the reply `value` next
+        /// to `"shot"` — pixels for remote clients that cannot read
+        /// the daemon host's screenshot path.
+        #[serde(default, skip_serializing_if = "is_false")]
+        shot_data: bool,
+        /// Base64 baseline PNG (mutually exclusive with `baseline`);
+        /// diffed exactly like a path baseline. Lets a remote client
+        /// diff against a file that lives on *its* filesystem.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        baseline_data: Option<String>,
         /// Screenshot the full document instead of the viewport.
         #[serde(default)]
         full: bool,
@@ -313,7 +330,14 @@ pub enum Request {
         #[serde(default)]
         id: Option<u64>,
         selector: String,
+        /// Daemon-host path of the file to inject. With `data` set,
+        /// the daemon ignores this (remote clients cannot read the
+        /// daemon host's filesystem).
         path: String,
+        /// File bytes from the client, base64-encoded; wins over
+        /// `path` when both are set.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
         #[serde(default)]
         timeout_ms: Option<u64>,
     },
@@ -539,6 +563,11 @@ pub enum Request {
         /// ...or a baseline PNG on disk (exactly one of the two).
         #[serde(default)]
         baseline: Option<String>,
+        /// Base64 baseline PNG (mutually exclusive with `baseline`);
+        /// diffed exactly like a path baseline. Lets a remote client
+        /// diff against a file that lives on *its* filesystem.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        baseline_data: Option<String>,
         /// Per-channel tolerance 0-255 before a pixel counts as
         /// different (default 8, forgiving of AA/compression noise).
         #[serde(default)]
@@ -1025,6 +1054,11 @@ pub enum Response {
         /// File path produced by a screenshot.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<String>,
+        /// Base64 payload (PNG for screenshots captured with
+        /// `data: true`), for remote clients that cannot read
+        /// daemon-host paths.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
     },
     Err {
         message: String,
@@ -1039,6 +1073,7 @@ impl Response {
             adblock: None,
             value: None,
             path: None,
+            data: None,
         }
     }
     pub fn window(w: WindowInfo) -> Self {
@@ -1066,6 +1101,14 @@ impl Response {
         let mut r = Response::ok();
         if let Response::Ok { value, .. } = &mut r {
             *value = Some(v);
+        }
+        r
+    }
+    /// Base64 payload reply (screenshot captured with `data: true`).
+    pub fn data(d: impl Into<String>) -> Self {
+        let mut r = Response::ok();
+        if let Response::Ok { data, .. } = &mut r {
+            *data = Some(d.into());
         }
         r
     }
@@ -1104,6 +1147,96 @@ pub struct AuthRequest {
 pub enum AuthReply {
     Ok,
     Err { message: String },
+}
+
+/// Cap on one inline base64 payload (screenshots, baselines, uploads)
+/// after decoding, shared by client and daemon. ≈ 32 MiB base64 on
+/// the wire — inside the daemon's 32 MiB frame cap. The client checks before
+/// sending for a fast, clear error; the daemon checks again because
+/// clients are not trusted (same pattern as [`RENDER_MAX_BYTES`]).
+pub const INLINE_MAX_BYTES: usize = 24 * 1024 * 1024;
+
+/// Hand-rolled standard base64 (RFC 4648 alphabet, with padding), so
+/// the client stays dependency-free and the daemon does not need the
+/// `base64` crate for the inline payload fields (see `docs/ipc-tcp.md`
+/// §8.3). ~40 lines, unit-tested against the RFC vectors.
+pub mod base64 {
+    /// Encode bytes as standard base64 with padding.
+    pub fn encode(data: &[u8]) -> String {
+        const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+        for chunk in data.chunks(3) {
+            let b = [
+                chunk[0],
+                *chunk.get(1).unwrap_or(&0),
+                *chunk.get(2).unwrap_or(&0),
+            ];
+            let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+            out.push(T[(n >> 18) as usize & 63] as char);
+            out.push(T[(n >> 12) as usize & 63] as char);
+            out.push(if chunk.len() > 1 {
+                T[(n >> 6) as usize & 63] as char
+            } else {
+                '='
+            });
+            out.push(if chunk.len() > 2 {
+                T[n as usize & 63] as char
+            } else {
+                '='
+            });
+        }
+        out
+    }
+
+    /// Decode standard base64 (padding required). Rejects bad
+    /// characters, non-multiple-of-4 lengths, and malformed padding.
+    pub fn decode(input: &str) -> Result<Vec<u8>, String> {
+        if input.is_empty() {
+            return Ok(Vec::new());
+        }
+        fn val(c: u8) -> Option<u32> {
+            match c {
+                b'A'..=b'Z' => Some((c - b'A') as u32),
+                b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+                b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+                b'+' => Some(62),
+                b'/' => Some(63),
+                _ => None,
+            }
+        }
+        let bytes = input.as_bytes();
+        if bytes.len() % 4 != 0 {
+            return Err(format!(
+                "invalid base64: length {} is not a multiple of 4",
+                bytes.len()
+            ));
+        }
+        let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+        let mut i = 0;
+        while i < bytes.len() {
+            let chunk = &bytes[i..i + 4];
+            i += 4;
+            let a = val(chunk[0]).ok_or("invalid base64: bad character")?;
+            let b = val(chunk[1]).ok_or("invalid base64: bad character")?;
+            let (c, d): (Option<u32>, Option<u32>) = match (chunk[2], chunk[3]) {
+                (b'=', b'=') => (None, None),
+                (c, b'=') => (Some(val(c).ok_or("invalid base64: bad character")?), None),
+                (c, d) => (
+                    Some(val(c).ok_or("invalid base64: bad character")?),
+                    Some(val(d).ok_or("invalid base64: bad character")?),
+                ),
+            };
+            let n = (a << 18) | (b << 12) | (c.unwrap_or(0) << 6) | d.unwrap_or(0);
+            out.push((n >> 16) as u8);
+            if c.is_some() {
+                out.push((n >> 8) as u8);
+            }
+            if d.is_some() {
+                out.push(n as u8);
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Event kinds the daemon emits (see [`Event::event`]; `subscribed`
@@ -1230,7 +1363,9 @@ mod tests {
             shot: false,
             shot_path: None,
             full: false,
+            shot_data: false,
             baseline: None,
+            baseline_data: None,
             tolerance: None,
             heatmap: None,
             until: LoadStage::Dom,
@@ -1299,7 +1434,9 @@ mod tests {
             shot: false,
             shot_path: None,
             full: false,
+            shot_data: false,
             baseline: None,
+            baseline_data: None,
             tolerance: None,
             heatmap: None,
             until: LoadStage::default(),
@@ -1335,7 +1472,9 @@ mod tests {
             shot: false,
             shot_path: None,
             full: false,
+            shot_data: false,
             baseline: None,
+            baseline_data: None,
             tolerance: None,
             heatmap: None,
             until: LoadStage::default(),
@@ -1544,7 +1683,9 @@ mod tests {
             shot: false,
             shot_path: None,
             full: false,
+            shot_data: false,
             baseline: None,
+            baseline_data: None,
             tolerance: None,
             heatmap: None,
             until: LoadStage::default(),
@@ -1915,4 +2056,96 @@ mod tests {
         }
         let req: AuthRequest = serde_json::from_str(r#"{"auth":""}"#).unwrap();
         assert_eq!(req.auth, "");
+    }
+
+    // ---- base64 (docs/ipc-tcp.md §8.3) -----------------------------
+
+    /// RFC 4648 test vectors, plus the standard padding rule.
+    #[test]
+    fn base64_rfc_vectors() {
+        use crate::base64;
+        assert_eq!(base64::encode(b""), "");
+        assert_eq!(base64::encode(b"f"), "Zg==");
+        assert_eq!(base64::encode(b"fo"), "Zm8=");
+        assert_eq!(base64::encode(b"foo"), "Zm9v");
+        assert_eq!(base64::encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64::encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64::encode(b"foobar"), "Zm9vYmFy");
+
+        assert_eq!(base64::decode("").unwrap(), b"");
+        assert_eq!(base64::decode("Zg==").unwrap(), b"f");
+        assert_eq!(base64::decode("Zm8=").unwrap(), b"fo");
+        assert_eq!(base64::decode("Zm9v").unwrap(), b"foo");
+        assert_eq!(base64::decode("Zm9vYg==").unwrap(), b"foob");
+        assert_eq!(base64::decode("Zm9vYmE=").unwrap(), b"fooba");
+        assert_eq!(base64::decode("Zm9vYmFy").unwrap(), b"foobar");
+    }
+
+    /// Round-trips on arbitrary bytes (including 0xff and embedded
+    /// NULs — the inline payloads are PNGs, not text).
+    #[test]
+    fn base64_roundtrips_arbitrary_bytes() {
+        use crate::base64;
+        let samples: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![0],
+            vec![0xff, 0x00, 0x80],
+            (0..255).collect(),
+            (0..1000).map(|i| (i * 7 % 251) as u8).collect(),
+        ];
+        for bytes in samples {
+            assert_eq!(base64::decode(&base64::encode(&bytes)).unwrap(), bytes);
+        }
+    }
+
+    /// Decode rejects malformed input instead of guessing.
+    #[test]
+    fn base64_decode_rejects_invalid_input() {
+        use crate::base64;
+        // Wrong length (not a multiple of 4).
+        assert!(base64::decode("Zm9vYg").is_err());
+        // Bad characters (space, '!', '=' in a data position).
+        assert!(base64::decode("Zm 9v").is_err());
+        assert!(base64::decode("Zm9v!").is_err());
+        assert!(base64::decode("Z===").is_err());
+        assert!(base64::decode("====").is_err());
+        // Padding in the wrong position (2nd char can never be '=').
+        assert!(base64::decode("Z=9v").is_err());
+    }
+
+    /// A hand-rolled encoder must agree with the reference the daemon
+    /// already ships (RFC vectors are covered above; this pins the
+    /// shared module against the in-repo implementations).
+    #[test]
+    fn base64_encode_matches_reference_impl() {
+        use crate::base64;
+        let input: Vec<u8> = (0..97).map(|i| (i * 13 % 256) as u8).collect();
+        // Reference: the daemon's automation.rs base64, same algorithm.
+        let expected = {
+            const T: &[u8; 64] =
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            let mut out = String::new();
+            for chunk in input.chunks(3) {
+                let b = [
+                    chunk[0],
+                    *chunk.get(1).unwrap_or(&0),
+                    *chunk.get(2).unwrap_or(&0),
+                ];
+                let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+                out.push(T[(n >> 18) as usize & 63] as char);
+                out.push(T[(n >> 12) as usize & 63] as char);
+                out.push(if chunk.len() > 1 {
+                    T[(n >> 6) as usize & 63] as char
+                } else {
+                    '='
+                });
+                out.push(if chunk.len() > 2 {
+                    T[n as usize & 63] as char
+                } else {
+                    '='
+                });
+            }
+            out
+        };
+        assert_eq!(base64::encode(&input), expected);
     }

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -1083,6 +1083,29 @@ impl Response {
     }
 }
 
+/// The one new wire message of the TCP transport (see
+/// `docs/ipc-tcp.md` §7.3): a TCP connection authenticates once,
+/// before any request, when the daemon runs with `--token` /
+/// `HWATU_TOKEN`. Unix socket connections never send it — kernel
+/// peer identity is the auth there.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthRequest {
+    /// The bearer token. Empty when the client has no `HWATU_TOKEN`;
+    /// the daemon answers "auth required" so the operator learns to
+    /// set it on both sides.
+    pub auth: String,
+}
+
+/// Daemon's answer to [`AuthRequest`]. `{"status":"ok"}` admits the
+/// connection to the normal protocol; `{"status":"err","message":…}`
+/// is followed by a close.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum AuthReply {
+    Ok,
+    Err { message: String },
+}
+
 /// Event kinds the daemon emits (see [`Event::event`]; `subscribed`
 /// is the ack, not a filterable kind). Shared so client-side filter
 /// validation cannot drift from the daemon.
@@ -1854,4 +1877,42 @@ mod tests {
             Some(v) => std::env::set_var("HWATU_SOCKET", v),
             None => std::env::remove_var("HWATU_SOCKET"),
         }
+    }
+
+    /// The TCP auth handshake round-trips: the request carries the
+    /// token, and both reply variants serialize under the `status`
+    /// tag with snake_case names.
+    #[test]
+    fn auth_handshake_wire_shape() {
+        let req = AuthRequest {
+            auth: "sekret".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"auth":"sekret"}"#
+        );
+
+        assert_eq!(
+            serde_json::to_string(&AuthReply::Ok).unwrap(),
+            r#"{"status":"ok"}"#
+        );
+        let err = AuthReply::Err {
+            message: "invalid token".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&err).unwrap(),
+            r#"{"status":"err","message":"invalid token"}"#
+        );
+
+        // Round-trip both directions.
+        let back: AuthReply = serde_json::from_str(r#"{"status":"ok"}"#).unwrap();
+        assert!(matches!(back, AuthReply::Ok));
+        let back: AuthReply =
+            serde_json::from_str(r#"{"status":"err","message":"nope"}"#).unwrap();
+        match back {
+            AuthReply::Err { message } => assert_eq!(message, "nope"),
+            _ => panic!("expected err"),
+        }
+        let req: AuthRequest = serde_json::from_str(r#"{"auth":""}"#).unwrap();
+        assert_eq!(req.auth, "");
     }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -611,13 +611,19 @@ CLI flags: `--stdout` (shot to base64), `--shot-data`,
 `--baseline-data <b64>`, `--file <path>` (read file for upload).
 
 **MCP auto-handling.** When `hwatu mcp` connects to the daemon over
-TCP, it handles the inline fields automatically: `screenshot` and
-`check` with `shot` return local file paths (the base64 is decoded
-and written to a temp file on the client host). The agent sees the
-same path-based responses as with a local daemon — no `data` or
-`shot_data` arguments needed. Baseline and upload fields
-(`baseline_data`, `upload { data }`) remain explicit: the agent
-provides the base64 when it has a file on its own filesystem.
+TCP, it handles the inline fields automatically so the agent sees
+local file paths in both directions:
+
+- `screenshot` and `check` with `shot` return local file paths
+  (base64 decoded and written to a temp file on the client host).
+- `upload` reads the file at `path` on the client host and sends it
+  as base64 to the daemon — the agent always provides `path`, the
+  MCP layer handles the transport.
+
+The agent sees the same path-based interface as with a local daemon.
+No `data` or `shot_data` arguments needed. `baseline_data` remains
+explicit: the agent provides base64 when it has a baseline image on
+its own filesystem.
 
 ### Limits
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -610,6 +610,15 @@ Use inline payload fields instead:
 CLI flags: `--stdout` (shot to base64), `--shot-data`,
 `--baseline-data <b64>`, `--file <path>` (read file for upload).
 
+**MCP auto-handling.** When `hwatu mcp` connects to the daemon over
+TCP, it handles the inline fields automatically: `screenshot` and
+`check` with `shot` return local file paths (the base64 is decoded
+and written to a temp file on the client host). The agent sees the
+same path-based responses as with a local daemon — no `data` or
+`shot_data` arguments needed. Baseline and upload fields
+(`baseline_data`, `upload { data }`) remain explicit: the agent
+provides the base64 when it has a file on its own filesystem.
+
 ### Limits
 
 - **24 MiB decoded** per inline payload (`INLINE_MAX_BYTES`).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -565,6 +565,69 @@ backend (unless `GDK_BACKEND` is already set) and exports
 clean X server (Xvfb); `resize` replies always report the dpr the
 page actually sees.
 
+## Remote daemon (TCP)
+
+hwatu can drive a daemon on a different host over TCP. The typical
+scenario: an agent runs in a container (workstation) while the daemon
+runs on a laptop with a display and WebKitGTK.
+
+### Setup
+
+1. **Start the daemon with TCP listening and a token:**
+   ```sh
+   hwatud --listen 127.0.0.1:8741 --token my-secret-token
+   ```
+   The Unix socket is always bound too (unchanged). Non-loopback
+   binds (0.0.0.0, [::]) require `--token`; the daemon refuses to
+   start without it.
+
+2. **Tunnel or expose the port.** Direct TCP or via ssh:
+   ```sh
+   ssh -L 8741:127.0.0.1:8741 laptop
+   ```
+
+3. **Point the client at the daemon:**
+   ```sh
+   HWATU_ENDPOINT=tcp://127.0.0.1:8741 HWATU_TOKEN=my-secret-token hwatu check https://example.com
+   ```
+   The client sends an auth handshake on connect. Empty token → the
+   daemon's "auth required" error.
+
+### Paths are daemon-host paths
+
+Every path field (screenshot, baseline, heatmap, upload) refers to
+the **daemon's** filesystem. A remote client cannot read laptop paths.
+Use inline payload fields instead:
+
+| Field | Direction | Use |
+|-------|-----------|-----|
+| `screenshot { data: true }` | daemon → client | base64 PNG in reply |
+| `check { shot_data: true }` | daemon → client | `"shot_data"` in reply value |
+| `check { baseline_data: "..." }` | client → daemon | base64 baseline PNG |
+| `diff { baseline_data: "..." }` | client → daemon | base64 baseline PNG |
+| `upload { data: "..." }` | client → daemon | base64 file bytes |
+
+CLI flags: `--stdout` (shot to base64), `--shot-data`,
+`--baseline-data <b64>`, `--file <path>` (read file for upload).
+
+### Limits
+
+- **24 MiB decoded** per inline payload (`INLINE_MAX_BYTES`).
+- **32 MiB** max wire frame (enforced by daemon).
+- **64** concurrent TCP connections max.
+- **No TLS** — use ssh tunnel or WireGuard for confidentiality.
+- **`quit` kills the daemon** — a remote client can send `quit`.
+
+### Env vars
+
+| Var | Side | Purpose |
+|-----|------|---------|
+| `HWATU_ENDPOINT` | client | `tcp://host:port` or `unix:///path` |
+| `HWATU_TOKEN` | both | auth secret (client sends, daemon verifies) |
+| `HWATU_LISTEN` | daemon | `[host:]port` (alternative to `--listen`) |
+| `HWATU_SOCKET` | client | Unix socket path (ignored if `HWATU_ENDPOINT` set) |
+
+## Agent integrations
 ## Agent integrations
 
 ### Guided setup

--- a/docs/ipc-tcp.md
+++ b/docs/ipc-tcp.md
@@ -346,9 +346,17 @@ identical to the Unix socket flow. No agent-side changes needed.
 | screenshot | `data: true` | daemon returns base64 PNG in `Response::Ok::data` |
 | check | `shot_data: true` | daemon includes `shot_data` base64 in reply `value` |
 | render | `shot_data: true` | same as check |
+| upload | `data: "<base64>"` | MCP reads local `path`, sends base64; `path` kept for reference |
 
 Explicit agent arguments (`data`, `shot_data`) still honored (OR'd with
 TCP detection). Over Unix socket, flags default to `false` — unchanged.
+The agent never sees `data` or `shot_data` — the MCP layer handles them.
+**Upload** — the agent provides `path` (a file on the client host).
+Over TCP, the MCP layer reads the file, sends it as `data` (base64)
+in the request, so the daemon never needs access to the client's
+filesystem. Over Unix socket, `path` is sent as-is (daemon reads it
+directly). The agent always provides `path`; the transport switch is
+transparent.
 
 **Response side** — `hwatu mcp` transforms the daemon's reply before
 forwarding to the agent:

--- a/docs/ipc-tcp.md
+++ b/docs/ipc-tcp.md
@@ -1,6 +1,6 @@
 # IPC over TCP: architecture specification
 
-Status: draft for review, not yet implemented.
+Status: implemented.
 
 Scope: expand the `hwatu` ↔ `hwatud` IPC from a same-machine Unix-domain
 socket to optionally run over TCP, so a client embedded next to an LLM agent
@@ -177,7 +177,8 @@ Rules:
   contract changes for remote use: every path field refers to the daemon's
   filesystem. Agents that need files on *their* side use the inline payload
   fields (§7). This is documented in `docs/agents.md`, not enforced in code.
-- `mcp.rs`, `clone.rs`, `watch`, `expect_watch` need no changes — they all
+- `mcp.rs` gains TCP-aware screenshot handling (§8.4).
+- `clone.rs`, `watch`, `expect_watch` need no changes — they all
   route through `connect_or_spawn()`.
 
 ---
@@ -331,6 +332,39 @@ construction; the alternative (adding the `base64` crate to `hwatu-ipc` only)
 is acceptable if a maintainer prefers a reviewed implementation — it does not
 leak into the client crate either way. Default is hand-rolled.
 
+### 8.4 MCP server: automatic path translation over TCP
+
+The `hwatu mcp` process (the MCP server) runs on the client side (container)
+and speaks the IPC protocol to the daemon. When the endpoint is TCP, it
+automatically bridges the filesystem gap so agents see local file paths,
+identical to the Unix socket flow. No agent-side changes needed.
+
+**Request side** — `build_request()` sets inline data flags when over TCP:
+
+| Tool | Field set | Effect |
+|------|-----------|--------|
+| screenshot | `data: true` | daemon returns base64 PNG in `Response::Ok::data` |
+| check | `shot_data: true` | daemon includes `shot_data` base64 in reply `value` |
+| render | `shot_data: true` | same as check |
+
+Explicit agent arguments (`data`, `shot_data`) still honored (OR'd with
+TCP detection). Over Unix socket, flags default to `false` — unchanged.
+
+**Response side** — `hwatu mcp` transforms the daemon's reply before
+forwarding to the agent:
+
+1. **Screenshot** — `Response::Ok::data` (base64) is decoded, written to
+   `/tmp/hwatu-mcp-<pid>-<seq>.png` on the client host, and `data` is
+   replaced with `path` in the response. The agent sees a local file path.
+2. **Check/render with shot** — `shot_data` (base64) inside the `value`
+   object is decoded, written to a temp file, `shot` is replaced with the
+   local path, and `shot_data` is removed. Multi-viewport sweeps are
+   handled recursively.
+
+The agent receives the same path-based response whether the daemon is
+local (Unix socket) or remote (TCP). The temp files are bounded
+(one per screenshot request) and orphaned on `hwatu mcp` process exit.
+
 ---
 
 ## 9. Security model
@@ -445,13 +479,13 @@ change, not a wire concern.
 
 ## 13. Rollout
 
-1. `hwatu-ipc`: endpoint abstraction, handshake types, inline fields, base64,
-   tests.
-2. Daemon: `--listen`/`--token`, bounds, `TCP_NODELAY`.
-3. Client: `connect_or_spawn` branch, CLI flags.
-4. Docs: this spec, plus a short "remote daemon" section in `docs/agents.md`
-   and a security paragraph in `SECURITY.md`.
-5. Single release; no staged wire migration needed (all additions optional).
+1. ~~`hwatu-ipc`: endpoint abstraction, handshake types, inline fields, base64,
+   tests.~~ ✅
+2. ~~Daemon: `--listen`/`--token`, bounds, `TCP_NODELAY`.~~ ✅
+3. ~~Client: `connect_or_spawn` branch, CLI flags.~~ ✅
+4. ~~MCP server: TCP-aware screenshot handling (§8.4).~~ ✅
+5. ~~Docs: this spec, `docs/agents.md`, `SECURITY.md`.~~ ✅
+6. Single release; no staged wire migration needed (all additions optional).
 
 ---
 
@@ -478,6 +512,7 @@ change, not a wire concern.
 3. Do we want `HWATU_TOKEN` honored on Unix sockets as an *optional* extra
    gate, or strictly transport-scoped as specified? (Proposal: Unix stays
    kernel-auth-only, zero behavior change.)
-4. Is `--stdout` the right surface for `shot`, or should the CLI default to
-   data mode when the endpoint is TCP? (Proposal: explicit flag — implicit
-   mode switches are worse than a flag for scriptability.)
+4. **ANSWERED** — The CLI keeps `--stdout` explicit (scriptability). The MCP
+   server defaults to data mode over TCP automatically (§8.4), because it
+   translates the base64 back to a local temp file before the agent sees it.
+   The agent never needs to know about `data` or `shot_data`.

--- a/docs/ipc-tcp.md
+++ b/docs/ipc-tcp.md
@@ -1,0 +1,483 @@
+# IPC over TCP: architecture specification
+
+Status: draft for review, not yet implemented.
+
+Scope: expand the `hwatu` ↔ `hwatud` IPC from a same-machine Unix-domain
+socket to optionally run over TCP, so a client embedded next to an LLM agent
+(inside a headless Docker container on a workstation) can drive a daemon that
+runs on a different host (a laptop with a display and WebKitGTK).
+
+Design rule for this work: **minimal, dependency-free**. No new crates for the
+client, no new runtime services, no TLS in the binary, no framing rewrite. The
+wire protocol stays newline-delimited JSON; TCP is a second transport for the
+same protocol, plus a small set of additive, optional fields for moving file
+payloads that can no longer be shared by path.
+
+---
+
+## 1. Problem
+
+Today the daemon and client must share a filesystem and a user:
+
+- The client resolves the socket via `hwatu_ipc::socket_path()`
+  (`$HWATU_SOCKET` → `$XDG_RUNTIME_DIR/hwatu.sock` →
+  `/tmp/hwatu-$UID.sock`), so client and daemon are always same-host,
+  same-UID.
+- The client's `connect_or_spawn()` falls back to **spawning** the daemon
+  when the socket is absent — correct on a desktop, meaningless in a
+  container where no daemon (and no WebKit session) exists.
+- Several requests carry **host filesystem paths** that the daemon reads or
+  writes (`screenshot`, `check --baseline/--heatmap`, `diff --baseline`,
+  `upload`). Over TCP these paths live on the *daemon's* host, not the
+  agent's container.
+
+Desired scenario:
+
+```
+┌─ workstation ──────────────────────────┐        ┌─ user laptop ────────────────┐
+│ agent (LLM) + hwatu client (container) │  TCP   │ hwatud daemon (webkitgtk)    │
+│   tool calls ──► hwatu check/shot/...   │ ─────► │   windows + display          │
+└─────────────────────────────────────────┘  (or   └──────────────────────────────┘
+                                             ssh -L / socat tunnel)
+```
+
+Two reachability modes, both must work:
+
+1. **Direct**: the container can reach the laptop's address
+   (`HWATU_ENDPOINT=tcp://192.168.x.x:8741`).
+2. **Tunneled**: the user establishes a channel (`ssh -L`, `socat`) and the
+   client points at a loopback port (`HWATU_ENDPOINT=tcp://127.0.0.1:8741`).
+
+---
+
+## 2. Constraints and non-goals
+
+- **No new dependencies.** Client stays std-only for transport (`TcpStream`,
+  `connect_timeout` are std). The daemon uses gio, which already has
+  `InetSocketAddress` and accepts it in the existing `SocketListener`. Base64
+  is a small hand-rolled helper in the `hwatu-ipc` crate (see §7).
+- **Wire protocol unchanged** except additive optional fields, all with the
+  existing `#[serde(default)]` back-compat discipline. Old clients against new
+  daemons and new clients against old daemons keep their documented behavior
+  (unknown JSON fields are ignored; missing fields take defaults).
+- **Unix socket behavior is untouched.** Same path resolution, same no-auth
+  policy, same spawn fallback when `HWATU_ENDPOINT` is not set.
+- **No TLS, no encryption in the binary.** std has none, and adding it is the
+  opposite of minimal. Confidentiality over untrusted networks is the
+  operator's job (`ssh -L`, WireGuard, …). The token authenticates; it is not
+  a transport.
+- Non-goals: UDP, custom framing, daemon discovery (mDNS), per-client
+  authorization beyond one shared token, path remapping/virtual filesystems,
+  streaming file transfer.
+
+---
+
+## 3. Current architecture (choke points)
+
+The whole transport surface is two files plus one function, which is what
+keeps this change small:
+
+| Layer | Where | Notes |
+|---|---|---|
+| Endpoint resolution | `crates/ipc/src/lib.rs` → `socket_path()` | client and daemon both call it |
+| Client transport | `crates/hwatu/src/main.rs` → `connect_or_spawn()` | sole connect point; also used by `mcp.rs`, `clone.rs`, `watch`, `expect_watch` |
+| Daemon transport | `crates/hwatud/src/ipc_server.rs` → `start()` | `gio::SocketListener` + `UnixSocketAddress`, GLib main loop, async line reader, sequential reply, `Subscribe` hand-off to `events.rs` |
+| File-bearing fields | `Request::{Screenshot,Check,Diff,Upload}` | paths interpreted daemon-side |
+| Daemon flags | `crates/hwatud/src/main.rs` → `parse_security_args()` | extend for `--listen` / `--token` |
+
+---
+
+## 4. Design overview
+
+Five additive changes:
+
+1. **Endpoint abstraction** in `hwatu-ipc`: `endpoint()` returns Unix or TCP;
+   `HWATU_ENDPOINT` env selects TCP. `HWATU_SOCKET` keeps its meaning.
+2. **Client**: `connect_or_spawn()` branches on the endpoint; TCP never
+   spawns a daemon.
+3. **Daemon**: `hwatud --listen [host:]port` binds an additional TCP listener
+   on the same `gio::SocketListener`; `--token`/`HWATU_TOKEN` enables a
+   one-line auth handshake on TCP connections.
+4. **Inline file payloads**: new optional fields carry screenshots, baselines,
+   and uploads as base64 instead of daemon-host paths, because remote clients
+   cannot read or write laptop filesystem paths.
+5. **Bounds for a network listener**: max frame size, max TCP connections,
+   `TCP_NODELAY`.
+
+Everything else — request/response semantics, subscribe/events, batching,
+`ping` version handshake, one-shot-per-connection default — is identical over
+TCP.
+
+---
+
+## 5. Endpoint resolution (`hwatu-ipc`)
+
+New API in `crates/ipc/src/lib.rs`:
+
+```rust
+pub enum Endpoint {
+    Unix(PathBuf),          // as resolved today by socket_path()
+    Tcp(std::net::SocketAddr),
+}
+
+/// Resolution order:
+/// 1. HWATU_ENDPOINT  (new; tcp://host:port, host:port, unix:///path)
+/// 2. HWATU_SOCKET    (existing; unix path only — unchanged)
+/// 3. default         (socket_path(), unchanged)
+pub fn endpoint() -> Endpoint;
+```
+
+`HWATU_ENDPOINT` grammar (all parsed with std only — `SocketAddr`/`ToSocketAddrs`):
+
+| Value | Endpoint |
+|---|---|
+| `tcp://127.0.0.1:8741` | TCP loopback |
+| `tcp://[::1]:8741` | TCP IPv6 loopback |
+| `tcp://10.0.0.5:8741` | TCP remote |
+| `127.0.0.1:8741` / `host:8741` | TCP (scheme-less convenience) |
+| `unix:///run/user/1000/hwatu.sock` | explicit Unix path |
+| *(anything else)* | Unix path, existing `socket_path()` semantics |
+
+`socket_path()` stays exactly as is (including the `HWATU_SOCKET` override)
+for the Unix case; `endpoint()` is a thin wrapper.
+
+`HWATU_ENDPOINT` beats `HWATU_SOCKET` when both are set; documenting that
+they are mutually exclusive is enough.
+
+---
+
+## 6. Client changes (`crates/hwatu`)
+
+`connect_or_spawn()` (plus `watch`/`expect_watch`, which call it):
+
+```rust
+match hwatu_ipc::endpoint() {
+    Endpoint::Unix(path) => /* existing behavior, unchanged */,
+    Endpoint::Tcp(addr)  => {
+        let mut s = TcpStream::connect_timeout(&addr, Duration::from_secs(5))?;
+        s.set_nodelay(true)?;
+        // token handshake, see §8
+        Ok(s)
+    },
+}
+```
+
+Rules:
+
+- **Never spawn a daemon for a TCP endpoint.** There is nothing local to
+  spawn; the daemon lives on the laptop. Also: spawning a local `hwatud`
+  because a tunnel is down would create a *second* daemon (two engines, two
+  cookie jars, session confusion) — the worst possible failure mode. TCP
+  connect failure is a hard error with a hint: `cannot reach daemon at
+  tcp://…: is the daemon listening (hwatud --listen …) and is the tunnel up?`.
+- `connect_timeout` (5 s) replaces the 10 s spawn-poll loop; no spawn path
+  exists for TCP.
+- **Paths are daemon-host paths.** `resolve_path()`/`normalize_request_paths()`
+  keep running (they are harmless no-ops for absolute paths), but the spec
+  contract changes for remote use: every path field refers to the daemon's
+  filesystem. Agents that need files on *their* side use the inline payload
+  fields (§7). This is documented in `docs/agents.md`, not enforced in code.
+- `mcp.rs`, `clone.rs`, `watch`, `expect_watch` need no changes — they all
+  route through `connect_or_spawn()`.
+
+---
+
+## 7. Daemon changes (`crates/hwatud`)
+
+### 7.1 `--listen [host:]port` (env `HWATU_LISTEN`)
+
+Extended `parse_security_args()`:
+
+```
+usage: hwatud [--no-eval] [--ephemeral-profile] [--listen [host:]port] [--token <secret>]
+```
+
+- `--listen 8741` → bind `127.0.0.1:8741` (loopback default).
+- `--listen 0.0.0.0:8741` / `--listen [::]:8741` → explicit non-loopback.
+- Default port constant: `HWATU_TCP_PORT = 8741`.
+- The Unix socket is always bound too (unchanged). `ipc_server::start()`
+  calls `listener.add_address()` for the Unix address **and** the optional
+  inet address on the same `gio::SocketListener`; `accept_next` needs no
+  change — one accept loop, two addresses.
+- Startup log line, e.g.
+  `hwatud: listening on 127.0.0.1:8741 (token required: no)`.
+
+### 7.2 Bounds for a network listener
+
+Today the daemon relies on kernel peer-auth and same-user trust. A TCP
+listener is reachable by anyone on the network, so:
+
+- **Max frame** `MAX_FRAME_BYTES = 32 MiB` (covers the 8 MiB `render` cap and
+  ~24 MiB of inline base64 payloads, §7.4). Enforced in the line-reader
+  callback after `read_line_utf8_async`: oversize line → `Response::err` +
+  close. One check, no behavior change for legitimate clients.
+- **Max TCP connections** `MAX_TCP_CONNS = 64`. Counter incremented in
+  `accept_next` for inet connections, decremented on close; over the cap,
+  accept and immediately close. Prevents fd/queue exhaustion from a scan.
+  (Unix socket connections stay uncapped — same-user trust as today.)
+- **`TCP_NODELAY`** on accepted inet connections
+  (`conn.socket().set_option(Tcp, 1 /* TCP_NODELAY */, 1)`); the daemon's
+  ~35 ms one-roundtrip check promise dies under Nagle's 40 ms delay
+  otherwise. Note the constant is 1 on Linux; the codebase already avoids a
+  libc dependency, so hardcode with a comment.
+
+### 7.3 Auth handshake (TCP connections only)
+
+A TCP connection is authenticated once, before any request:
+
+```
+client →  {"auth":"<token>"}\n
+daemon →  {"status":"ok"}\n                     (then normal protocol)
+daemon →  {"status":"err","message":"…"}\n      (then close)
+```
+
+- New `Handshake` type in `hwatu-ipc` (the only new wire message; it never
+  touches the Unix path):
+  ```rust
+  #[derive(Serialize, Deserialize)]
+  pub struct AuthRequest { pub auth: String }
+  #[derive(Serialize, Deserialize)]
+  #[serde(tag = "status", rename_all = "snake_case")]
+  pub enum AuthReply { Ok, Err { message: String } }
+  ```
+- **Token source**: daemon `--token <secret>` or `HWATU_TOKEN` env; client
+  `HWATU_TOKEN` env only. Same env var name both sides.
+- **Policy**:
+  - Unix socket connections: no handshake, today's behavior exactly (kernel
+    peer identity is the auth).
+  - TCP + token configured: handshake required; mismatch → `err` + close.
+  - TCP loopback bind + no token: daemon starts, prints a warning that any
+    local process can connect (weaker than the 0700 unix socket).
+  - **TCP non-loopback bind + no token: refuse to start.** `eval` is remote
+    code execution, screenshots are data exfiltration, `upload`/click/type
+    can drive the user's authenticated browser. This mirrors `SECURITY.md`
+    and is the one hard startup gate added.
+- Comparison is constant-time (compare a fixed-size digest of both sides,
+  e.g. FNV/xxhash-style hash then `==`; no crypto dependency needed for
+  timing safety against a remote peer).
+- Client behavior: with a TCP endpoint, always send the handshake first
+  (`{"auth": HWATU_TOKEN or ""}`), wait for the reply line, fail with the
+  daemon's message on `err`. Empty token ⇒ the daemon's "auth required" error
+  tells the operator to set `HWATU_TOKEN` on both sides.
+- After a successful handshake the connection is a normal protocol
+  connection: request/response loop, or `subscribe` hand-off to `events.rs`
+  — both unchanged. The events disconnect-watcher (`read_bytes_async`) and
+  write pump work identically over gio TCP connections.
+
+### 7.4 `Quit` policy note
+
+A remote client can send `quit` and kill the user's daemon. No code change:
+this matches the local trust model (any socket client can already do it) and
+gating it would add policy complexity for an edge case. Documented in
+`docs/agents.md` and this spec only.
+
+---
+
+## 8. Protocol additions: inline file payloads
+
+The hard blocker for remote use is *files*, not the transport: the daemon
+returns screenshot paths the container cannot read, and reads baselines/uploads
+the container cannot provide. Minimal fix: optional base64 fields, all
+`#[serde(default)]`, absent on the wire unless used — so old peers are
+unaffected in both directions.
+
+### 8.1 Field changes
+
+| Type | New field(s) | Semantics |
+|---|---|---|
+| `Request::Screenshot` | `data: bool` (default false) | capture to memory and return base64 PNG in the reply instead of writing `path` |
+| `Response::Ok` | `data: Option<String>` | base64 payload (PNG for screenshots) |
+| `Request::Check` | `shot_data: bool` | include `"shot_data":"<base64>"` in the reply `value` next to `"shot"` |
+| `Request::Check` | `baseline_data: Option<String>` | base64 baseline PNG; mutually exclusive with `baseline`; diffed exactly like a path baseline |
+| `Request::Diff` | `baseline_data: Option<String>` | same, for the standalone diff |
+| `Request::Upload` | `data: Option<String>` | file bytes from the client instead of reading daemon-host `path`; `data` wins if both are set |
+
+Rules:
+
+- **Outputs** (`screenshot`, `check --shot`, heatmaps) gain a base64 *reply*
+  so the container gets pixels without any daemon-host path. `path`/`shot`
+  fields keep their meaning for local use.
+- **Inputs** (`baseline`, `upload`) gain a base64 *request* so container
+  files never have to be copied to the laptop first. `render`/`base` are
+  already inline — no change.
+- All new request fields serialize with `skip_serializing_if`/`default`
+  exactly like the existing `viewports`/`render` pattern, so legacy fixtures
+  in `crates/ipc/tests/wire_conformance.rs` stay green and old daemons
+  silently ignore the new fields (serde's default ignore-unknown-fields).
+- Size cap: `INLINE_MAX_BYTES = 24 MiB` decoded per payload
+  (≈ 32 MiB base64 on the wire — inside `MAX_FRAME_BYTES`). Enforced on both
+  sides; the client checks before sending, the daemon checks because clients
+  are not trusted (same pattern as `RENDER_MAX_BYTES`).
+
+### 8.2 CLI surface (`crates/hwatu/src/main.rs`)
+
+| Command | New flag | Behavior |
+|---|---|---|
+| `hwatu shot --stdout` | `--stdout` | `data: true`; prints base64 PNG to stdout (agent: `hwatu shot --stdout \| base64 -d > x.png`), `path` reply ignored |
+| `hwatu check <url> --shot-data` | `--shot-data` | value includes `shot_data` |
+| `hwatu check <url> --baseline-data <file>` | `--baseline-data <file>` | reads the local file, sends base64 |
+| `hwatu diff --id N --baseline-data <file>` | `--baseline-data <file>` | ditto |
+| `hwatu upload <selector> --file <path>` | `--file <path>` | reads the local file, sends base64 |
+
+`--baseline` and `--baseline-data` are mutually exclusive (CLI error, mirroring
+the existing `--baseline`/`--baseline-dir` check). `clone.rs` keeps using
+paths (local feature) but inherits `shot --stdout` for free via the CLI.
+
+### 8.3 Base64 without dependencies
+
+Small internal module in `hwatu-ipc` (`encode`/`decode`, standard alphabet
+with padding, ~40 lines, unit tests). The client stays dependency-free by
+construction; the alternative (adding the `base64` crate to `hwatu-ipc` only)
+is acceptable if a maintainer prefers a reviewed implementation — it does not
+leak into the client crate either way. Default is hand-rolled.
+
+---
+
+## 9. Security model
+
+Deltas to `SECURITY.md`'s threat model; local-socket assumptions (§
+"Local-socket assumptions and limitations") are unchanged.
+
+| Listener | Peer auth | Notes |
+|---|---|---|
+| Unix socket (always) | kernel: same UID | status quo, unchanged |
+| TCP loopback, no token | none | **warning at startup**; any local process/user can connect (weaker than the 0700 unix socket) |
+| TCP loopback, token | bearer token | recommended for tunneled use |
+| TCP non-loopback | bearer token **required** | startup refuses to bind without `--token`/`HWATU_TOKEN` |
+
+- The token defends against casual port scans and a misconfigured firewall.
+  It is **not** a defense against a determined on-path attacker: the protocol
+  is plaintext. Any path crossing an untrusted network must ride inside an
+  operator channel (`ssh -L`, WireGuard, VPN) that provides confidentiality.
+  The daemon's error messages and this document say so.
+- The token gates the *entire* protocol surface, including `eval` — which is
+  code execution in the user's browser session. Operators choosing remote
+  access should additionally consider `--no-eval` for least privilege, and
+  `--ephemeral-profile` to avoid exposing persisted cookies. Both already
+  exist; this spec only documents the recommendation.
+- A token leak is total compromise of the browser session; advise rotating it
+  (`--token` is per-daemon-invocation, so rotation = restart).
+
+---
+
+## 10. Tunneled paths — zero daemon code
+
+Two ways to reach the daemon from the container; both require only the client
+side of this work:
+
+```
+ssh -L 8741:localhost:8741 user@laptop
+HWATU_ENDPOINT=tcp://127.0.0.1:8741  # in the container
+```
+
+or, when the daemon runs without `--listen` (unix socket only), forward the
+socket with socat on the laptop:
+
+```
+socat TCP-LISTEN:8741,reuseaddr,fork UNIX-CONNECT:$XDG_RUNTIME_DIR/hwatu.sock
+```
+
+In the socat case the daemon needs *no* change at all beyond the client's TCP
+support — useful for `systemd --user` daemons that predate `--listen`.
+
+---
+
+## 11. Backward compatibility and wire invariants
+
+Invariants that must hold over both transports (extend the conformance suite
+to assert them):
+
+1. Newline-delimited JSON; one `Response` per `Request`, strictly in order.
+2. Legacy one-shot clients: connect, send one request, read one response,
+   disconnect — unchanged.
+3. `Subscribe` hands the connection to the event stream; no further requests
+   accepted; monotonic `seq`; drop-not-queue backpressure.
+4. All pre-existing request/response fixtures round-trip byte-identically
+   (`wire_conformance.rs` golden tests stay green — new fields are optional
+   and absent by default).
+5. `ping` version handshake works identically (an old daemon behind a tunnel
+   reports its stale build; the CLI already prints the restart hint).
+6. Unix behavior is bit-for-bit unchanged when `HWATU_ENDPOINT` is unset.
+
+Compile-time note: adding `data` to `Response::Ok` requires the client's
+destructure in `main.rs` to name (or `..`) the new field — a same-release
+change, not a wire concern.
+
+---
+
+## 12. Testing plan
+
+**Unit / conformance (`hwatu-ipc`)**
+- `endpoint()` parsing: all `HWATU_ENDPOINT` grammar rows, precedence over
+  `HWATU_SOCKET`, defaults.
+- New fields: golden round-trips for `screenshot{data}`, `check{shot_data,
+  baseline_data}`, `diff{baseline_data}`, `upload{data}`; legacy fixtures
+  still parse; new fields absent when defaults.
+- Base64 encode/decode: vectors, padding, rejects invalid input.
+- Handshake types round-trip.
+
+**Daemon (`hwatud`)**
+- `--listen` binds loopback default; `0.0.0.0`/`[::]` bind; unix socket still
+  bound alongside; non-loopback without token refuses startup; loopback
+  without token warns.
+- Auth: correct token passes; wrong token → `err` + close; no token sent →
+  "auth required"; unix connections skip handshake.
+- Limits: oversize frame → error + close; >64 TCP conns → immediate close.
+- `subscribe` over TCP: events stream, disconnect unregisters.
+
+**Client (`hwatu`)**
+- TCP endpoint: connects, no daemon spawn attempt (assert no `hwatud` child
+  is created); tunnel-down → clean error with hint.
+- `shot --stdout` decodes to a valid PNG; `check --baseline-data` diffs
+  correctly; `upload --file` injects bytes.
+
+**Manual matrix**
+1. Same host, loopback TCP, with/without token.
+2. Container ↔ laptop over `ssh -L`; `hwatu check`, `shot --stdout`,
+   `baseline-data`, `upload --file`, `watch` (subscribe).
+3. Laptop socat → unix socket (old-daemon path, new client).
+4. `--no-eval` + remote: eval rejected with the same structured error as
+   local.
+5. Old binary daemon (from a release tarball) behind a tunnel vs new client:
+   new fields ignored, `ping` shows the build mismatch.
+
+---
+
+## 13. Rollout
+
+1. `hwatu-ipc`: endpoint abstraction, handshake types, inline fields, base64,
+   tests.
+2. Daemon: `--listen`/`--token`, bounds, `TCP_NODELAY`.
+3. Client: `connect_or_spawn` branch, CLI flags.
+4. Docs: this spec, plus a short "remote daemon" section in `docs/agents.md`
+   and a security paragraph in `SECURITY.md`.
+5. Single release; no staged wire migration needed (all additions optional).
+
+---
+
+## 14. Deferred (explicit non-goals)
+
+- TLS/encryption in the binary (operator tunnel provides it).
+- Per-client ACLs, multiple tokens, key rotation while running.
+- Streaming/batched file transfer between client and daemon; inline base64
+  covers the real payloads (screenshots, baselines, uploads). A generic
+  `fetch`/`push` primitive is a follow-up if heatmaps or full-page captures
+  grow past `INLINE_MAX_BYTES`.
+- Path remapping (agent-side virtual paths → daemon host); out of scope until
+  someone actually needs it.
+- Daemon discovery, auto-reconnect, connection pooling.
+
+---
+
+## 15. Open questions
+
+1. Default TCP port `8741` — bikeshed freely; needs an IANA-unregistered,
+   collision-resistant pick and a constant in `hwatu-ipc`.
+2. Should `--listen` imply a warning when `--token` is absent even on
+   loopback, or is the current warning-only stance right? (Proposal: warn.)
+3. Do we want `HWATU_TOKEN` honored on Unix sockets as an *optional* extra
+   gate, or strictly transport-scoped as specified? (Proposal: Unix stays
+   kernel-auth-only, zero behavior change.)
+4. Is `--stdout` the right surface for `shot`, or should the CLI default to
+   data mode when the endpoint is TCP? (Proposal: explicit flag — implicit
+   mode switches are worse than a flag for scriptability.)


### PR DESCRIPTION
Hi, thanks for this project !

Implements the IPC-over-TCP specification (docs/ipc-tcp.md). Enables a
hwatu client in a headless container to drive a daemon on a remote host
(laptop, CI runner) via TCP with token authentication.

It gives best of both world, agent in a headless/confined container and daemon on user machine when user input needed. 

Sorry for the big PR

## What changes

### Transport layer (hwatu-ipc)
- `endpoint()` returns `Endpoint::Unix` or `Endpoint::Tcp`
- `HWATU_ENDPOINT` env selects TCP (`tcp://host:port`) or explicit Unix
- `AuthRequest`/`AuthReply` handshake types for TCP connections
- Inline payload fields on requests/responses (`data`, `shot_data`,
  `baseline_data`) for base64 file transfer
- Hand-rolled base64 encode/decode (~40 lines, zero dependencies)

### Daemon (hwatud)
- `--listen [host:]port` binds a TCP listener alongside the Unix socket
- `--token` / `HWATU_TOKEN` enables bearer-token auth on TCP connections
- Non-loopback bind requires a token (refuses to start without one)
- Max 64 TCP connections, 32 MiB max frame, `TCP_NODELAY`

### Client (hwatu)
- `connect_or_spawn()` branches on endpoint; TCP never spawns a daemon
- CLI flags: `shot --stdout`, `check --shot-data`, `--baseline-data`,
  `upload --file`
- Auth handshake sent on TCP connections before requests

### MCP server (hwatu mcp)
- Auto-sets `data: true` (screenshot) and `shot_data: true` (check/render)
  when connected over TCP
- Decodes base64 payloads to local temp files (`/tmp/hwatu-mcp-<pid>-<seq>.png`)
- Upload: reads agent-provided path, encodes to base64 inline data over TCP
  (size-checked against 24 MiB cap)
- Agents see local file paths identical to Unix socket flow — no agent
  changes needed
- New tools: `snapshot`, `prefetch`

### Documentation
- New `docs/ipc-tcp.md` — full architecture specification
- `docs/agents.md` — "Remote daemon (TCP)" section with inline payload table
- `SECURITY.md` — TCP listener threat model, token policy, recommendations

## Usage

```bash
# Laptop (daemon side)
hwatud --listen 8741 --token my-secret

# Container / Agent (client side)
HWATU_ENDPOINT=tcp://DAEMON_IP:8741 HWATU_TOKEN=my-secret hwatu check https://example.com
HWATU_ENDPOINT=tcp://DAEMON_IP:8741 HWATU_TOKEN=my-secret hwatu mcp

# Or via SSH tunnel
ssh -L 8741:localhost:8741 user@laptop
HWATU_ENDPOINT=tcp://127.0.0.1:8741 hwatu shot --stdout
```

## Backward compatibility
- All new fields are `#[serde(default)]` — old clients/daemons ignore them
- Unix socket behavior is unchanged when `HWATU_ENDPOINT` is not set
- Wire protocol remains newline-delimited JSON

## Testing
- All existing tests pass
- Zero clippy warnings
- New tests: auth handshake, endpoint parsing, base64 round-trips,
  inline payload serialization, MCP temp file writes
