### PR TITLE
Gate clone verification on region significance too

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,19 @@ summary of easing/velocity/keyframes.
 > head-to-head data and methodology:
 > [docs/benchmarks.md](docs/benchmarks.md).
 
+**What about Claude in Chrome?** Different category. Claude in
+Chrome is Claude driving *your* Chrome through a browser extension:
+one agent product, one browser, sharing your profile, tabs, and
+focus. hwatu is a client-agnostic daemon any agent (Claude Code,
+Cursor, or a shell script) calls over CLI/MCP, with its own warm
+WebKit engine, headless by default, and verification primitives
+(`check`, pixel diff, motion capture) built in. Speed is not really
+comparable: claude-in-chrome's loop is extension messaging inside a
+full human browser and is not callable by other tools, while hwatu
+is a purpose-built verification service (~35 ms per check). Use
+Claude in Chrome to let Claude browse alongside you; use hwatu when
+agents need cheap, repeated, measurable page checks.
+
 ## Feedback
 
 Tried hwatu? A successful check, a failed install, a missing keybind,

--- a/crates/hwatu/src/clone.rs
+++ b/crates/hwatu/src/clone.rs
@@ -382,7 +382,13 @@ fn clone_with_window(opts: &Opts, live: u64) -> Result<String, String> {
         eprintln!("clone: verifying against the live page...");
         let verified = verify(opts, live)?;
         if let (Some(map), Some(vmap)) = (report.as_object_mut(), verified.as_object()) {
-            for k in ["tolerance", "positions", "average_match_percent"] {
+            for k in [
+                "tolerance",
+                "positions",
+                "average_match_percent",
+                "significant_regions",
+                "worst_region",
+            ] {
                 if let Some(v) = vmap.get(k) {
                     map.insert(k.to_string(), v.clone());
                 }
@@ -392,8 +398,12 @@ fn clone_with_window(opts: &Opts, live: u64) -> Result<String, String> {
             .get("average_match_percent")
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
+        let significant = report
+            .get("significant_regions")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         summary.push_str(&format!(
-            "\nverify: {avg:.1}% average pixel match ({} positions)",
+            "\nverify: {significant} significant region(s) across {} positions; {avg:.1}% average pixel match",
             report
                 .get("positions")
                 .and_then(|v| v.as_array())
@@ -1720,6 +1730,8 @@ fn verify_with(opts: &Opts, live: u64, clone_win: u64) -> Result<serde_json::Val
     let mut positions = Vec::new();
     let mut sum = 0.0;
     let mut n = 0usize;
+    let mut total_significant = 0u64;
+    let mut worst_region: Option<serde_json::Value> = None;
     for frac in fractions {
         let y = (max_scroll * frac).round();
         for id in [live, clone_win] {
@@ -1759,22 +1771,53 @@ fn verify_with(opts: &Opts, live: u64, clone_win: u64) -> Result<serde_json::Val
             .unwrap_or(0.0);
         sum += pct;
         n += 1;
-        eprintln!("clone: verify y={y}: {pct:.1}% match");
+        let significant = value
+            .get("significant_regions")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        total_significant += significant;
+        if let Some(worst) = value.get("worst_region") {
+            let worst_px = worst
+                .get("mismatched_pixels")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if worst_px
+                > worst_region
+                    .as_ref()
+                    .and_then(|w: &serde_json::Value| w.get("mismatched_pixels"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0)
+            {
+                let mut worst = worst.clone();
+                worst["scroll_y"] = serde_json::json!(y);
+                worst_region = Some(worst);
+            }
+        }
+        eprintln!("clone: verify y={y}: {pct:.1}% match, {significant} significant region(s)");
         positions.push(serde_json::json!({
             "scroll_y": y,
             "match_percent": pct,
+            "significant_regions": significant,
             "regions": value.get("regions").cloned().unwrap_or(serde_json::Value::Null),
         }));
     }
     let avg = if n == 0 { 0.0 } else { sum / n as f64 };
-    Ok(serde_json::json!({
+    let mut out = serde_json::json!({
         "url": opts.url,
         "viewport": { "w": opts.viewport.0, "h": opts.viewport.1 },
         "tolerance": opts.tolerance.unwrap_or(8),
         "positions": positions,
         "average_match_percent": (avg * 100.0).round() / 100.0,
+        // The gate, not the trend: the mean is diluted by unchanged
+        // background, a cluster count is not. A faithful clone is
+        // significant_regions == 0 at every offset.
+        "significant_regions": total_significant,
         "envelope": "still clone; scores cover exactly this viewport and these scroll offsets",
-    }))
+    });
+    if let Some(worst) = worst_region {
+        out["worst_region"] = worst;
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/hwatu/src/main.rs
+++ b/crates/hwatu/src/main.rs
@@ -73,6 +73,14 @@ pub(crate) fn normalize_request_paths(request: &mut Request) {
 
 fn main() {
     let mut args: Vec<String> = std::env::args().skip(1).collect();
+    if is_version_flag(args.first().map(String::as_str)) {
+        println!(
+            "hwatu {} ({})",
+            env!("CARGO_PKG_VERSION"),
+            env!("HWATU_GIT_HASH")
+        );
+        return;
+    }
     if args.first().map(String::as_str) == Some("update") {
         std::process::exit(update::run());
     }
@@ -209,6 +217,14 @@ fn main() {
 /// interpreted as a URL by the browser client.
 fn is_onboarding_command(command: Option<&str>) -> bool {
     matches!(command, Some("doctor") | Some("setup") | Some("demo"))
+}
+
+/// `hwatu --version` must print the version, not "unknown flag" (and
+/// certainly not open a web search: see the unknown-flag guard in
+/// `parse`). Only the first argument counts; later `--version` tokens
+/// may be eval JS or typed text.
+fn is_version_flag(command: Option<&str>) -> bool {
+    matches!(command, Some("--version") | Some("-V") | Some("version"))
 }
 
 fn parse(args: &[String]) -> Result<Request, String> {
@@ -1242,7 +1258,7 @@ const USAGE: &str = "usage: hwatu [--app-id <id>] [--profile <name|auto>] [--bac
 | doctor | setup [--client claude|cursor|generic|jcode] [--scope project|user] [--dry-run] [--undo] \
 | demo [url] [--focus] \
 | verify <spec.json> | verify --stdin \
-| mcp | update | ping | quit";
+| mcp | update | ping | quit | --version";
 
 /// `hwatu watch`: subscribe and stream events as JSON lines until the
 /// daemon goes away or we are killed. The shell-agent face of push
@@ -1644,8 +1660,9 @@ fn client_token() -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        authenticate_tcp, is_current_gio_launch, is_onboarding_command, normalize_request_paths,
-        parse_with_default_mode, read_response, should_default_to_normal, OpenMode,
+        authenticate_tcp, is_current_gio_launch, is_onboarding_command, is_version_flag,
+        normalize_request_paths, parse_with_default_mode, read_response, should_default_to_normal,
+        OpenMode,
     };
     use hwatu_ipc::{AuthReply, AuthRequest, PressKey, Request, Response};
 
@@ -1697,6 +1714,19 @@ mod tests {
         assert!(is_onboarding_command(Some("demo")));
         assert!(!is_onboarding_command(Some("https://example.com")));
         assert!(!is_onboarding_command(None));
+    }
+
+    /// `hwatu --version` prints the version locally; it must be caught
+    /// before the parser (which rejects unknown flags) and only as the
+    /// first argument, so eval/type free text keeps its tokens.
+    #[test]
+    fn version_flag_is_handled_before_url_parsing() {
+        assert!(is_version_flag(Some("--version")));
+        assert!(is_version_flag(Some("-V")));
+        assert!(is_version_flag(Some("version")));
+        assert!(!is_version_flag(Some("-v")));
+        assert!(!is_version_flag(Some("https://example.com")));
+        assert!(!is_version_flag(None));
     }
 
     #[test]

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: hongnoul <namyang@mit.edu>
 pkgname=hwatu
-pkgver=0.6.0
+pkgver=0.7.0
 pkgrel=1
 pkgdesc="Visual verification browser for AI coding agents: daemon-based WebKitGTK, real rendering, ~13ms window spawn"
 arch=('x86_64')
@@ -9,7 +9,7 @@ license=('AGPL-3.0-only')
 depends=('webkitgtk-6.0' 'gtk4')
 makedepends=('cargo')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/hongnoul/hwatu/archive/v$pkgver.tar.gz")
-sha256sums=('1397ab5e9969a6c7d865bc343ba90fd10f629b3633e037b980e16cafa97ae78a')
+sha256sums=('f16529ada2c96c321b5b63ac6bc95a58ddb6443b222cb784ee39a4beee561020')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Follow-up to #74: `hwatu clone`'s verify loop still summarized with `average_match_percent`, the same background-diluted mean the diff protocol moved away from.

- per-position entries gain `significant_regions`
- the report gains the summed `significant_regions` and the single `worst_region` across scroll offsets (tagged with its `scroll_y`)
- the stderr/report summary leads with the region gate: `verify: N significant region(s) across P positions; X% average pixel match`

A faithful clone is `significant_regions == 0` at every offset; the average stays as the trend number. Additive only: existing report fields unchanged.

Verified: `cargo test -p hwatu` 114/114, clippy `-D warnings`, fmt clean.