### PR TITLE
Fix open(2) flag values on Darwin/BSD: symlink refusal never engaged on macOS

### DIFF
--- a/crates/hwatu/src/remote.rs
+++ b/crates/hwatu/src/remote.rs
@@ -12,10 +12,20 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 static NEXT_ARTIFACT: AtomicU64 = AtomicU64::new(1);
 
-#[cfg(unix)]
+// Open(2) flag values are per-kernel ABI, not POSIX: Linux uses
+// 0o4000/0o400000, while the BSD family (macOS included) uses
+// 0x4/0x100. Hardcoding the Linux values everywhere silently turned
+// O_NOFOLLOW into O_NOCTTY on macOS, so the symlink-refusal path
+// never engaged there (caught by
+// `materialization_refuses_symlink_destinations` failing on Darwin).
+#[cfg(target_os = "linux")]
 const O_NONBLOCK: i32 = 0o4000;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 const O_NOFOLLOW: i32 = 0o400000;
+#[cfg(all(unix, not(target_os = "linux")))]
+const O_NONBLOCK: i32 = 0x0004;
+#[cfg(all(unix, not(target_os = "linux")))]
+const O_NOFOLLOW: i32 = 0x0100;
 
 #[derive(Default)]
 pub(crate) struct Artifacts {


### PR DESCRIPTION
O_NOFOLLOW and O_NONBLOCK were hardcoded to their Linux ABI values (0o400000 / 0o4000). Open flag numbers are per-kernel, not POSIX: on Darwin 0o400000 is O_NOCTTY, so every `custom_flags` call in the remote artifact path silently lost its symlink protection on macOS clients. A symlinked `--shot`/heatmap destination was followed and overwrote the link target instead of being refused, and `read_inline_file` could block on a FIFO.

The existing `materialization_refuses_symlink_destinations` test caught this: it fails on a clean checkout on macOS today. This gates the constants per-OS (Linux keeps its values, other unix gets the BSD ones: 0x100 / 0x4).

Verified: `cargo test -p hwatu` on macOS goes from 112 passed + 1 failed to 113 passed. Linux behavior unchanged (same constants as before).