### PR TITLE
hwatu --version handler, PKGBUILD 0.7.0 bump, claude-in-chrome comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,19 @@ summary of easing/velocity/keyframes.
 > head-to-head data and methodology:
 > [docs/benchmarks.md](docs/benchmarks.md).
 
+**What about Claude in Chrome?** Different category. Claude in
+Chrome is Claude driving *your* Chrome through a browser extension:
+one agent product, one browser, sharing your profile, tabs, and
+focus. hwatu is a client-agnostic daemon any agent (Claude Code,
+Cursor, or a shell script) calls over CLI/MCP, with its own warm
+WebKit engine, headless by default, and verification primitives
+(`check`, pixel diff, motion capture) built in. Speed is not really
+comparable: claude-in-chrome's loop is extension messaging inside a
+full human browser and is not callable by other tools, while hwatu
+is a purpose-built verification service (~35 ms per check). Use
+Claude in Chrome to let Claude browse alongside you; use hwatu when
+agents need cheap, repeated, measurable page checks.
+
 ## Feedback
 
 Tried hwatu? A successful check, a failed install, a missing keybind,

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -73,6 +73,14 @@ pub(crate) fn normalize_request_paths(request: &mut Request) {
 
 fn main() {
     let mut args: Vec<String> = std::env::args().skip(1).collect();
+    if is_version_flag(args.first().map(String::as_str)) {
+        println!(
+            "hwatu {} ({})",
+            env!("CARGO_PKG_VERSION"),
+            env!("HWATU_GIT_HASH")
+        );
+        return;
+    }
     if args.first().map(String::as_str) == Some("update") {
         std::process::exit(update::run());
     }
@@ -209,6 +217,14 @@ fn main() {
 /// interpreted as a URL by the browser client.
 fn is_onboarding_command(command: Option<&str>) -> bool {
     matches!(command, Some("doctor") | Some("setup") | Some("demo"))
+}
+
+/// `hwatu --version` must print the version, not "unknown flag" (and
+/// certainly not open a web search: see the unknown-flag guard in
+/// `parse`). Only the first argument counts; later `--version` tokens
+/// may be eval JS or typed text.
+fn is_version_flag(command: Option<&str>) -> bool {
+    matches!(command, Some("--version") | Some("-V") | Some("version"))
 }
 
 fn parse(args: &[String]) -> Result<Request, String> {
@@ -1242,7 +1258,7 @@ const USAGE: &str = "usage: hwatu [--app-id <id>] [--profile <name|auto>] [--bac
 | doctor | setup [--client claude|cursor|generic|jcode] [--scope project|user] [--dry-run] [--undo] \
 | demo [url] [--focus] \
 | verify <spec.json> | verify --stdin \
-| mcp | update | ping | quit";
+| mcp | update | ping | quit | --version";
 
 /// `hwatu watch`: subscribe and stream events as JSON lines until the
 /// daemon goes away or we are killed. The shell-agent face of push
@@ -1644,8 +1660,9 @@ fn client_token() -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        authenticate_tcp, is_current_gio_launch, is_onboarding_command, normalize_request_paths,
-        parse_with_default_mode, read_response, should_default_to_normal, OpenMode,
+        authenticate_tcp, is_current_gio_launch, is_onboarding_command, is_version_flag,
+        normalize_request_paths, parse_with_default_mode, read_response, should_default_to_normal,
+        OpenMode,
     };
     use hwatu_ipc::{AuthReply, AuthRequest, PressKey, Request, Response};
 
@@ -1697,6 +1714,19 @@ mod tests {
         assert!(is_onboarding_command(Some("demo")));
         assert!(!is_onboarding_command(Some("https://example.com")));
         assert!(!is_onboarding_command(None));
+    }
+
+    /// `hwatu --version` prints the version locally; it must be caught
+    /// before the parser (which rejects unknown flags) and only as the
+    /// first argument, so eval/type free text keeps its tokens.
+    #[test]
+    fn version_flag_is_handled_before_url_parsing() {
+        assert!(is_version_flag(Some("--version")));
+        assert!(is_version_flag(Some("-V")));
+        assert!(is_version_flag(Some("version")));
+        assert!(!is_version_flag(Some("-v")));
+        assert!(!is_version_flag(Some("https://example.com")));
+        assert!(!is_version_flag(None));
     }
 
     #[test]

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: hongnoul <namyang@mit.edu>
 pkgname=hwatu
-pkgver=0.6.0
+pkgver=0.7.0
 pkgrel=1
 pkgdesc="Visual verification browser for AI coding agents: daemon-based WebKitGTK, real rendering, ~13ms window spawn"
 arch=('x86_64')
@@ -9,7 +9,7 @@ license=('AGPL-3.0-only')
 depends=('webkitgtk-6.0' 'gtk4')
 makedepends=('cargo')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/hongnoul/hwatu/archive/v$pkgver.tar.gz")
-sha256sums=('1397ab5e9969a6c7d865bc343ba90fd10f629b3633e037b980e16cafa97ae78a')
+sha256sums=('f16529ada2c96c321b5b63ac6bc95a58ddb6443b222cb784ee39a4beee561020')
 
 build() {
   cd "$pkgname-$pkgver"

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = hwatu
+	pkgdesc = Visual verification browser for AI coding agents: daemon-based WebKitGTK, real rendering, ~13ms window spawn
+	pkgver = 0.7.0
+	pkgrel = 1
+	url = https://github.com/hongnoul/hwatu
+	arch = x86_64
+	license = AGPL-3.0-only
+	makedepends = cargo
+	depends = webkitgtk-6.0
+	depends = gtk4
+	source = hwatu-0.7.0.tar.gz::https://github.com/hongnoul/hwatu/archive/v0.7.0.tar.gz
+	sha256sums = f16529ada2c96c321b5b63ac6bc95a58ddb6443b222cb784ee39a4beee561020
+
+pkgname = hwatu

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: hongnoul <namyang@mit.edu>
+pkgname=hwatu
+pkgver=0.7.0
+pkgrel=1
+pkgdesc="Visual verification browser for AI coding agents: daemon-based WebKitGTK, real rendering, ~13ms window spawn"
+arch=('x86_64')
+url="https://github.com/hongnoul/hwatu"
+license=('AGPL-3.0-only')
+depends=('webkitgtk-6.0' 'gtk4')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/hongnoul/hwatu/archive/v$pkgver.tar.gz")
+sha256sums=('f16529ada2c96c321b5b63ac6bc95a58ddb6443b222cb784ee39a4beee561020')
+
+build() {
+  cd "$pkgname-$pkgver"
+  cargo build --release --locked
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  install -Dm755 target/release/hwatu "$pkgdir/usr/bin/hwatu"
+  install -Dm755 target/release/hwatud "$pkgdir/usr/bin/hwatud"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
Resolves the actionable parts of #72 and #73.

## `hwatu --version` (#72)
`--version`, `-V`, and `version` as the first argument now print `hwatu <version> (<git hash>)`. Previously they hit the unknown-flag guard (which exists so typo'd flags don't get web-searched in a visible window) and errored. Only the first argument counts, so eval JS and typed text keep their `--tokens`. Usage string updated; unit test added.

## PKGBUILD bump (#72 root cause)
The AUR package is at 0.6.0-1, but `hwatu setup` shipped in v0.6.1, hence `unknown flag "--client"` for yay users. Bumped `packaging/PKGBUILD` to 0.7.0 with the v0.7.0 tarball sha256. The AUR upload itself (and its incorrect MIT license field, repo is AGPL-3.0-only) is handled out-of-band.

## README (#73)
Added a short honest "What about Claude in Chrome?" paragraph to the comparison section: different category (agent-product extension driving your Chrome vs client-agnostic warm verification daemon), and why a speed head-to-head is apples-to-oranges.

## Validation
- `cargo test -p hwatu`: 114 passed
- `cargo clippy -p hwatu --all-targets`, `cargo fmt --check`: clean
- Manual: `hwatu --version` prints `hwatu 0.7.0 (c8915ba11)`; `--badflag` still rejected; tarball sha256 verified against the v0.7.0 release archive.