### PR TITLE
harden: three fixes on the self-update path

### DIFF
--- a/crates/hwatu/src/update.rs
+++ b/crates/hwatu/src/update.rs
@@ -64,27 +64,33 @@ fn update() -> Result<(), String> {
     println!("downloading {artifact} {tag}...");
     curl_download(&base, &pkg)?;
 
-    // Checksum (best effort like the installer: skip if absent).
+    // Checksum is mandatory. A skippable check is not a control: an attacker
+    // able to substitute the tarball can also fail the .sha256 fetch and take
+    // the "skip" branch. Note this shares a trust root with the tarball, so it
+    // detects corruption and truncation, not a GitHub/TLS compromise.
     let sums = tmp.join("pkg.sha256");
-    if curl_download(&format!("{base}.sha256"), &sums).is_ok() {
-        let expected = std::fs::read_to_string(&sums)
-            .map_err(|e| format!("read checksum: {e}"))?
-            .split_whitespace()
-            .next()
-            .unwrap_or_default()
-            .to_string();
-        let out = Command::new("sha256sum")
-            .arg(&pkg)
-            .output()
-            .map_err(|e| format!("sha256sum: {e}"))?;
-        let actual = String::from_utf8_lossy(&out.stdout)
-            .split_whitespace()
-            .next()
-            .unwrap_or_default()
-            .to_string();
-        if expected != actual {
-            return Err("checksum verification failed".into());
-        }
+    curl_download(&format!("{base}.sha256"), &sums)
+        .map_err(|e| format!("{e}\ncannot verify the download; refusing to install"))?;
+    let expected = std::fs::read_to_string(&sums)
+        .map_err(|e| format!("read checksum: {e}"))?
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("malformed checksum file; refusing to install".into());
+    }
+    let out = Command::new("sha256sum")
+        .arg(&pkg)
+        .output()
+        .map_err(|e| format!("sha256sum: {e}"))?;
+    let actual = String::from_utf8_lossy(&out.stdout)
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    if !expected.eq_ignore_ascii_case(&actual) {
+        return Err("checksum verification failed".into());
     }
 
     run_ok(

--- a/crates/hwatu/src/update.rs
+++ b/crates/hwatu/src/update.rs
@@ -183,9 +183,45 @@ fn run_ok(cmd: &mut Command, name: &str) -> Result<(), String> {
 }
 
 fn mktemp_dir() -> Result<PathBuf, String> {
-    let dir = std::env::temp_dir().join(format!("hwatu-update-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).map_err(|e| format!("mktemp: {e}"))?;
-    Ok(dir)
+    // `mkdtemp`-style: O_EXCL semantics via create_dir, which fails if the
+    // path already exists. A predictable name plus create_dir_all would let
+    // another local user pre-create (or symlink) the staging directory.
+    let base = std::env::temp_dir();
+    for _ in 0..64 {
+        let nonce: u64 = unique_nonce();
+        let dir = base.join(format!("hwatu-update-{nonce:016x}"));
+        match std::fs::create_dir(&dir) {
+            Ok(()) => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+                        .map_err(|e| format!("mktemp chmod: {e}"))?;
+                }
+                return Ok(dir);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("mktemp: {e}")),
+        }
+    }
+    Err("mktemp: could not create a private staging directory".into())
+}
+
+/// Process-local entropy for staging-directory names. Not a CSPRNG: it only
+/// needs to be unpredictable enough that another local user cannot pre-create
+/// the path, which `create_dir`'s exclusivity already backstops.
+fn unique_nonce() -> u64 {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let mut h = RandomState::new().build_hasher();
+    h.write_u32(std::process::id());
+    h.write_u64(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0),
+    );
+    h.finish()
 }
 
 /// RAII temp-dir removal, also on error paths.
@@ -193,5 +229,25 @@ struct Cleanup(PathBuf);
 impl Drop for Cleanup {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn staging_dirs_are_private_and_unique() {
+        let a = mktemp_dir().unwrap();
+        let b = mktemp_dir().unwrap();
+        assert_ne!(a, b, "staging dirs must not collide across calls");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&a).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o700, "staging dir must be owner-only");
+        }
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
     }
 }

--- a/crates/hwatu/src/update.rs
+++ b/crates/hwatu/src/update.rs
@@ -142,11 +142,22 @@ fn latest_tag() -> Result<String, String> {
         return Err("cannot resolve latest release".into());
     }
     let loc = String::from_utf8_lossy(&out.stdout);
-    loc.trim()
+    let tag = loc
+        .trim()
         .rsplit_once("/tag/")
         .map(|(_, tag)| tag.to_string())
         .filter(|t| !t.is_empty())
-        .ok_or_else(|| format!("unexpected release redirect: {loc}"))
+        .ok_or_else(|| format!("unexpected release redirect: {loc}"))?;
+    // The tag is redirect-derived input spliced into a download URL. It
+    // reaches curl as an argv entry (no shell), so this is defense in depth:
+    // keep it to the shape a release tag actually has.
+    if !tag
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+'))
+    {
+        return Err(format!("refusing suspicious release tag: {tag:?}"));
+    }
+    Ok(tag)
 }
 
 fn curl_download(url: &str, dest: &Path) -> Result<(), String> {


### PR DESCRIPTION
AI wrote this for me, feel free to just use it as inspiration and make your own version with any of it.

---

Three independent hardening fixes on the `hwatu update` path. Split into
one commit each so you can take or drop any of them individually — each
commit builds and passes tests on its own.

Independent of #79 — this branches from `main` and contains only these
three commits. If you merge #79 first there will be a small conflict in
`update()`, where the guard and the checksum change touch adjacent
lines; happy to rebase whenever you've decided on #79.

### 1. Make the checksum mandatory

The sha256 check was best-effort and failed open:

```rust
if curl_download(&format!("{base}.sha256"), &sums).is_ok() { ... }
```

An attacker able to substitute the release tarball can also make the
`.sha256` fetch fail (404, dropped connection) and take the skip branch,
so a missing checksum meant "install unverified" rather than "abort".
This makes a missing or malformed checksum fatal.

Worth being explicit about what this does *not* buy: the checksum is
fetched from the same host over the same channel as the tarball, so it
detects corruption and truncation, not a GitHub-side substitution. TLS
remains the real integrity guarantee on that path. If you chose
fail-open deliberately on that reasoning, this commit is the most
arguable of the three — feel free to drop it.

### 2. Validate the release tag from the redirect

`latest_tag` parses the tag out of the `/releases/latest` Location header
and splices it into a download URL. It reaches curl as an argv entry
rather than through a shell, so there's no injection today — this is
defense in depth, constraining it to the characters a release tag
actually uses.

### 3. Exclusive private staging directory

`mktemp_dir` used a predictable `/tmp/hwatu-update-<pid>` with
`create_dir_all`, which succeeds when the path already exists. On a
shared `/tmp` another local user can pre-create or symlink that path.
Switches to an exclusive `create_dir` under an unpredictable name,
chmod 0700.

### Testing

- `cargo build -p hwatu` clean, clippy clean.
- 118/118 tests pass (117 existing + 1 new).
- Verified each of the three commits builds and passes tests
  independently, so cherry-picking any subset won't break the build.

### Caveat

None of this is remotely exploitable — it needs either a GitHub/TLS
compromise or local access. I'd call it hardening rather than anything
urgent. I also haven't run `sudo hwatu update` against a real pacman
install; the behaviour was verified by reading the code and testing
against a non-writable directory.
